### PR TITLE
chore: add request for stackblitz repro link to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -27,10 +27,12 @@ Please provide ther version of NGXS that you are using as well as the version of
 ### Repro steps
 
 <!--
-Simple steps to reproduce this bug.
+If possible a link to a http://stackblitz.com (or github) repo with a repro or a failing test would be great.
+Please provide simple steps to reproduce this bug.
 Please include: commands run, packages added, related code changes.
-A link to a sample repo would help too.
 -->
+
+Stackblitz / Github link: https://stackblitz.com/fork/ngxs-simple
 
 * Step 1
 * Step 2


### PR DESCRIPTION
Added text to issue template requesting a stackblitz link  as a repo if possible.
Much easier to reproduce the issue and verify the fix afterwards if provided.

Also provided a sample link that, if followed, would give them a forked version of the simple ngxs sample.