### PR TITLE
fix(store): always set action type

### DIFF
--- a/packages/devtools-plugin/src/devtools.plugin.ts
+++ b/packages/devtools-plugin/src/devtools.plugin.ts
@@ -39,7 +39,8 @@ export class NgxsReduxDevtoolsPlugin implements NgxsPlugin {
           this.devtoolsExtension.init(state);
         } else {
           const type = getActionTypeFromInstance(action);
-          this.devtoolsExtension.send({ ...action, type }, newState);
+
+          this.devtoolsExtension.send({ ...action, type: type.desc || type }, newState);
         }
       })
     );

--- a/packages/devtools-plugin/src/devtools.plugin.ts
+++ b/packages/devtools-plugin/src/devtools.plugin.ts
@@ -1,5 +1,5 @@
 import { Injectable, Inject } from '@angular/core';
-import { NgxsPlugin, getActionTypeFromInstance, StateStream } from '@ngxs/store';
+import { NgxsPlugin, getActionTypeFromInstance, StateStream, getActionNameFromInstance } from '@ngxs/store';
 import { tap } from 'rxjs/operators';
 
 import { NgxsDevtoolsExtension, NgxsDevtoolsOptions, NGXS_DEVTOOLS_OPTIONS, NgxsDevtoolsAction } from './symbols';
@@ -38,9 +38,9 @@ export class NgxsReduxDevtoolsPlugin implements NgxsPlugin {
         if (isInitAction) {
           this.devtoolsExtension.init(state);
         } else {
-          const type = getActionTypeFromInstance(action);
+          const type = getActionNameFromInstance(action);
 
-          this.devtoolsExtension.send({ ...action, type: type.desc || type }, newState);
+          this.devtoolsExtension.send({ ...action, type }, newState);
         }
       })
     );

--- a/packages/logger-plugin/src/logger.plugin.ts
+++ b/packages/logger-plugin/src/logger.plugin.ts
@@ -21,7 +21,7 @@ export class NgxsLoggerPlugin implements NgxsPlugin {
       2
     )}.${pad(time.getMilliseconds(), 3)}`;
 
-    const message = `action ${actionName}${formattedTime}`;
+    const message = `action ${actionName.desc || actionName}${formattedTime}`;
     const startMessage = options.collapsed ? logger.groupCollapsed : logger.group;
 
     try {

--- a/packages/logger-plugin/src/logger.plugin.ts
+++ b/packages/logger-plugin/src/logger.plugin.ts
@@ -1,6 +1,7 @@
 import { Injectable, Inject } from '@angular/core';
 import { NgxsPlugin } from '@ngxs/store';
-import { getActionTypeFromInstance } from '@ngxs/store';
+import { getActionNameFromInstance } from '@ngxs/store';
+
 import { NGXS_LOGGER_PLUGIN_OPTIONS, NgxsLoggerPluginOptions } from './symbols';
 import { pad } from './internals';
 import { tap } from 'rxjs/operators';
@@ -12,7 +13,7 @@ export class NgxsLoggerPlugin implements NgxsPlugin {
   handle(state, event, next) {
     const options = this._options || <any>{};
     const logger = options.logger || console;
-    const actionName = getActionTypeFromInstance(event);
+    const actionName = getActionNameFromInstance(event);
     const time = new Date();
 
     // tslint:disable-next-line
@@ -21,7 +22,7 @@ export class NgxsLoggerPlugin implements NgxsPlugin {
       2
     )}.${pad(time.getMilliseconds(), 3)}`;
 
-    const message = `action ${actionName.desc || actionName}${formattedTime}`;
+    const message = `action ${actionName || actionName}${formattedTime}`;
     const startMessage = options.collapsed ? logger.groupCollapsed : logger.group;
 
     try {

--- a/packages/logger-plugin/src/logger.plugin.ts
+++ b/packages/logger-plugin/src/logger.plugin.ts
@@ -22,7 +22,7 @@ export class NgxsLoggerPlugin implements NgxsPlugin {
       2
     )}.${pad(time.getMilliseconds(), 3)}`;
 
-    const message = `action ${actionName || actionName}${formattedTime}`;
+    const message = `action ${actionName}${formattedTime}`;
     const startMessage = options.collapsed ? logger.groupCollapsed : logger.group;
 
     try {

--- a/packages/store/src/action.ts
+++ b/packages/store/src/action.ts
@@ -35,14 +35,16 @@ export function Action(actions: any | any[], options?: ActionOptions) {
         action.type = new ActionToken(action.name);
       }
 
-      if (!meta.actions[action.type]) {
-        meta.actions[action.type] = [];
+      const type = action.type;
+
+      if (!meta.actions[type]) {
+        meta.actions[type] = [];
       }
 
-      meta.actions[action.type].push({
+      meta.actions[type].push({
         fn: name,
         options: options || {},
-        type: action.type
+        type
       });
     }
   };

--- a/packages/store/src/action.ts
+++ b/packages/store/src/action.ts
@@ -1,11 +1,18 @@
-import { ensureStoreMetadata, createId } from './internals';
+import { ensureStoreMetadata } from './internals';
 import { ActionOptions } from './symbols';
 
 export class ActionToken {
-  private readonly stamp = createId();
-  private readonly description = `ActionToken ${this.desc} ${this.stamp}`;
+  static counter = 0;
 
-  constructor(public readonly desc: string) {}
+  private readonly stamp: number;
+  private readonly description: string;
+
+  constructor(public readonly desc: string) {
+    ActionToken.counter++;
+
+    this.stamp = ActionToken.counter;
+    this.description = `ActionToken ${this.desc} ${this.stamp}`;
+  }
 
   toString(): string {
     return this.description;

--- a/packages/store/src/action.ts
+++ b/packages/store/src/action.ts
@@ -1,13 +1,14 @@
-import { ensureStoreMetadata, uuid } from './internals';
+import { ensureStoreMetadata, createId } from './internals';
 import { ActionOptions } from './symbols';
 
 export class ActionToken {
-  private readonly stamp = uuid();
+  private readonly stamp = createId();
+  private readonly description = `ActionToken ${this.desc} ${this.stamp}`;
 
   constructor(public readonly desc: string) {}
 
   toString(): string {
-    return `ActionToken ${this.desc} ${this.stamp}`;
+    return this.description;
   }
 }
 

--- a/packages/store/src/action.ts
+++ b/packages/store/src/action.ts
@@ -1,5 +1,15 @@
-import { ensureStoreMetadata, getTypeFromKlass } from './internals';
+import { ensureStoreMetadata, uuid } from './internals';
 import { ActionOptions } from './symbols';
+
+export class ActionToken {
+  private readonly stamp = uuid();
+
+  constructor(public readonly desc: string) {}
+
+  toString(): string {
+    return `ActionToken ${this.desc} ${this.stamp}`;
+  }
+}
 
 /**
  * Decorates a method with a action information.
@@ -13,15 +23,20 @@ export function Action(actions: any | any[], options?: ActionOptions) {
     }
 
     for (const action of actions) {
-      const type = getTypeFromKlass(action);
-      if (!meta.actions[type]) {
-        meta.actions[type] = [];
+      if (typeof action.type === 'string') {
+        action.type = new ActionToken(action.type);
+      } else if (!action.type) {
+        action.type = new ActionToken(action.name);
       }
 
-      meta.actions[type].push({
+      if (!meta.actions[action.type]) {
+        meta.actions[action.type] = [];
+      }
+
+      meta.actions[action.type].push({
         fn: name,
         options: options || {},
-        type
+        type: action.type
       });
     }
   };

--- a/packages/store/src/action.ts
+++ b/packages/store/src/action.ts
@@ -23,9 +23,7 @@ export function Action(actions: any | any[], options?: ActionOptions) {
     }
 
     for (const action of actions) {
-      if (typeof action.type === 'string') {
-        action.type = new ActionToken(action.type);
-      } else if (!action.type) {
+      if (!action.type) {
         action.type = new ActionToken(action.name);
       }
 

--- a/packages/store/src/internals.ts
+++ b/packages/store/src/internals.ts
@@ -9,14 +9,6 @@ export interface MetaDataModel {
   instance: any;
 }
 
-let idCounter = 0;
-
-export function createId(): string {
-  idCounter = idCounter + 1;
-
-  return idCounter.toString();
-}
-
 /**
  * Ensures metadata is attached to the klass and returns it.
  */

--- a/packages/store/src/internals.ts
+++ b/packages/store/src/internals.ts
@@ -8,6 +8,18 @@ export interface MetaDataModel {
   children: any[];
 }
 
+/* FROM: https://gist.github.com/jed/982883 */
+/* tslint:disable  */
+export function uuid(a?, b?) {
+  for (
+    b = a = '';
+    a++ < 36;
+    b += (a * 51) & 52 ? (a ^ 15 ? 8 ^ (Math.random() * (a ^ 20 ? 16 : 4)) : 4).toString(16) : '-'
+  );
+
+  return b;
+}
+
 /**
  * Ensures metadata is attached to the klass and returns it.
  */
@@ -46,17 +58,6 @@ export function fastPropGetter(paths: string[]): (x: any) => any {
   const fn = new Function('store', 'return ' + expr + ';');
 
   return <(x: any) => any>fn;
-}
-
-/**
- * Returns the type from a event class.
- */
-export function getTypeFromKlass(event) {
-  if (event.type) {
-    return event.type;
-  } else if (event.name) {
-    return event.name;
-  }
 }
 
 /**

--- a/packages/store/src/internals.ts
+++ b/packages/store/src/internals.ts
@@ -6,18 +6,15 @@ export interface MetaDataModel {
   defaults: any;
   path: string;
   children: any[];
+  instance: any;
 }
 
-/* FROM: https://gist.github.com/jed/982883 */
-/* tslint:disable  */
-export function uuid(a?, b?) {
-  for (
-    b = a = '';
-    a++ < 36;
-    b += (a * 51) & 52 ? (a ^ 15 ? 8 ^ (Math.random() * (a ^ 20 ? 16 : 4)) : 4).toString(16) : '-'
-  );
+let idCounter = 0;
 
-  return b;
+export function createId(): string {
+  idCounter = idCounter + 1;
+
+  return idCounter.toString();
 }
 
 /**
@@ -30,7 +27,8 @@ export function ensureStoreMetadata(target): MetaDataModel {
       actions: {},
       defaults: {},
       path: null,
-      children: []
+      children: [],
+      instance: null
     };
 
     Object.defineProperty(target, META_KEY, { value: defaultMetadata });

--- a/packages/store/src/public_api.ts
+++ b/packages/store/src/public_api.ts
@@ -7,4 +7,4 @@ export { Actions } from './actions-stream';
 export { ofAction } from './of-action';
 export { NgxsPlugin, NgxsPluginFn, StateContext } from './symbols';
 export { Selector } from './selector';
-export { getActionTypeFromInstance } from './utils';
+export { getActionTypeFromInstance, getActionNameFromInstance } from './utils';

--- a/packages/store/src/state-factory.ts
+++ b/packages/store/src/state-factory.ts
@@ -113,19 +113,17 @@ export class StateFactory {
           const stateContext = this.createStateContext(getState, setState, dispatch, metadata);
           let result = metadata.instance[actionMeta.fn](stateContext, action);
 
-          if (result === undefined) {
+          if (!result) {
             result = of({}).pipe(shareReplay());
           } else if (result instanceof Promise) {
             result = fromPromise(result);
           }
 
-          if (result instanceof Observable) {
-            result = result.pipe(
-              (<ActionOptions>actionMeta.options).takeLast
-                ? takeUntil(actions$.pipe(ofAction(action.constructor)))
-                : map(r => r)
-            ); // act like a noop
-          }
+          result = result.pipe(
+            (<ActionOptions>actionMeta.options).takeLast
+              ? takeUntil(actions$.pipe(ofAction(action.constructor)))
+              : map(r => r)
+          ); // act like a noop
 
           results.push(result);
         }

--- a/packages/store/src/state-factory.ts
+++ b/packages/store/src/state-factory.ts
@@ -101,9 +101,12 @@ export class StateFactory {
   invokeActions(getState, setState, dispatch, actions$, action) {
     const results = [];
 
-    for (const metadata of this.states) {
+    for (const data of this.states) {
+      const metadata: MetaDataModel = data;
+
       const name = getActionTypeFromInstance(action);
-      const actionMetas = metadata.actions[name];
+
+      const actionMetas = metadata.actions[name.toString()];
 
       if (actionMetas) {
         for (const actionMeta of actionMetas) {

--- a/packages/store/src/utils.ts
+++ b/packages/store/src/utils.ts
@@ -1,6 +1,6 @@
 import { ActionToken } from './action';
 /**
- * Returns the type from a event instance.
+ * Returns the type from an action instance.
  */
 export function getActionTypeFromInstance(action: any): ActionToken | string {
   if (action.constructor.type) {
@@ -15,6 +15,9 @@ export function getActionTypeFromInstance(action: any): ActionToken | string {
   }
 }
 
+/**
+ * Returns the name of the action from an action instance
+ */
 export function getActionNameFromInstance(action: any): string {
   const type = getActionTypeFromInstance(action);
 

--- a/packages/store/src/utils.ts
+++ b/packages/store/src/utils.ts
@@ -1,15 +1,28 @@
+import { ActionToken } from './action';
 /**
  * Returns the type from a event instance.
  */
-export function getActionTypeFromInstance(event) {
-  if (event.constructor.type) {
-    return event.constructor.type;
-  } else if (event.constructor.name) {
-    return event.constructor.name;
-  } else if (event.type) {
+export function getActionTypeFromInstance(action: any): ActionToken | string {
+  if (action.constructor.type) {
+    if (action.constructor.type.desc) {
+      return action.constructor.type as ActionToken;
+    }
+
+    return action.constructor.type as string;
+  } else if (action.type) {
     // events from dev tools are plain objects
-    return event.type;
+    return action.type;
   }
+}
+
+export function getActionNameFromInstance(action: any): string {
+  const type = getActionTypeFromInstance(action);
+
+  if (typeof type === 'string') {
+    return type;
+  }
+
+  return (type as ActionToken).desc;
 }
 
 /**

--- a/packages/store/tests/action.spec.ts
+++ b/packages/store/tests/action.spec.ts
@@ -4,7 +4,10 @@ import { ensureStoreMetadata } from '../src/internals';
 
 describe('Action', () => {
   it('supports multiple actions', () => {
-    class Action1 {}
+    class Action1 {
+      static type = 'ACTION 1';
+    }
+
     class Action2 {}
 
     @State({
@@ -18,7 +21,7 @@ describe('Action', () => {
     }
 
     const meta = ensureStoreMetadata(BarStore);
-    expect(meta.actions['Action1']).toBeDefined();
-    expect(meta.actions['Action2']).toBeDefined();
+    expect(meta.actions[Action1.type]).toBeDefined();
+    expect(meta.actions[Action2['type']]).toBeDefined();
   });
 });

--- a/packages/store/tests/action.spec.ts
+++ b/packages/store/tests/action.spec.ts
@@ -1,6 +1,6 @@
-import { Action } from '../src/action';
+import { Action, ActionToken } from '../src/action';
 import { State } from '../src/state';
-import { ensureStoreMetadata } from '../src/internals';
+import { META_KEY } from '../src/symbols';
 
 describe('Action', () => {
   it('supports multiple actions', () => {
@@ -15,13 +15,15 @@ describe('Action', () => {
     })
     class BarStore {
       @Action([Action1, Action2])
-      foo({ setState }) {
-        setState({ foo: false });
-      }
+      foo() {}
     }
 
-    const meta = ensureStoreMetadata(BarStore);
+    const meta = BarStore[META_KEY];
+
     expect(meta.actions[Action1.type]).toBeDefined();
-    expect(meta.actions[Action2['type']]).toBeDefined();
+    expect(meta.actions[(<ActionToken>Action2['type']).toString()]).toBeDefined();
+
+    // NOTE: becuase Jasmine type will change when more actions are added to tests.
+    expect((<ActionToken>Action2['type']).toString()).toBe('ActionToken Action2 5');
   });
 });

--- a/packages/store/tests/dispatch.spec.ts
+++ b/packages/store/tests/dispatch.spec.ts
@@ -13,6 +13,7 @@ describe('Dispatch', () => {
     'should correctly dispatch the event',
     async(() => {
       class Increment {}
+
       class Decrement {}
 
       @State<number>({

--- a/packages/store/tests/state.spec.ts
+++ b/packages/store/tests/state.spec.ts
@@ -34,7 +34,7 @@ describe('Store', () => {
     }
 
     const meta = ensureStoreMetadata(BarS2tore);
-    expect(meta.actions['Eat']).toBeDefined();
-    expect(meta.actions['Drink']).toBeDefined();
+    expect(meta.actions[Eat['type']]).toBeDefined();
+    expect(meta.actions[Drink['type']]).toBeDefined();
   });
 });


### PR DESCRIPTION
The goal of this PR is to mitigate any minification or name collision issues.

My First thought was to use Symbol but since that isn't supported by any IE browsers id rather not force folks to depend on a polyfill so I am thinking use a small Token class and use that as the token if none is provided. The hope here is to create completely unique actions without depending on the user to add a static property themselves.

Questions:
How would this impact plugins? - solved
Are there performance implications?

Fixes #200

@amcdnl @leon