### PR TITLE
feat(store): rename takeLast @Action option to cancelUncompleted (#191)

### DIFF
--- a/docs/advanced/cancelation.md
+++ b/docs/advanced/cancelation.md
@@ -3,7 +3,7 @@ If you have an async action sometimes you want to cancel a previous observable i
 This is useful for canceling previous requests like in a typeahead.
 
 ## Basic
-For basic scenarios, we can use the `takeLast` action decorator option.
+For basic scenarios, we can use the `cancelUncompleted` action decorator option.
 
 ```TS
 import { State, Action } from '@ngxs/store';
@@ -16,7 +16,7 @@ import { State, Action } from '@ngxs/store';
 export class ZooState {
   constructor(private animalService: AnimalService, private actions$: Actions) {}
 
-  @Action(FeedAnimals, { takeLast: true })
+  @Action(FeedAnimals, { cancelUncompleted: true })
   get({ setState }, { payload }) {
     return this.animalService.get(payload).pipe(
       tap((res) => {

--- a/packages/store/src/state-factory.ts
+++ b/packages/store/src/state-factory.ts
@@ -119,7 +119,7 @@ export class StateFactory {
 
           if (result instanceof Observable) {
             result = result.pipe(
-              (<ActionOptions>actionMeta.options).takeLast
+              (<ActionOptions>actionMeta.options).cancelUncompleted
                 ? takeUntil(actions$.pipe(ofAction(action.constructor)))
                 : map(r => r)
             ); // act like a noop

--- a/packages/store/src/symbols.ts
+++ b/packages/store/src/symbols.ts
@@ -59,7 +59,7 @@ export interface StoreOptions<T> {
 
 export interface ActionOptions {
   /**
-   * Cancel the previous uncompleted request(s).
+   * Cancel the previous uncompleted observable(s).
    */
-  takeLast: boolean;
+  cancelUncompleted: boolean;
 }

--- a/packages/store/tests/dispatch.spec.ts
+++ b/packages/store/tests/dispatch.spec.ts
@@ -184,7 +184,7 @@ describe('Dispatch', () => {
         defaults: 0
       })
       class MyState {
-        @Action(Increment, { takeLast: true })
+        @Action(Increment, { cancelUncompleted: true })
         increment({ getState, setState, dispatch }: StateContext<number>) {
           return timer(0).pipe(
             tap(() => {


### PR DESCRIPTION
As discussed here is the PR for the name change.
@amcdnl @deebloo After our back and forth over `cancelUncompleted` and `cancelsUncompleted` I settled on `cancelUncompleted` to match the same instructional tone as how rxjs pipes are named.

It will follow on from this that the Action Pipes that we are soon to create should generally have the same name as the option.