### PR TITLE
Rename COMPLETED status to SUCCESSFUL

### DIFF
--- a/docs/advanced/action-handlers.md
+++ b/docs/advanced/action-handlers.md
@@ -15,13 +15,14 @@ of message array to make the dialog show up. With Action Handlers, we can respon
 
 The action handler is an Observable that recieves all the actions dispatched before the state takes any action on it.
 
-Actions in NGXS also have a lifecycle. Since any potential action can be async we tag actions showing whether they are "DISPATCHED" or "COMPLETED". This gives you the ability to react to actions at different points in their existence.
+Actions in NGXS also have a lifecycle. Since any potential action can be async we tag actions showing when they are "DISPATCHED", "SUCCESSFUL", "CANCELED" or "ERRORED". This gives you the ability to react to actions at different points in their existence.
 
 Since it's an Observable, we can use the following four pipes:
 
 * `ofAction`: triggers when any of the below lifecycle events happen
-* `ofActionDispatched`: triggers when an action has been dispatched but NOT when it completes
-* `ofActionCompleted`: triggers when an action has been completed but NOT when it is dispatched
+* `ofActionDispatched`: triggers when an action has been dispatched
+* `ofActionSuccessful`: triggers when an action has been completed successfully
+* `ofActionCanceled`: triggers when an action has been canceled
 * `ofActionErrored`: triggers when an action has caused an error to be thrown
 
 Below is a action handler that filters for `RouteNavigate` actions and then tells the router to navigate to that
@@ -70,7 +71,7 @@ export class CartComponent {
   constructor(private actions$: Actions) {}
 
   ngOnInit() {
-    this.actions$.pipe(ofActionCompleted(CartDelete)).subscribe(() => alert('Item deleted'));
+    this.actions$.pipe(ofActionSuccessful(CartDelete)).subscribe(() => alert('Item deleted'));
   }
 }
 ```

--- a/packages/store/src/actions-stream.ts
+++ b/packages/store/src/actions-stream.ts
@@ -6,7 +6,7 @@ import { Observable, Subject } from 'rxjs';
  */
 export const enum ActionStatus {
   Dispatched = 'DISPATCHED',
-  Completed = 'COMPLETED',
+  Successful = 'SUCCESSFUL',
   Canceled = 'CANCELED',
   Errored = 'ERRORED'
 }

--- a/packages/store/src/dispatcher.ts
+++ b/packages/store/src/dispatcher.ts
@@ -80,7 +80,7 @@ export class InternalDispatcher {
       .pipe(
         exhaustMap((ctx: ActionContext) => {
           switch (ctx.status) {
-            case ActionStatus.Completed:
+            case ActionStatus.Successful:
               return of(this._stateStream.getValue());
             case ActionStatus.Errored:
               return throwError(ctx.error);

--- a/packages/store/src/of-action.ts
+++ b/packages/store/src/of-action.ts
@@ -27,16 +27,16 @@ export function ofActionDispatched(...allowedTypes: any[]) {
 /**
  * RxJS operator for selecting out specific actions.
  *
- * This will ONLY grab actions that have just been completed
+ * This will ONLY grab actions that have just been successfully completed
  */
-export function ofActionCompleted(...allowedTypes: any[]) {
-  return ofActionOperator(allowedTypes, ActionStatus.Completed);
+export function ofActionSuccessful(...allowedTypes: any[]) {
+  return ofActionOperator(allowedTypes, ActionStatus.Successful);
 }
 
 /**
  * RxJS operator for selecting out specific actions.
  *
- * This will ONLY grab actions that have just been completed
+ * This will ONLY grab actions that have just been canceled
  */
 export function ofActionCanceled(...allowedTypes: any[]) {
   return ofActionOperator(allowedTypes, ActionStatus.Canceled);
@@ -45,7 +45,7 @@ export function ofActionCanceled(...allowedTypes: any[]) {
 /**
  * RxJS operator for selecting out specific actions.
  *
- * This will ONLY grab actions that have thrown an error
+ * This will ONLY grab actions that have just thrown an error
  */
 export function ofActionErrored(...allowedTypes: any[]) {
   return ofActionOperator(allowedTypes, ActionStatus.Errored);

--- a/packages/store/src/public_api.ts
+++ b/packages/store/src/public_api.ts
@@ -4,7 +4,7 @@ export { Store } from './store';
 export { State } from './state';
 export { Select } from './select';
 export { Actions } from './actions-stream';
-export { ofAction, ofActionCompleted, ofActionDispatched, ofActionErrored } from './of-action';
+export { ofAction, ofActionSuccessful, ofActionDispatched, ofActionErrored } from './of-action';
 export { NgxsPlugin, NgxsPluginFn, StateContext, NgxsOnInit } from './symbols';
 export { Selector } from './selector';
 export { getActionTypeFromInstance, actionMatcher } from './utils';

--- a/packages/store/src/state-factory.ts
+++ b/packages/store/src/state-factory.ts
@@ -137,7 +137,7 @@ export class StateFactory {
         filter((ctx: ActionContext) => ctx.status === ActionStatus.Dispatched),
         mergeMap(({ action }) =>
           this.invokeActions(this._actions, action).pipe(
-            map(() => <ActionContext>{ action, status: ActionStatus.Completed }),
+            map(() => <ActionContext>{ action, status: ActionStatus.Successful }),
             defaultIfEmpty(<ActionContext>{ action, status: ActionStatus.Canceled }),
             catchError(error => of(<ActionContext>{ action, status: ActionStatus.Errored, error }))
           )

--- a/packages/store/tests/action.spec.ts
+++ b/packages/store/tests/action.spec.ts
@@ -9,7 +9,7 @@ import { throwError, of } from 'rxjs';
 import { NgxsModule } from '../src/module';
 import { Store } from '../src/store';
 import { Actions } from '../src/actions-stream';
-import { ofActionCompleted, ofActionDispatched, ofAction, ofActionErrored, ofActionCanceled } from '../src/of-action';
+import { ofActionSuccessful, ofActionDispatched, ofAction, ofActionErrored, ofActionCanceled } from '../src/of-action';
 
 describe('Action', () => {
   let store: Store;
@@ -78,17 +78,17 @@ describe('Action', () => {
         callbacksCalled.push('ofActionDispatched');
       });
 
-      actions.pipe(ofActionCompleted(Action1)).subscribe(action => {
-        callbacksCalled.push('ofActionCompleted');
-        expect(callbacksCalled).toEqual(['ofAction', 'ofActionDispatched', 'ofAction', 'ofActionCompleted']);
+      actions.pipe(ofActionSuccessful(Action1)).subscribe(action => {
+        callbacksCalled.push('ofActionSuccessful');
+        expect(callbacksCalled).toEqual(['ofAction', 'ofActionDispatched', 'ofAction', 'ofActionSuccessful']);
       });
 
       store.dispatch(new Action1()).subscribe(() => {
-        expect(callbacksCalled).toEqual(['ofAction', 'ofActionDispatched', 'ofAction', 'ofActionCompleted']);
+        expect(callbacksCalled).toEqual(['ofAction', 'ofActionDispatched', 'ofAction', 'ofActionSuccessful']);
       });
 
       tick(1);
-      expect(callbacksCalled).toEqual(['ofAction', 'ofActionDispatched', 'ofAction', 'ofActionCompleted']);
+      expect(callbacksCalled).toEqual(['ofAction', 'ofActionDispatched', 'ofAction', 'ofActionSuccessful']);
     })
   );
 
@@ -108,8 +108,8 @@ describe('Action', () => {
         callbacksCalled.push('ofActionDispatched');
       });
 
-      actions.pipe(ofActionCompleted(ErrorAction)).subscribe(action => {
-        callbacksCalled.push('ofActionCompleted');
+      actions.pipe(ofActionSuccessful(ErrorAction)).subscribe(action => {
+        callbacksCalled.push('ofActionSuccessful');
       });
 
       actions.pipe(ofActionErrored(ErrorAction)).subscribe(action => {
@@ -143,8 +143,8 @@ describe('Action', () => {
         callbacksCalled.push('ofActionErrored');
       });
 
-      actions.pipe(ofActionCompleted(CancelingAction)).subscribe(action => {
-        callbacksCalled.push('ofActionCompleted');
+      actions.pipe(ofActionSuccessful(CancelingAction)).subscribe(action => {
+        callbacksCalled.push('ofActionSuccessful');
         expect(callbacksCalled).toEqual([
           'ofAction',
           'ofActionDispatched',
@@ -153,7 +153,7 @@ describe('Action', () => {
           'ofAction',
           'ofActionCanceled',
           'ofAction',
-          'ofActionCompleted'
+          'ofActionSuccessful'
         ]);
       });
 
@@ -182,7 +182,7 @@ describe('Action', () => {
         'ofAction',
         'ofActionCanceled',
         'ofAction',
-        'ofActionCompleted'
+        'ofActionSuccessful'
       ]);
     })
   );

--- a/packages/store/tests/actions-stream.spec.ts
+++ b/packages/store/tests/actions-stream.spec.ts
@@ -60,7 +60,7 @@ describe('The Actions stream', () => {
     internalActions.subscribe(({ status }) => callsRecorded.push('1st Subscriber:' + status));
     internalActions.subscribe(({ status }) => {
       callsRecorded.push('2nd Subscriber:' + status);
-      if (status === ActionStatus.Dispatched) internalActions.next({ status: ActionStatus.Completed, action: null });
+      if (status === ActionStatus.Dispatched) internalActions.next({ status: ActionStatus.Successful, action: null });
     });
     internalActions.subscribe(({ status }) => callsRecorded.push('3rd Subscriber:' + status));
 
@@ -70,9 +70,9 @@ describe('The Actions stream', () => {
       '1st Subscriber:DISPATCHED',
       '2nd Subscriber:DISPATCHED',
       '3rd Subscriber:DISPATCHED',
-      '1st Subscriber:COMPLETED',
-      '2nd Subscriber:COMPLETED',
-      '3rd Subscriber:COMPLETED'
+      '1st Subscriber:SUCCESSFUL',
+      '2nd Subscriber:SUCCESSFUL',
+      '3rd Subscriber:SUCCESSFUL'
     ]);
   }));
 });


### PR DESCRIPTION
As discussed with the team...

The thinking behind renaming `completed` to `successful` was because when I introduced `canceled` I looked at the `canceled` and `errored` statuses and realized that they can both be viewed as 'completion' statuses too. So I felt that the `completed` status could potentially be interpreted by a user as representing all completion statuses. Then I decided that `successful` may be a better status because it only implies successful completion and not general completion.

Note: I have not regenerated the API docs as part of this PR.
I assume that this will be done as part of the release process?