### PR TITLE
fix(docs): set empty state not working

### DIFF
--- a/docs/recipes/authentication.md
+++ b/docs/recipes/authentication.md
@@ -6,8 +6,8 @@ First, let's define our state model and our actions:
 
 ```TS
 export class AuthStateModel {
-  token: string;
-  username: string;
+  token?: string;
+  username?: string;
 }
 
 export class Login {


### PR DESCRIPTION
token and username could not be empty.

There's also another solution for that:
```
export class AuthStateModel {
  token: string;
  username: string;
}

const AuthStateDefaults: AuthStateModel = {
  token: null,
  username: null,
};

@State<AuthStateModel>({
  name: 'auth',
  defaults: AuthStateDefaults,
})
```

And in the action:
`setState(AuthStateDefaults)`