### PR TITLE
feat(selector): enable the creation of selectors with arguments (#413)

### DIFF
--- a/packages/store/src/public_api.ts
+++ b/packages/store/src/public_api.ts
@@ -7,4 +7,5 @@ export { Actions } from './actions-stream';
 export { ofAction, ofActionSuccessful, ofActionDispatched, ofActionErrored } from './of-action';
 export { NgxsPlugin, NgxsPluginFn, StateContext, NgxsOnInit } from './symbols';
 export { Selector } from './selector';
+export { SelectorCreator } from './selector-creator';
 export { getActionTypeFromInstance, actionMatcher } from './utils';

--- a/packages/store/src/selector-creator.ts
+++ b/packages/store/src/selector-creator.ts
@@ -1,0 +1,19 @@
+import { Selector } from './selector';
+
+export function SelectorCreator(selectors?: any[]) {
+  return (target: any, key: string, descriptor: PropertyDescriptor) => {
+    if (descriptor.value !== null) {
+      return {
+        configurable: true,
+        get() {
+          return function factory(...args) {
+            const value = descriptor.value(...args);
+            return Selector(selectors)(target, key, { ...descriptor, value }).get();
+          };
+        }
+      };
+    } else {
+      throw new Error('SelectorCreators only work on methods');
+    }
+  };
+}

--- a/packages/store/tests/selector-creator.spec.ts
+++ b/packages/store/tests/selector-creator.spec.ts
@@ -1,0 +1,102 @@
+import { async, TestBed } from '@angular/core/testing';
+import { State, SelectorCreator } from '@ngxs/store';
+import { Store } from '../src/store';
+import { NgxsModule } from '../src/module';
+import { Selector } from '../src/selector';
+
+describe('SelectorCreator', () => {
+  interface MyStateModel {
+    foo: string;
+    bar: string;
+  }
+
+  @State<MyStateModel>({
+    name: 'counter',
+    defaults: {
+      foo: 'Hello',
+      bar: 'World'
+    }
+  })
+  class MyState {
+    @Selector()
+    static foo(state) {
+      return state.foo;
+    }
+
+    @SelectorCreator()
+    static getStateKey(key: keyof MyStateModel) {
+      return (state: MyStateModel) => state[key];
+    }
+  }
+
+  interface MyState2Model {
+    foo: string;
+    bar: string;
+  }
+
+  @State<MyState2Model>({
+    name: 'zoo',
+    defaults: {
+      foo: 'Hello',
+      bar: 'World'
+    }
+  })
+  class MyState2 {
+    @Selector([MyState.getStateKey('bar')])
+    static foo(myState2: MyState2Model, bar: string) {
+      return myState2.foo + bar;
+    }
+  }
+
+  class MetaSelector {
+    @Selector([MyState.getStateKey('foo')])
+    static foo(myState) {
+      return myState;
+    }
+
+    @SelectorCreator([MyState2.foo])
+    static concatFooState2(text: string) {
+      return (foo: string) => foo + text;
+    }
+  }
+
+  it('should select the state', async(() => {
+    TestBed.configureTestingModule({
+      imports: [NgxsModule.forRoot([MyState])]
+    });
+
+    const store: Store = TestBed.get(Store);
+    const slice = store.selectSnapshot(MyState.foo);
+    expect(slice).toBe('Hello');
+
+    const slice2 = store.selectSnapshot(MyState.getStateKey('foo'));
+    expect(slice2).toBe('Hello');
+
+    const slice3 = store.selectSnapshot(MyState.getStateKey('bar'));
+    expect(slice3).toBe('World');
+  }));
+
+  it('should select using the meta selector', async(() => {
+    TestBed.configureTestingModule({
+      imports: [NgxsModule.forRoot([MyState, MyState2])]
+    });
+
+    const store: Store = TestBed.get(Store);
+    const slice = store.selectSnapshot(MetaSelector.foo);
+    expect(slice).toBe('Hello');
+
+    const slice2 = store.selectSnapshot(MetaSelector.concatFooState2('!'));
+    expect(slice2).toBe('HelloWorld!');
+  }));
+
+  it('should still be usable as a function', async(() => {
+    TestBed.configureTestingModule({
+      imports: [NgxsModule.forRoot([MyState])]
+    });
+
+    const store: Store = TestBed.get(Store);
+    const myState = store.selectSnapshot(<any>MyState);
+    const slice = MyState.getStateKey('foo')(myState);
+    expect(slice).toBe('Hello');
+  }));
+});


### PR DESCRIPTION
Hi team, I believe this new feature will bring great value to this awesome library, this feature enables what can be easily done in `@ngrx/store` using the `createSelector` function:

```ts
export function getSchemaSelector(type: keyof ConfigStateModel) {
   return createSelector(state => state[type].schema);
}
```

This new decorator will work as a factory to create selectors, with preconfigured parameters, here is an example of the syntax:

```ts
@State<ConfigStateModel>({
  name: 'config',
  defaults: { clients: { schema: {} }, incomes: { schema: {} } }
})
export class ConfigState {
  @SelectorCreator()
  static getSchema(type: keyof ConfigStateModel) {
    return (state: ConfigStateModel) => state[type].schema;
  }
}

@Component(...)
export class ClientsListComponent {

  @Select(ConfigState.getSchema('clients'))
  public clientSchema$: Observable<any>;

}
```

Here I have a working demo, using this new feature:
https://stackblitz.com/edit/angular-v89xad?embed=1&file=src/app/app.module.ts