### PR TITLE
More logical lists for describe naming of actions

### DIFF
--- a/docs/concepts/actions.md
+++ b/docs/concepts/actions.md
@@ -43,8 +43,8 @@ They are usually trigged by user events such as clicking on a button, or selecti
 Names should contain three parts:
 
 * A context as to where the command came from, `[User API]`, `[Product Page]`, `[Dashboard Page]`.
-* The entity we are acting upon, `User`, `Card`, `Project`.
 * A verb describing what we want to do with the entity.
+* The entity we are acting upon, `User`, `Card`, `Project`.
 
 Examples:
 


### PR DESCRIPTION
I've changed that, because first you should use verb in action then noun. Looks like more logical :)

When you read previous variant, of that list you can be confused, that is noun described first in the list, then verb but actually you should use verb before noun.