### PR TITLE
feat: entity base with NgxsOnInit

### DIFF
--- a/packages/store/src/entity-base.ts
+++ b/packages/store/src/entity-base.ts
@@ -1,4 +1,4 @@
-import { NgxsOnInit, StateContext } from '@ngxs/store';
+import { NgxsOnInit, StateContext } from './symbols';
 
 export interface EntityStateModel<V> {
   ids: (string | number)[];

--- a/packages/store/src/entity-base.ts
+++ b/packages/store/src/entity-base.ts
@@ -1,4 +1,4 @@
-import { StateBase } from './state-base';
+import { NgxsOnInit, StateContext } from '@ngxs/store';
 
 export interface EntityStateModel<V> {
   ids: (string | number)[];
@@ -26,7 +26,9 @@ export enum EntityMutation {
   None
 }
 
-export abstract class EntityBase<T, S extends EntityStateModel<T>> extends StateBase<S> {
+export abstract class EntityBase<T, S extends EntityStateModel<T>> implements NgxsOnInit {
+  private ctx: StateContext<S>;
+
   /**
    * The defaults for all state classes that inherit from EntityBase
    */
@@ -51,6 +53,10 @@ export abstract class EntityBase<T, S extends EntityStateModel<T>> extends State
 
   static selectTotal<T>(state: EntityStateModel<T>) {
     return (state.ids || []).length;
+  }
+
+  ngxsOnInit(ctx: StateContext<S>) {
+    this.ctx = ctx;
   }
 
   /**

--- a/packages/store/src/state-base.ts
+++ b/packages/store/src/state-base.ts
@@ -1,4 +1,4 @@
-import { StateContext, META_KEY } from './symbols';
+import { StateContext } from './symbols';
 
 export abstract class StateBase<StateModel> {
   public ctx: StateContext<StateModel> = null; // gets set in StateFactory


### PR DESCRIPTION
Use NgxsOnInit to avoid inherit from StateBase

I believe with this approach, there is some advantages:
- Simple classes
- Maybe StateBase isn't neccessary anymore, so it's possible to use it without Store modifications
