### PR TITLE
Consolidate internal state operations

### DIFF
--- a/packages/store/src/internals.ts
+++ b/packages/store/src/internals.ts
@@ -17,7 +17,7 @@ export interface ActionHandlerMetaData {
   type: string;
 }
 
-export interface InternalStateOperations<T> {
+export interface StateOperations<T> {
   getState(): T;
   setState(val: T);
   dispatch(actions: any | any[]): Observable<void>;

--- a/packages/store/src/state-context-factory.ts
+++ b/packages/store/src/state-context-factory.ts
@@ -2,10 +2,9 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { StateContext } from './symbols';
-import { InternalStateOperations, MappedStore } from './internals';
+import { MappedStore } from './internals';
 import { setValue, getValue } from './utils';
-import { InternalDispatcher } from './dispatcher';
-import { StateStream } from './state-stream';
+import { InternalStateOperations } from './state-operations';
 
 /**
  * State Context factory class
@@ -13,21 +12,15 @@ import { StateStream } from './state-stream';
  */
 @Injectable()
 export class StateContextFactory {
-  constructor(private _stateStream: StateStream, private _dispatcher: InternalDispatcher) {}
-
-  private get rootStateOperations(): InternalStateOperations<any> {
-    return {
-      getState: () => this._stateStream.getValue(),
-      setState: newState => this._stateStream.next(newState),
-      dispatch: actions => this._dispatcher.dispatch(actions)
-    };
-  }
+  constructor(
+    private _internalStateOperations: InternalStateOperations
+  ) {}
 
   /**
    * Create the state context
    */
   createStateContext(metadata: MappedStore): StateContext<any> {
-    const root = this.rootStateOperations;
+    const root = this._internalStateOperations.getRootStateOperations();
     return {
       getState(): any {
         const state = root.getState();

--- a/packages/store/src/state-operations.ts
+++ b/packages/store/src/state-operations.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+
+import { StateOperations } from './internals';
+import { InternalDispatcher } from './dispatcher';
+import { StateStream } from './state-stream';
+
+/**
+ * State Context factory class
+ * @ignore
+ */
+@Injectable()
+export class InternalStateOperations {
+  constructor(private _stateStream: StateStream, private _dispatcher: InternalDispatcher) {}
+
+  public getRootStateOperations(): StateOperations<any> {
+    const rootStateOperations = {
+      getState: () => this._stateStream.getValue(),
+      setState: newState => this._stateStream.next(newState),
+      dispatch: actions => this._dispatcher.dispatch(actions)
+    };
+
+    return rootStateOperations;
+  }
+}

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -4,17 +4,21 @@ import { distinctUntilChanged, catchError, take, map } from 'rxjs/operators';
 
 import { StateStream } from './state-stream';
 import { getSelectorFn } from './selector-utils';
-import { InternalDispatcher } from './dispatcher';
+import { InternalStateOperations } from './state-operations';
 
 @Injectable()
 export class Store {
-  constructor(private _stateStream: StateStream, private _dispatcher: InternalDispatcher) {}
+  constructor(
+    private _stateStream: StateStream,
+    private _internalStateOperations: InternalStateOperations
+  ) {}
 
   /**
    * Dispatches event(s).
    */
   dispatch(event: any | any[]): Observable<any> {
-    return this._dispatcher.dispatch(event);
+    const operations = this._internalStateOperations.getRootStateOperations();
+    return operations.dispatch(event);
   }
 
   /**


### PR DESCRIPTION
This consolidation is required for the freeze functionality of the development mode.
This is so that all internal `dispatch` and `setState` operations go through a single point so that they can be intercepted and frozen. This could also be a useful point to gather debug information.
 
PS. Kept the `StateOperations` interface internal and reverted the plugin interface (as opposed to the last PR).