### PR TITLE
fix(store): expose ofActionCanceled function

### DIFF
--- a/packages/store/src/public_api.ts
+++ b/packages/store/src/public_api.ts
@@ -4,7 +4,7 @@ export { Store } from './store';
 export { State } from './decorators/state';
 export { Select } from './decorators/select';
 export { Actions } from './actions-stream';
-export { ofAction, ofActionSuccessful, ofActionDispatched, ofActionErrored } from './operators/of-action';
+export { ofAction, ofActionDispatched, ofActionSuccessful, ofActionCanceled, ofActionErrored } from './operators/of-action';
 export { NgxsPlugin, NgxsPluginFn, StateContext, NgxsOnInit } from './symbols';
 export { Selector } from './decorators/selector';
 export { getActionTypeFromInstance, actionMatcher } from './utils/utils';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Action stream ofActionCanceled is not exposed in the store public api.

Issue Number: #526 


## What is the new behavior?
Add ofActionCanceled into public api file and reorder the exports just like in the of-action file.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```