### PR TITLE
feat: npm auto build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,12 +68,17 @@ jobs:
       - *restore_cache
       - *yarn_install
       - *save_cache
+      - run:
+          name: Compile NGXS
+          command: yarn build
+      - run:
+          name: Create Pack
+          command: yarn pack --filename ngxs-core.tgz
       - *persist_workspace
       - store_artifacts:
-          path: ~/workspace/app/dist
-          destination: dist
+          path: ngxs-core.tgz
       - store_artifacts:
-          path: ~/workspace/app/docs
+          path: docs
           destination: docs
 
   lint:
@@ -114,13 +119,18 @@ jobs:
           name: Upload coverage results to Code Climate
           command: /tmp/cc-test-reporter < ~/workspace/app/coverage/lcov.info
 
-  publish_next:
+  # Publish latest build to npm under the @next tag
+  publish_build_to_npm:
     <<: *job_defaults
     steps:
       - *attach_workspace
       - run:
-          name: Publish Build to @next
-          command: yarn publish --tag next
+          name: Publish Build to NPM @ngxs/core@next
+          command: |
+            CURRENT_VERSION=$(node -pe "require('./package.json').version")
+            SHORT_SHA1=$(echo $CIRCLE_SHA1 | cut -c -7)
+            yarn publish --access public --non-interactive --new-version $CURRENT_VERSION+dev.$SHORT_SHA1 --tag next
+
 #
 # Workflow
 #
@@ -148,10 +158,10 @@ workflows:
             - unit_tests
             - integration_tests
 
-#      - publish_next:
-#          filters:
-#            branches:
-#              - master
-#          requires:
-#            - unit_tests
-#            - integration_tests
+      - publish_build_to_npm:
+          filters:
+            branches:
+              - master
+          requires:
+            - unit_tests
+            - integration_tests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "ngxs",
-  "version": "2.0.0-rc.18",
+  "name": "@ngxs/core",
+  "version": "2.0.0-rc.20",
   "description": "State Mangement for Angular",
   "main": "index.js",
   "scripts": {
@@ -13,8 +13,8 @@
     "test:integration": "yarn build && yarn link --frozen-lockfile --silent && ng test --progress=false --preserve-symlinks --app 1 -sr --browsers ChromeHeadless",
 
     "//": "Ci Testing",
-    "test:ci": "ng test --code-coverage --progress=false --browsers ChromeHeadless --single-run",
-    "test:ci:integration": "yarn build && yarn link --frozen-lockfile --silent && ng test --progress=false --preserve-symlinks --app 1 --single-run --browsers ChromeHeadless && ng build --prod --progress=false --preserve-symlinks --app 1",
+    "test:ci": "ng test --code-coverage --progress=false --single-run --browsers ChromeHeadless",
+    "test:ci:integration": "yarn link --frozen-lockfile --silent && ng test --progress=false --preserve-symlinks --app 1 --single-run --browsers ChromeHeadless && ng build --prod --progress=false --preserve-symlinks --app 1",
 
     "//": "Building",
     "build": "ng-packagr -p package.json",
@@ -90,5 +90,9 @@
   },
   "dependencies": {
     "npm": "^5.7.1"
+  },
+  "publishConfig": {
+    "access": "public",
+    "tag": "next"
   }
 }


### PR DESCRIPTION
Publish dev builds to npm so that people can follow along with nightly builds.

The format for the version will follow semver and publish under the current version present in package.json and append `+dev.buildsha1`

example:
```
yarn install @ngxs/core@2.0.0-rc.19+dev.ae34ea2
```

**Note**
This pull request will also switch to the new npm repo `@ngxs/core`