### PR TITLE
feat: add strictContentSecurityPolicy compatibility rule

### DIFF
--- a/packages/store/src/internal/internals.ts
+++ b/packages/store/src/internal/internals.ts
@@ -28,6 +28,7 @@ export interface MetaDataModel {
   actions: ObjectKeyMap<ActionHandlerMetaData[]>;
   defaults: any;
   path: string;
+  selectFromAppState: SelectFromState;
   children: StateClass[];
   instance: any;
 }
@@ -61,6 +62,7 @@ export function ensureStoreMetadata(target): MetaDataModel {
       actions: {},
       defaults: {},
       path: null,
+      selectFromAppState: null,
       children: [],
       instance: null
     };
@@ -106,6 +108,21 @@ export function ensureSelectorMetadata(target): SelectorMetaDataModel {
  */
 export function getSelectorMetadata(target): SelectorMetaDataModel {
   return target[SELECTOR_META_KEY];
+}
+
+/**
+ * Get a deeply nested value. Example:
+ *
+ *    getValue({ foo: bar: [] }, 'foo.bar') //=> []
+ *
+ * Note: This is not as fast as the `fastPropGetter` but is strict Content Security Policy compliant.
+ * See perf hit: https://jsperf.com/fast-value-getter-given-path/1
+ *
+ * @ignore
+ */
+export function compliantPropGetter(paths: string[]): (x: any) => any {
+  const copyOfPaths = [...paths];
+  return obj => copyOfPaths.reduce((acc: any, part: string) => acc && acc[part], obj);
 }
 
 /**

--- a/packages/store/src/module.ts
+++ b/packages/store/src/module.ts
@@ -96,7 +96,7 @@ export function ngxsConfigFactory(options: ModuleOptions): NgxsConfig {
   return config;
 }
 
-export const ROOT_OPTIONS = new InjectionToken('ROOT_OPTIONS');
+export const ROOT_OPTIONS = new InjectionToken<ModuleOptions>('ROOT_OPTIONS');
 
 /**
  * Ngxs Module

--- a/packages/store/src/symbols.ts
+++ b/packages/store/src/symbols.ts
@@ -20,6 +20,20 @@ export class NgxsConfig {
    * (default: false)
    */
   developmentMode: boolean;
+  compatibility: {
+    /**
+     * Support a strict Content Security Policy.
+     * This will cirumvent some optimisations that violate a strict CSP through the use of `new Function(...)`.
+     * (default: false)
+     */
+    strictContentSecurityPolicy: boolean;
+  };
+
+  constructor() {
+    this.compatibility = {
+      strictContentSecurityPolicy: false
+    };
+  }
 }
 
 /**

--- a/packages/store/src/utils/selector-utils.ts
+++ b/packages/store/src/utils/selector-utils.ts
@@ -1,10 +1,4 @@
-import {
-  SelectFromState,
-  fastPropGetter,
-  ensureSelectorMetadata,
-  getSelectorMetadata,
-  getStoreMetadata
-} from '../internal/internals';
+import { SelectFromState, ensureSelectorMetadata, getSelectorMetadata, getStoreMetadata } from '../internal/internals';
 import { memoize } from '../utils/memoize';
 
 /**
@@ -76,16 +70,6 @@ export function createSelector(
  * @ignore
  */
 export function getSelectorFn(selector: any): SelectFromState {
-  const selectorMetadata = getSelectorMetadata(selector);
-  if (selectorMetadata) {
-    const selectFromAppState = selectorMetadata.selectFromAppState;
-    if (selectFromAppState) {
-      return selectFromAppState;
-    }
-  }
-  const stateMetadata = getStoreMetadata(selector);
-  if (stateMetadata && stateMetadata.path) {
-    return fastPropGetter(stateMetadata.path.split('.'));
-  }
-  return selector;
+  const metadata = getSelectorMetadata(selector) || getStoreMetadata(selector);
+  return (metadata && metadata.selectFromAppState) || selector;
 }


### PR DESCRIPTION
Setting the config option of strictContentSecurityPolicy to true will avoid CSP violations

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: #516 #439 


## What is the new behavior?
Add a config setting to allow for a strict Content Security Policy.
There will be a small performance hit to selectors because this circumvents an optimisation.
This should be provided in the ngxs options to the root module as follows:
```TS
NgxsModule.forRoot([
      ZooState
    ], {
      compatibility: {
        strictContentSecurityPolicy: true
      }
    })
```
## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

## Other information
