### PR TITLE
fix(store): always set action type

### DIFF
--- a/packages/store/src/action.ts
+++ b/packages/store/src/action.ts
@@ -1,12 +1,12 @@
-import { ensureStoreMetadata } from './internals';
+import { ensureStoreMetadata, uuid } from './internals';
 import { ActionOptions } from './symbols';
 
 export class ActionToken {
-  private readonly stamp = Date.now();
+  private readonly stamp = uuid();
 
   constructor(public readonly desc: string) {}
 
-  toString() {
+  toString(): string {
     return `ActionToken ${this.desc} ${this.stamp}`;
   }
 }
@@ -23,7 +23,13 @@ export function Action(actions: any | any[], options?: ActionOptions) {
     }
 
     for (const action of actions) {
-      action.type = action.type || new ActionToken(action.name);
+      if (typeof action.type === 'string') {
+        action.type = new ActionToken(action.type);
+      } else if (!action.type) {
+        action.type = new ActionToken(action.name);
+      }
+
+      console.log(action.type.toString());
 
       if (!meta.actions[action.type]) {
         meta.actions[action.type] = [];

--- a/packages/store/src/action.ts
+++ b/packages/store/src/action.ts
@@ -7,7 +7,7 @@ export class ActionToken {
   constructor(public readonly desc: string) {}
 
   toString() {
-    return `InjectionToken ${this.desc}`;
+    return `ActionToken ${this.desc}`;
   }
 }
 

--- a/packages/store/src/action.ts
+++ b/packages/store/src/action.ts
@@ -2,10 +2,12 @@ import { ensureStoreMetadata } from './internals';
 import { ActionOptions } from './symbols';
 
 export class ActionToken {
+  private readonly stamp = Date.now();
+
   constructor(public readonly desc: string) {}
 
   toString() {
-    return `ActionToken ${this.desc}`;
+    return `ActionToken ${this.desc} ${this.stamp}`;
   }
 }
 

--- a/packages/store/src/action.ts
+++ b/packages/store/src/action.ts
@@ -29,8 +29,6 @@ export function Action(actions: any | any[], options?: ActionOptions) {
         action.type = new ActionToken(action.name);
       }
 
-      console.log(action.type.toString());
-
       if (!meta.actions[action.type]) {
         meta.actions[action.type] = [];
       }

--- a/packages/store/src/action.ts
+++ b/packages/store/src/action.ts
@@ -1,5 +1,3 @@
-// import { InjectionToken } from '@angular/core';
-
 import { ensureStoreMetadata } from './internals';
 import { ActionOptions } from './symbols';
 

--- a/packages/store/src/action.ts
+++ b/packages/store/src/action.ts
@@ -1,4 +1,6 @@
-import { ensureStoreMetadata, getTypeFromKlass } from './internals';
+import { InjectionToken } from '@angular/core';
+
+import { ensureStoreMetadata } from './internals';
 import { ActionOptions } from './symbols';
 
 /**
@@ -13,15 +15,16 @@ export function Action(actions: any | any[], options?: ActionOptions) {
     }
 
     for (const action of actions) {
-      const type = getTypeFromKlass(action);
-      if (!meta.actions[type]) {
-        meta.actions[type] = [];
+      action.type = action.type || new InjectionToken(action.name);
+
+      if (!meta.actions[action.type]) {
+        meta.actions[action.type] = [];
       }
 
-      meta.actions[type].push({
+      meta.actions[action.type].push({
         fn: name,
         options: options || {},
-        type
+        type: action.type
       });
     }
   };

--- a/packages/store/src/action.ts
+++ b/packages/store/src/action.ts
@@ -1,7 +1,15 @@
-import { InjectionToken } from '@angular/core';
+// import { InjectionToken } from '@angular/core';
 
 import { ensureStoreMetadata } from './internals';
 import { ActionOptions } from './symbols';
+
+export class ActionToken {
+  constructor(public readonly desc: string) {}
+
+  toString() {
+    return `InjectionToken ${this.desc}`;
+  }
+}
 
 /**
  * Decorates a method with a action information.
@@ -15,7 +23,7 @@ export function Action(actions: any | any[], options?: ActionOptions) {
     }
 
     for (const action of actions) {
-      action.type = action.type || new InjectionToken(action.name);
+      action.type = action.type || new ActionToken(action.name);
 
       if (!meta.actions[action.type]) {
         meta.actions[action.type] = [];

--- a/packages/store/src/internals.ts
+++ b/packages/store/src/internals.ts
@@ -8,6 +8,18 @@ export interface MetaDataModel {
   children: any[];
 }
 
+/* FROM: https://gist.github.com/jed/982883 */
+/* tslint:disable  */
+export function uuid(a?, b?) {
+  for (
+    b = a = '';
+    a++ < 36;
+    b += (a * 51) & 52 ? (a ^ 15 ? 8 ^ (Math.random() * (a ^ 20 ? 16 : 4)) : 4).toString(16) : '-'
+  );
+
+  return b;
+}
+
 /**
  * Ensures metadata is attached to the klass and returns it.
  */

--- a/packages/store/src/internals.ts
+++ b/packages/store/src/internals.ts
@@ -49,17 +49,6 @@ export function fastPropGetter(paths: string[]): (x: any) => any {
 }
 
 /**
- * Returns the type from a event class.
- */
-export function getTypeFromKlass(event) {
-  if (event.type) {
-    return event.type;
-  } else if (event.name) {
-    return event.name;
-  }
-}
-
-/**
  * Given an array of states, it will return a object graph. Example:
  *    const states = [
  *      Cart,

--- a/packages/store/tests/action.spec.ts
+++ b/packages/store/tests/action.spec.ts
@@ -5,7 +5,7 @@ import { ensureStoreMetadata } from '../src/internals';
 describe('Action', () => {
   it('supports multiple actions', () => {
     class Action1 {
-      static type = Symbol();
+      static type = 'ACTION 1';
     }
 
     class Action2 {}

--- a/packages/store/tests/action.spec.ts
+++ b/packages/store/tests/action.spec.ts
@@ -4,7 +4,10 @@ import { ensureStoreMetadata } from '../src/internals';
 
 describe('Action', () => {
   it('supports multiple actions', () => {
-    class Action1 {}
+    class Action1 {
+      static type = Symbol();
+    }
+
     class Action2 {}
 
     @State({
@@ -18,7 +21,7 @@ describe('Action', () => {
     }
 
     const meta = ensureStoreMetadata(BarStore);
-    expect(meta.actions['Action1']).toBeDefined();
-    expect(meta.actions['Action2']).toBeDefined();
+    expect(meta.actions[Action1.type]).toBeDefined();
+    expect(meta.actions[Action2['type']]).toBeDefined();
   });
 });

--- a/packages/store/tests/dispatch.spec.ts
+++ b/packages/store/tests/dispatch.spec.ts
@@ -13,6 +13,7 @@ describe('Dispatch', () => {
     'should correctly dispatch the event',
     async(() => {
       class Increment {}
+
       class Decrement {}
 
       @State<number>({

--- a/packages/store/tests/state.spec.ts
+++ b/packages/store/tests/state.spec.ts
@@ -34,7 +34,7 @@ describe('Store', () => {
     }
 
     const meta = ensureStoreMetadata(BarS2tore);
-    expect(meta.actions['Eat']).toBeDefined();
-    expect(meta.actions['Drink']).toBeDefined();
+    expect(meta.actions[Eat['type']]).toBeDefined();
+    expect(meta.actions[Drink['type']]).toBeDefined();
   });
 });


### PR DESCRIPTION
The goal of this PR is to mitigate any minification or name collision issues.

My First thought was to use Symbol but since that isn't supported by any IE browsers id rather not force folks to depend on a polyfill so I am thinking use a small Token class and use that as the token if none is provided. The hope here is to create completely unique actions without depending on the user to add a static property themselves. 

Questions:
How would this impact plugins?
Are there performance implications?

Fixes #200

@amcdnl @leon 