### PR TITLE
fix(store): move the subscribe into a zone

### DIFF
--- a/packages/store/src/dispatcher.ts
+++ b/packages/store/src/dispatcher.ts
@@ -41,7 +41,7 @@ export class InternalDispatcher {
     });
 
     result.subscribe({
-      error: error => this._errorHandler.handleError(error)
+      error: error => this._ngZone.run(() => this._errorHandler.handleError(error))
     });
 
     return result.pipe(enterZone(this._ngZone));

--- a/packages/store/src/dispatcher.ts
+++ b/packages/store/src/dispatcher.ts
@@ -6,6 +6,7 @@ import { compose } from './compose';
 import { InternalActions, ActionStatus, ActionContext } from './actions-stream';
 import { StateStream } from './state-stream';
 import { PluginManager } from './plugin-manager';
+import { enterZone } from './zone';
 
 /**
  * Internal Action result stream that is emitted when an action is completed.
@@ -43,7 +44,7 @@ export class InternalDispatcher {
       error: error => this._errorHandler.handleError(error)
     });
 
-    return result;
+    return result.pipe(enterZone(this._ngZone));
   }
 
   private dispatchSingle(action: any): Observable<any> {

--- a/packages/store/src/zone.ts
+++ b/packages/store/src/zone.ts
@@ -1,0 +1,19 @@
+import { Observable, Observer } from 'rxjs';
+import { NgZone } from '@angular/core';
+
+/**
+ * Operator to run the `subscribe` in a Angular zone.
+ */
+export function enterZone<T>(zone: NgZone) {
+  return (source: Observable<T>) => {
+    return new Observable((sink: Observer<T>) => {
+      return source.subscribe({
+        next(x) {
+          zone.run(() => sink.next(x));
+        },
+        error: sink.error.bind(sink),
+        complete: sink.complete.bind(sink)
+      });
+    });
+  };
+}

--- a/packages/store/src/zone.ts
+++ b/packages/store/src/zone.ts
@@ -11,8 +11,12 @@ export function enterZone<T>(zone: NgZone) {
         next(x) {
           zone.run(() => sink.next(x));
         },
-        error: sink.error.bind(sink),
-        complete: sink.complete.bind(sink)
+        error(e) {
+          zone.run(() => sink.error(e));
+        },
+        complete() {
+          zone.run(() => sink.complete());
+        }
       });
     });
   };

--- a/packages/store/tests/dispatch.spec.ts
+++ b/packages/store/tests/dispatch.spec.ts
@@ -1,4 +1,4 @@
-import { ErrorHandler, Injectable } from '@angular/core';
+import { ErrorHandler, Injectable, NgZone } from '@angular/core';
 import { async, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { timer, of, throwError } from 'rxjs';
 import { tap, skip, delay } from 'rxjs/operators';
@@ -55,6 +55,28 @@ describe('Dispatch', () => {
     store.dispatch(new Increment()).subscribe(() => {}, err => observedCalls.push('observer.error(...)'));
 
     expect(observedCalls).toEqual(['handleError(...)', 'observer.error(...)']);
+  }));
+
+  it('should run outside zone and return back in zone', async(() => {
+    @State<number>({
+      name: 'counter',
+      defaults: 0
+    })
+    class MyState {
+      @Action(Increment)
+      increment() {
+        expect(NgZone.isInAngularZone()).toBe(false);
+      }
+    }
+
+    TestBed.configureTestingModule({
+      imports: [NgxsModule.forRoot([MyState]), NgxsModule.forFeature([])]
+    });
+
+    const store: Store = TestBed.get(Store);
+    store.dispatch(new Increment()).subscribe(() => {
+      expect(NgZone.isInAngularZone()).toBe(true);
+    });
   }));
 
   it('should only call action once', async(() => {

--- a/packages/store/tests/dispatch.spec.ts
+++ b/packages/store/tests/dispatch.spec.ts
@@ -74,8 +74,12 @@ describe('Dispatch', () => {
     });
 
     const store: Store = TestBed.get(Store);
-    store.dispatch(new Increment()).subscribe(() => {
+    const zone: NgZone = TestBed.get(NgZone);
+    zone.run(() => {
       expect(NgZone.isInAngularZone()).toBe(true);
+      store.dispatch(new Increment()).subscribe(() => {
+        expect(NgZone.isInAngularZone()).toBe(true);
+      });
     });
   }));
 


### PR DESCRIPTION
This moves the `subscribe` function of the dispatch back into a angular zone.