### PR TITLE
fix(store): add deep-freeze-strict to peerDeps

### DIFF
--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "sideEffects": true,
   "peerDependencies": {
+    "deep-freeze-strict": "^1.1.1",
     "@angular/core": ">=5.0.0 <7.0.0",
     "rxjs": ">=6.0.0 || ^5.6.0-forward-compat.4"
   }


### PR DESCRIPTION
Add missing (peer)dependecy of the store module.  Although it seems that
defining lib. deps through peerDeps is the preferred way (see https://github.com/dherges/ng-packagr/pull/687) it feels weird to force consumers to explicitly add this to their
application deps.

A better approach would be to bundle the deep-freeze module into the store package.

Closes #412