### PR TITLE
Renaming ArchiveProject to Project

### DIFF
--- a/docs/concepts/actions.md
+++ b/docs/concepts/actions.md
@@ -43,7 +43,7 @@ They are usually trigged by user events such as clicking on a button, or selecti
 Names should contain three parts:
 
 * A context as to where the command came from, '[User API]', '[Product Page]', '[Dashboard Page]`.
-* The entity we are acting upon, `User`, `Card`, `ArchiveProject`.
+* The entity we are acting upon, `User`, `Card`, `Project`.
 * A verb describing what we want to do with the entity.
 
 Examples:


### PR DESCRIPTION
By example, there was no verb added to the ArchiveProject, 
so I think the entity to act upon is Project and the verb is Archive.