### PR TITLE
feat: expose RouterStateModel in @ngxs/router-plugin

### DIFF
--- a/packages/router-plugin/index.ts
+++ b/packages/router-plugin/index.ts
@@ -1,3 +1,3 @@
 export { NgxsRouterPluginModule } from './src/router.module';
-export { RouterState } from './src/router.state';
+export { RouterState, RouterStateModel } from './src/router.state';
 export * from './src/router.actions';


### PR DESCRIPTION
I need these imports:

```
import { RouterState } from '@ngxs/router-plugin';
import { RouterStateModel } from '@ngxs/router-plugin/src/router.state';
```

to use this:
```
this.store.select(RouterState)
  .subscribe((route: RouterStateModel) => console.log(route.state));
```

And I think it should be better:

```
import { RouterState, RouterStateModel } from '@ngxs/router-plugin';
```

