### PR TITLE
Fix concepts link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ NGXS is modeled after the CQRS pattern popularly implemented in libraries like R
 but reduces boilerplate by using modern TypeScript features such as classes and decorators.
 
 ## New to NGXS?
-If your just getting started with NGXS, I recommend you head over to the [concepts](concepts/README.md)
+If your just getting started with NGXS, I recommend you head over to the [concepts](concepts/)
 and then explore the rich ecosystem of examples in the [community resources](community/projects.md) page.
 
 ## ❤️ Giving Back


### PR DESCRIPTION
gitbooks link also responds with 404. I assume it needs to be replaced with https://ngxs.gitbook.io/ngxs/concepts