### PR TITLE
docs: fix example on state.md

### DIFF
--- a/docs/concepts/state.md
+++ b/docs/concepts/state.md
@@ -19,7 +19,7 @@ export class AnimalsState {}
 In the state decorator, we define some metadata about the state. These options
 include:
 
-- `name`: The name of the state slice. Note: The name is a required parameter and must be unique for the entire application. 
+- `name`: The name of the state slice. Note: The name is a required parameter and must be unique for the entire application.
 Names must be object property safe, AKA no dashes, dots, etc.
 - `defaults`: Default set of object/array for this state slice.
 - `children`: Child sub state associations.
@@ -41,7 +41,7 @@ export class ZooState {
 
 ## Defining Actions
 Our states listen to actions via a `@Action` decorator. The action decorator
-accepts an action class or an array of action classes. 
+accepts an action class or an array of action classes.
 
 ### Simple Actions
 Let's define a state that will listen to a `FeedAnimals` action to toggle whether the animals have been fed:
@@ -151,7 +151,7 @@ feedZebra(ctx: StateContext<ZooStateModel>, action: FeedZebra) {
 ```
 
 ### Async Actions
-Actions can perform async operations and update the state after an operation. 
+Actions can perform async operations and update the state after an operation.
 
 Typically in Redux your actions are pure functions and you have some other system like a saga or an effect to perform
 these operations and dispatch another action back to your state to mutate it. There are some
@@ -164,7 +164,7 @@ Let's take a look at a simple async action:
 import { State, Action, StateContext } from '@ngxs/store';
 import { tap } from 'rxjs/operators';
 
-export interface FeedAnimalsAction {
+export class FeedAnimals {
   static readonly type = '[Zoo] FeedAnimals';
   constructor(public animalsToFeed: string) {}
 }
@@ -214,7 +214,7 @@ that observable chain to look like this:
 ```TS
 import { State, Action } from '@ngxs/store';
 
-export interface FeedAnimalsAction {
+export class FeedAnimals {
   static readonly type = '[Zoo] FeedAnimals';
   constructor(public animalsToFeed: string) {}
 }


### PR DESCRIPTION
fixes a bug in example code where an interface with wrong name is used