### PR TITLE
fix(integration): errors in integration test

### DIFF
--- a/integration/app/app.component.spec.ts
+++ b/integration/app/app.component.spec.ts
@@ -11,6 +11,13 @@ describe('AppComponent', () => {
   let fixture: ComponentFixture<AppComponent>;
   let component: AppComponent;
 
+  const initialState = {
+    todos: {
+      todo: [],
+      pizza: { model: undefined }
+    }
+  };
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [AppModule, RouterTestingModule, FormsModule, ReactiveFormsModule],
@@ -22,7 +29,7 @@ describe('AppComponent', () => {
 
     // reset store because of storage plugin
     const store = TestBed.get(Store);
-    store.reset({});
+    store.reset(initialState);
   });
 
   it('should add a todo', () => {


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Errors appear in the integration test since storage plugin been added, for example:
```Bash
ERROR: 'ERROR', TypeError: Cannot read property 'concat' of undefined
TypeError: Cannot read property 'concat' of undefined
    at TodoState../integration/app/todo.state.ts.TodoState.addTodo (http://localhost:9876/_karma_webpack_/webpack:/integration/app/todo.state.ts:34:28)
```

But the tests itself isn't failing.

## What is the new behavior?
Todos state is initialized with a valid initial state, instead of an empty object.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```