### PR TITLE
docs: removed destructuring of StateContext and Actions

### DIFF
--- a/docs/advanced/cancellation.md
+++ b/docs/advanced/cancellation.md
@@ -17,9 +17,9 @@ export class ZooState {
   constructor(private animalService: AnimalService, private actions$: Actions) {}
 
   @Action(FeedAnimals, { cancelUncompleted: true })
-  get({ setState }, { payload }) {
-    return this.animalService.get(payload).pipe(
-      tap((res) => setState(res))
+  get(ctx: StateContext<ZooStateModel>, action: FeedAnimals) {
+    return this.animalService.get(action.payload).pipe(
+      tap((res) => ctx.setState(res))
     ));
   }
 }
@@ -41,9 +41,9 @@ export class ZooState {
   constructor(private animalService: AnimalService, private actions$: Actions) {}
 
   @Action(FeedAnimals)
-  get({ setState }, { payload }) {
-    return this.animalService.get(payload).pipe(
-      tap((res) => setState(res)),
+  get(ctx: StateContext<ZooStateModel>, action: FeedAnimals) {
+    return this.animalService.get(action.payload).pipe(
+      tap((res) => ctx.setState(res)),
       takeUntil(this.actions$.pipe(ofAction(RemoveTodo)))
     ));
   }

--- a/docs/advanced/life-cycle.md
+++ b/docs/advanced/life-cycle.md
@@ -1,20 +1,27 @@
 # Life-cycle
 States can implement life-cycle events.
 
-## `onInit`
-If specified on a state, the `onInit` function will be invoked after
-all the states for that module definition have been initialized and
-their states pushed into the state stream. The states are invoked in a hierarchical
-order going from parent to child. The function is invoked with the state context object.
+## `ngxsOnInit`
+If you implement the `NgxsOnInit` interface the `ngxsOnInit` function will be invoked after
+all the states for that module definition have been initialized and their states pushed into the state stream.
+The states are invoked in a topological sorted order going from parent to child.
+The first parameter is the `StateContext` where you can get the current state and dispatch actions as usual.
 
 ```TS
+export interface ZooStateModel {
+  animals: string[];
+}
+
 @State<any[]>({
   name: 'zoo',
-  defaults: []
+  defaults: {
+    animals: []
+  }
 })
-export class ZooState {
-  onInit(state: StateContext<any[]>) {
-    console.log('State initialized');
+export class ZooState extends NgxsOnInit {
+  ngxsOnInit(ctx: StateContext<ZooStateModel>) {
+    console.log('State initialized, now getting animals');
+    ctx.dispatch(new GetAnimals());
   }
 }
 ```

--- a/docs/advanced/shared-state.md
+++ b/docs/advanced/shared-state.md
@@ -14,22 +14,29 @@ preferences in order to be able to sort your animals. This is achievable with `s
     sort: [{ prop: 'name', dir: 'asc' }]
   }
 })
-export class PreferencesState {}
+export class PreferencesState {
+  @Selector()
+  static getSort(state: PreferencesStateModel) {
+    return state.sort;
+  }
+}
 
-@State<any[]>({
+@State<AnimalStateModel>({
   name: 'animals',
-  defaults: []
+  defaults: [
+    animals: []
+  ]
 })
 export class AnimalState {
 
   constructor(private store: Store) {}
 
   @Action(GetAnimals)
-  getAnimals({ setState, getState }) {
-    const state = getState();
+  getAnimals(ctx: StateContext<AnimalStateModel>) {
+    const state = ctx.getState();
 
     // select the snapshot state from preferences
-    const sort = this.store.selectSnapshot(state => state.preferences.sort);
+    const sort = this.store.selectSnapshot(PreferencesState.getSort);
 
     // do sort magic here
     return state.sort(sort);

--- a/docs/advanced/sub-states.md
+++ b/docs/advanced/sub-states.md
@@ -6,7 +6,7 @@ basis. With NGXS, we can use a concept called sub states to handle this.
 ## Example
 Let's take the following example state graph:
 
-```typescript
+```TS
 {
   cart: {
     checkedout: false,
@@ -24,7 +24,7 @@ Beneath that we have a `saved` object which represents another state slice.
 To express this relationship with NGXS, we simply need to use the `children`
 property in the `@State` decorator:
 
-```typescript
+```TS
 export interface CartStateModel {
   checkedout: boolean;
   items: CartItem[];
@@ -43,7 +43,7 @@ export class CartState {}
 
 Then we describe our substate like normal:
 
-```typescript
+```TS
 export interface CartSavedStateModel {
   dateSaved: Date;
   items: CartItem[];
@@ -61,7 +61,7 @@ export class CartSavedState {}
 
 The relationship between these two are bound by their hierarchical order. To finish this up, we need to import both of these into the `NgxsModule`:
 
-```typescript
+```TS
 @NgModule({
   imports: [
     NgxsModule.forRoot([

--- a/docs/concepts/actions.md
+++ b/docs/concepts/actions.md
@@ -1,6 +1,8 @@
 # Actions
-Actions are a set of instructions for what we want to do, as well as the payload data
-associated with it.
+Actions can either be thought of as a command which should trigger something to happen,
+or as the resulting event of something that has already happened.
+
+Each action contains a `type` field which is their unique identifier.
 
 ## Simple Action
 Let's say we want to update the status of whether the animals have been fed
@@ -12,25 +14,60 @@ export class FeedAnimals {
 }
 ```
 
-Later in our state container, we will listen to this action and mutate our
+Later in our state class, we will listen to this action and mutate our
 state, in this case flipping a boolean flag.
 
-## Actions with Data
-Often you need an action to have some data associated with it. Let's take the
-original `FeedAnimals` action and modify it to know which animal we have fed
-by adding a payload member like:
+## Actions with Metadata
+Often you need an action to have some data associated with it.
+Here we have an action that should trigger feeding a zebra with hay.
 
 ```TS
-export class FeedAnimals {
-  static readonly type = '[Zoo] Feed Animals';
-  constructor(public payload: string) {}
+export class FeedZebra {
+  static readonly type = '[Zoo] Feed Zebra';
+  constructor(public name: string, public hayAmount: number) {}
 }
 ```
 
-The `payload` object will represent the name of the animal we are feeding.
-
-Note: You don't have to name your data object as `payload` but for consistency practices
-we like to follow the [FSA Standard](https://github.com/redux-utilities/flux-standard-action).
+The `name` field of the action class will represent the name of the zebra we should feed.
+The `hayAmount` tells us how many kilos of hay the zebra should get.
 
 ## Dispatching Actions
 See [Store](store.md) documentation for how to dispatch actions.
+
+## How should you name your actions?
+
+### Commands
+Commands are actions that tell your app to do something.
+They are usually trigged by user events such as clicking on a button, or selecting something.
+
+Names should contain three parts:
+
+* A context as to where the command came from, '[User API]', '[Product Page]', '[Dashboard Page]`.
+* The entity we are acting upon, `User`, `Card`, `ArchiveProject`.
+* A verb describing what we want to do with the entity.
+
+Examples:
+
+* [User API] GetUser
+* [Product Page] AddItemToCart
+* [Dashboard Page] ArchiveProject
+
+### Event examples
+Events are actions that have already happended and we now need to react to them.
+
+The same naming conventions apply as to command, but they should always be in past tense.
+
+By using `API` in the context part we now that this event was fired because of a async action to an API.
+
+Actions are normally dispatched from container components such as router pages.
+By having explicit actions for each page, it's also easier to track where an event came from.
+
+Examples:
+
+* [User API] GetUserSuccess
+* [Project API] ProjectUpdateFailed
+* [User Details Page] PasswordChanged
+* [Project Stars Component] StarsUpdated
+
+A great video on the topic is [Good Action Hygiene by Mike Ryan](https://www.youtube.com/watch?v=JmnsEvoy-gY)
+It's for NGRX, but the same naming convensions apply to NGXS.

--- a/docs/concepts/intro.md
+++ b/docs/concepts/intro.md
@@ -2,7 +2,7 @@
 There are 4 major concepts to NGXS:
 
 - Store: Global state container, action dispatcher and selector
-- Actions: Class describing the action to take and its payload
+- Actions: Class describing the action to take and its associated metadata.
 - State: Class definition of the state
 - Selects: State slice selectors
 

--- a/docs/concepts/select.md
+++ b/docs/concepts/select.md
@@ -49,8 +49,11 @@ export class ZooComponent {
 This is most helpful to programmatic selects where we can't statically
 declare them with the select decorator.
 
-There is also a `selectOnce` function that will basically do `select().pipe(take(1))` for
-you automatically as a shortcut. This is very useful for unit testing.
+There is also a `selectOnce` that will basically do `select().pipe(take(1))` for
+you automatically as a shortcut method.
+
+This can be useful in route guards where you only want to check the current state and not continue
+watching the stream. It can also be useful for unit testing.
 
 ### Snapshot Selects
 On the store, there is a `selectSnapshot` function that allows you to pull out the

--- a/docs/concepts/store.md
+++ b/docs/concepts/store.md
@@ -11,11 +11,16 @@ and invoke the `dispatch` function with an action or an array of actions you wis
 import { Store } from '@ngxs/store';
 import { AddAnimal } from './animal.actions';
 
+export class AddAnimal {
+  static readonly type = '[Zoo] Add Animal';
+  constructor(public name: string) {}
+}
+
 @Component({ ... })
 export class ZooComponent {
   constructor(private store: Store) {}
 
-  addAnimal(name) {
+  addAnimal(name: string) {
     this.store.dispatch(new AddAnimal(name));
   }
 }
@@ -42,7 +47,7 @@ import { AddAnimal } from './animal.actions';
 export class ZooComponent {
   constructor(private store: Store) {}
 
-  addAnimal(name) {
+  addAnimal(name: string) {
     this.store.dispatch(new AddAnimal(name)).subscribe(() => this.form.reset());
   }
 }
@@ -67,9 +72,10 @@ export class ZooComponent {
   @Select(state => state.animals) animals$: Observable<any>;
   constructor(private store: Store) {}
 
-  addAnimal(name) {
-    this.store.dispatch(new AddAnimal(name))
-      .pipe(withLatestFrom(this.animals$))
+  addAnimal(name: string) {
+    this.store.dispatch(new AddAnimal(name)).pipe(
+      withLatestFrom(this.animals$)
+    )
       .subscribe(([animals]) => {
         // do something with animals
         this.form.reset();

--- a/docs/introduction/installation.md
+++ b/docs/introduction/installation.md
@@ -52,7 +52,7 @@ Your package.json file will be locked to that specific version.
 ```json
 {
   "dependencies": {
-    "@ngxs/store": "2.1.0-dev.a0d076d"
+    "@ngxs/store": "3.0.0-dev.a0d076d"
   }
 }
 ```

--- a/docs/plugins/websocket.md
+++ b/docs/plugins/websocket.md
@@ -41,7 +41,7 @@ Let's say you have a websocket message that comes in like:
 
 ```json
 {
-  "type": "ADD_ANIMALS",
+  "type": "[Zoo] AddAnimals",
   "animals": []
 }
 ```
@@ -51,7 +51,7 @@ look like:
 
 ```TS
 export class AddAnimals {
-  static readonly type = 'ADD_ANIMALS';
+  static readonly type = '[Zoo] AddAnimals';
   constructor(public animals: any[]) {}
 }
 ```
@@ -67,8 +67,8 @@ action:
 })
 export class ZooState {
   @Action(AddAnimals)
-  addAnimals({ setState }: StateContext<ZooStateModel>, { animals }: AddAnimals) {
-    setState({ animals: [...animals] });
+  addAnimals(ctx: StateContext<ZooStateModel>, action: AddAnimals) {
+    ctx.setState({ animals: [...action.animals] });
   }
 }
 ```

--- a/docs/recipes/cache.md
+++ b/docs/recipes/cache.md
@@ -6,31 +6,37 @@ There are many different ways to approach this. Below is a simple example of
 using the store's current values and returning them instead of calling the HTTP
 service.
 
-```typescript
-import { State, Action } from '@ngxs/store';
+```TS
+import { State, Action, StateContext } from '@ngxs/store';
 import { of } from 'rxjs/observable/of';
 import { tap } from 'rxjs/operators';
 
+export class GetZebra {
+  static readonly type = '[Zoo] GetZebra';
+  contstructor(public id: string) {}
+}
+
 @State<ZooStateModel>({
   defaults: {
-    animals: []
+    zebras: []
   }
 })
 export class ZooState {
 
   constructor(private animalService: AnimalService) {}
 
-  @Action(GetAnimals)
-  get({ getState, setState, dispatch }, { payload }) {
-    const state = getState();
+  @Action(GetZebra)
+  getZebra(ctx: StateContext<ZooStateModel>, action: GetZebra) {
+    const state = ctx.getState();
     // payload = id of animal
-    const idx = state.animals.findIndex(animal => animal.id === payload);
+    const idx = state.zebras.findIndex(zebra => zebra.id === action.id);
     if (idx > -1) {
       // if we have the cache, just return it from the store
-      return dispatch(new GetAnimalsSuccess(state.animals[idx]));
+      return dispatch(new GetZebraSuccess(state.zebras[idx]));
     } else {
-      return this.animalService.get(payload)
-        .pipe(map(resp => dispatch(new GetAnimalsSuccess(resp))));
+      return this.animalService.getZebra(action.id).pipe(
+        map(resp => dispatch(new GetZebraSuccess(resp)))
+      );
     }
   }
 

--- a/docs/recipes/style-guide.md
+++ b/docs/recipes/style-guide.md
@@ -31,10 +31,6 @@ Actions should NOT have a suffix
 ### Unit tests
 Unit tests for the state should be named `my-store-name.state.spec.ts`
 
-### Event Payload
-Actions should ALWAYS use the `payload` public name
-
 ### Action Operations
 Actions should NOT deal with view related operations (i.e. showing popups/etc). Use the action
 stream to handle these types of operations.
-


### PR DESCRIPTION
# Destructuring
To better cater for new developers which haven't become familiar with destructuring of types.
I have rewritten the docs to use:

```TS
@Action(FeedAnimals)
feedAnimals(ctx: StateContext<ZooStateModel>, action: FeedAnimals) {...}
```

# More info on how to name actions
https://github.com/ngxs/store/blob/feature/docs-ctx-update/docs/concepts/actions.md#how-should-you-name-your-actions

and the mental model you should use when designing your app.
Based on the great talk by Mike Ryan https://www.youtube.com/watch?v=JmnsEvoy-gY

What do you guys think of having a section about the mental model for actions, is it any good?