### PR TITLE
fix(select.md): fix small typo

### DIFF
--- a/docs/concepts/select.md
+++ b/docs/concepts/select.md
@@ -18,7 +18,7 @@ import { ZooState } from './zoo.state';
 
 @Component({ ... })
 export class ZooComponent {
- // Reads the name of the store from the store class
+ // Reads the name of the state from the state class
   @Select(ZooState) animals$: Observable<string[]>;
 
   // Uses the pandas memoized selector to only return pandas


### PR DESCRIPTION
This PR fixes a small typo in `select.md`.