### PR TITLE
fix(devtools-plugin): support "relaxed" json format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ngxs",
-  "version": "3.1.4",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1109,12 +1109,6 @@
         "@types/node": "*"
       }
     },
-    "@types/googlemaps": {
-      "version": "3.30.9",
-      "resolved": "https://registry.npmjs.org/@types/googlemaps/-/googlemaps-3.30.9.tgz",
-      "integrity": "sha512-Ti8XvV5OYxvxYAeQja29JH48F2T3pV7LhuEcNf6yM/iHvRq3guzFL/J9QIG9v3L9KCkk4NgO38SKc2kWvX8aZA==",
-      "dev": true
-    },
     "@types/handlebars": {
       "version": "4.0.36",
       "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.36.tgz",
@@ -1141,6 +1135,12 @@
       "requires": {
         "@types/jasmine": "*"
       }
+    },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
     },
     "@types/lodash": {
       "version": "4.14.104",
@@ -6342,6 +6342,14 @@
             "emojis-list": "^2.0.0",
             "json5": "^0.5.0",
             "object-assign": "^4.0.1"
+          },
+          "dependencies": {
+            "json5": {
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+              "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+              "dev": true
+            }
           }
         }
       }
@@ -8009,10 +8017,21 @@
       "dev": true
     },
     "json5": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -9365,6 +9384,14 @@
         "big.js": "^3.1.3",
         "emojis-list": "^2.0.0",
         "json5": "^0.5.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+          "dev": true
+        }
       }
     },
     "locate-character": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "private": true,
   "devDependencies": {
+    "@angular-devkit/build-angular": "~0.6.8",
     "@angular/cli": "6.0.8",
     "@angular/common": "6.0.5",
     "@angular/compiler": "6.0.5",
@@ -87,9 +88,9 @@
     "@commitlint/config-conventional": "^6.1.3",
     "@types/deep-freeze-strict": "^1.1.0",
     "@types/fs-extra": "^5.0.1",
-    "@types/googlemaps": "^3.29.2",
     "@types/jasmine": "~2.8.6",
     "@types/jasminewd2": "~2.0.2",
+    "@types/json5": "0.0.29",
     "@types/node": "~9.6.0",
     "@types/semver": "^5.5.0",
     "codelyzer": "^4.0.0",
@@ -98,6 +99,7 @@
     "husky": "^0.15.0-rc.13",
     "jasmine-core": "~2.99.1",
     "jasmine-spec-reporter": "~4.2.1",
+    "json5": "^1.0.1",
     "karma": "~2.0.0",
     "karma-chrome-launcher": "~2.2.0",
     "karma-cli": "~1.0.1",
@@ -107,6 +109,7 @@
     "lint-staged": "^7.0.0",
     "mock-socket": "^7.1.0",
     "ng-packagr": "3.0.0-rc.1",
+    "npm-run-all": "^4.1.2",
     "prettier": "^1.8.2",
     "rxjs": "^6.0.0",
     "rxjs-compat": "^6.0.0",
@@ -117,8 +120,6 @@
     "typedoc": "^0.11.1",
     "typedoc-plugin-markdown": "^1.1.1",
     "typescript": "2.7.2",
-    "npm-run-all": "^4.1.2",
-    "zone.js": "^0.8.26",
-    "@angular-devkit/build-angular": "~0.6.8"
+    "zone.js": "^0.8.26"
   }
 }

--- a/packages/devtools-plugin/src/devtools.plugin.ts
+++ b/packages/devtools-plugin/src/devtools.plugin.ts
@@ -2,6 +2,8 @@ import { Injectable, Inject, Injector } from '@angular/core';
 import { NgxsPlugin, getActionTypeFromInstance, Store } from '@ngxs/store';
 import { tap } from 'rxjs/operators';
 
+import * as json5 from 'json5';
+
 import { NgxsDevtoolsExtension, NgxsDevtoolsOptions, NGXS_DEVTOOLS_OPTIONS, NgxsDevtoolsAction } from './symbols';
 
 /**
@@ -15,6 +17,7 @@ export class NgxsReduxDevtoolsPlugin implements NgxsPlugin {
 
   constructor(@Inject(NGXS_DEVTOOLS_OPTIONS) private _options: NgxsDevtoolsOptions, private _injector: Injector) {
     const globalDevtools = this.windowObj['__REDUX_DEVTOOLS_EXTENSION__'] || this.windowObj['devToolsExtension'];
+
     if (globalDevtools) {
       this.devtoolsExtension = globalDevtools.connect(_options) as NgxsDevtoolsExtension;
       this.devtoolsExtension.subscribe(a => this.dispatched(a));
@@ -26,6 +29,7 @@ export class NgxsReduxDevtoolsPlugin implements NgxsPlugin {
    */
   handle(state: any, action: any, next: any) {
     const isDisabled = this._options && this._options.disabled;
+
     if (!this.devtoolsExtension || isDisabled) {
       return next(state, action);
     }
@@ -34,6 +38,7 @@ export class NgxsReduxDevtoolsPlugin implements NgxsPlugin {
       tap(newState => {
         // if init action, send initial state to dev tools
         const isInitAction = getActionTypeFromInstance(action) === '@@INIT';
+
         if (isInitAction) {
           this.devtoolsExtension.init(state);
         } else {
@@ -49,24 +54,36 @@ export class NgxsReduxDevtoolsPlugin implements NgxsPlugin {
    * Handle the action from the dev tools subscription
    */
   dispatched(action: NgxsDevtoolsAction) {
-    // Lazy get the store for circular depedency issues
+    // Lazy get the store for circular dependency issues
     const store = this._injector.get(Store);
+
     if (action.type === 'DISPATCH') {
-      if (action.payload.type === 'JUMP_TO_ACTION' || action.payload.type === 'JUMP_TO_STATE') {
-        const prevState = JSON.parse(action.state);
-        store.reset(prevState);
-      } else if (action.payload.type === 'TOGGLE_ACTION') {
-        console.warn('Skip is not supported at this time.');
-      } else if (action.payload.type === 'IMPORT_STATE') {
-        const { actionsById, computedStates, currentStateIndex } = action.payload.nextLiftedState;
-        this.devtoolsExtension.init(computedStates[0].state);
-        Object.keys(actionsById)
-          .filter(actionId => actionId !== '0')
-          .forEach(actionId => this.devtoolsExtension.send(actionsById[actionId], computedStates[actionId].state));
-        store.reset(computedStates[currentStateIndex].state);
+      switch (action.payload.type) {
+        case 'JUMP_TO_ACTION':
+        case 'JUMP_TO_STATE':
+          const prevState = json5.parse(action.state);
+
+          store.reset(prevState);
+          break;
+
+        case 'TOGGLE_ACTION':
+          console.warn('Skip is not supported at this time.');
+          break;
+
+        case 'IMPORT_STATE':
+          const { actionsById, computedStates, currentStateIndex } = action.payload.nextLiftedState;
+
+          this.devtoolsExtension.init(computedStates[0].state);
+
+          Object.keys(actionsById)
+            .filter(actionId => actionId !== '0')
+            .forEach(actionId => this.devtoolsExtension.send(actionsById[actionId], computedStates[actionId].state));
+          store.reset(computedStates[currentStateIndex].state);
+          break;
       }
     } else if (action.type === 'ACTION') {
-      const actionPayload = JSON.parse(action.payload);
+      const actionPayload = json5.parse(action.payload);
+
       store.dispatch(actionPayload);
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -386,10 +386,6 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/googlemaps@^3.29.2":
-  version "3.30.8"
-  resolved "https://registry.yarnpkg.com/@types/googlemaps/-/googlemaps-3.30.8.tgz#cc6ab90f79f3a8b799860ea1d70252a221af702e"
-
 "@types/handlebars@4.0.36":
   version "4.0.36"
   resolved "https://registry.yarnpkg.com/@types/handlebars/-/handlebars-4.0.36.tgz#ff57c77fa1ab6713bb446534ddc4d979707a3a79"
@@ -407,6 +403,10 @@
   resolved "https://registry.yarnpkg.com/@types/jasminewd2/-/jasminewd2-2.0.3.tgz#0d2886b0cbdae4c0eeba55e30792f584bf040a95"
   dependencies:
     "@types/jasmine" "*"
+
+"@types/json5@0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
 
 "@types/lodash@4.14.104":
   version "4.14.104"
@@ -4418,6 +4418,12 @@ json3@^3.3.2:
 json5@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+
+json5@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
+  dependencies:
+    minimist "^1.2.0"
 
 jsonfile@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
When copying a raw state from the devtools plugin, the JSON is in "relaxed" format and JSON.parse isn't supporting that, for example:
```
{
  payload: 'Make pizza',
  type: 'AddTodo'
}
```

So in this PR I did the following:
1. Added [JSON5](https://github.com/json5/json5) package dependency and changed JSON.parse to json5.parse. I also changed the JSON.parse in importing state for consistency, even though it's not required because the state.json is stringified.
2. After updating the package-lock file, the ngxs version has also been updated, the dependencies automatically reordered and I found out there is an unnecessary package (@types/googlemaps).
3. I also refactored a little bit the dispatched method in the plugin to make it more readable.

All the features have been tested using Chrome.