### PR TITLE
chore(docs): add info about using form-plugin in submodule

### DIFF
--- a/docs/plugins/form.md
+++ b/docs/plugins/form.md
@@ -33,6 +33,19 @@ import { NgxsFormPluginModule } from '@ngxs/form-plugin';
 export class AppModule {}
 ```
 
+When your form is used a submodule you have to import `NgxsFormPluginModule` as well:
+
+```TS
+import { NgxsFormPluginModule } from '@ngxs/form-plugin';
+
+@NgModule({
+  imports: [
+    NgxsFormPluginModule,
+  ]
+})
+export class SomeModule {}
+```
+
 ### Form State 
 Define your default form state as part of your application state.
 


### PR DESCRIPTION
The `ngxsForm` used by form-plugin is a directive therefore must be imported in every module. This PR adds this information to the documentation.