### PR TITLE
Feature/proto replacement

### DIFF
--- a/packages/store/src/state.ts
+++ b/packages/store/src/state.ts
@@ -16,10 +16,9 @@ export const stateNameErrorMessage = name =>
 export function State<T>(options: StoreOptions<T>) {
   return function(target: any) {
     const meta = ensureStoreMetadata(target);
-
     // Handle inheritance
-    if (target.__proto__.hasOwnProperty(META_KEY)) {
-      const parentMeta = target.__proto__[META_KEY];
+    if (Object.getPrototypeOf(target).hasOwnProperty(META_KEY)) {
+      const parentMeta = Object.getPrototypeOf(target)[META_KEY];
 
       meta.actions = {
         ...meta.actions,

--- a/packages/store/src/state.ts
+++ b/packages/store/src/state.ts
@@ -16,6 +16,7 @@ export const stateNameErrorMessage = name =>
 export function State<T>(options: StoreOptions<T>) {
   return function(target: any) {
     const meta = ensureStoreMetadata(target);
+
     // Handle inheritance
     if (Object.getPrototypeOf(target).hasOwnProperty(META_KEY)) {
       const parentMeta = Object.getPrototypeOf(target)[META_KEY];


### PR DESCRIPTION
Replaced __proto__ property with Object.getPrototypeOf as its deprecated.
Link for reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto