### PR TITLE
chore(docs): concepts/actions, rename file and fix typos

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -5,7 +5,7 @@
   * [Installation](introduction/installation.md)
 * [Concepts](concepts/README.md)
   * [Store](concepts/store.md)
-  * [Action](concepts/actions.md)
+  * [Actions](concepts/actions.md)
   * [State](concepts/state.md)
   * [Select](concepts/select.md)
 * Advanced

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -5,7 +5,7 @@
   * [Installation](introduction/installation.md)
 * [Concepts](concepts/README.md)
   * [Store](concepts/store.md)
-  * [Action](concepts/action.md)
+  * [Action](concepts/actions.md)
   * [State](concepts/state.md)
   * [Select](concepts/select.md)
 * Advanced

--- a/docs/concepts/actions.md
+++ b/docs/concepts/actions.md
@@ -1,5 +1,5 @@
 # Actions
-Actions is a set of instructions for what we want to do along with payload data
+Actions are a set of instructions for what we want to do along with payload data
 associated to it.
 
 ## Simple Action
@@ -17,7 +17,7 @@ state, in this case flipping a boolean flag.
 
 ## Actions with Data
 Often you need an action to have some data associated with it. Let's take that
-original `FeedAnimals` action and modify it to have which animal we have feed
+original `FeedAnimals` action and modify it to know which animal we have fed
 by adding a payload member like:
 
 ```TS


### PR DESCRIPTION
Since in the whole docs, action it actually always mentioned in its plural form, I think it would be better to change the title and file name as well.