### PR TITLE
feat(form-plugin): ngxsForm directive takes in an observable that triggers saving

### DIFF
--- a/docs/plugins/form.md
+++ b/docs/plugins/form.md
@@ -103,10 +103,11 @@ export class PizzaComponent {
 
 Now anytime your form updates, your state will also reflect the new state.
 
-The directive also has two inputs you can utilize as well:
+The directive also has three inputs you can utilize as well:
 
 - `ngxsFormDebounce: number` - Debounce the value changes to the form. Default value: `100`.
 - `ngxsFormClearOnDestroy: boolean` - Clear the state on destroy of the form.
+- `ngxsFormStoreOn: Observable<any>` - Disables auto saving and lets you control when to update the store with an observable.
 
 ### Actions
 In addition to it automatically keeping track of the form, you can also

--- a/integration/app/app.component.spec.ts
+++ b/integration/app/app.component.spec.ts
@@ -107,4 +107,17 @@ describe('AppComponent', () => {
     });
     expect(flag).toBe(true);
   });
+
+  it(
+    'should only save when triggered with storeOn',
+    fakeAsync(() => {
+      component.savingForm.patchValue({ toppings: 'cheese' });
+      tick(200);
+      component.saveRequests$.next();
+      component.pizza$.pipe(take(1)).subscribe((pizza: any) => {
+        expect(pizza.model.toppings).toBe('cheese');
+      });
+      discardPeriodicTasks();
+    })
+  );
 });

--- a/integration/app/app.component.spec.ts
+++ b/integration/app/app.component.spec.ts
@@ -108,16 +108,11 @@ describe('AppComponent', () => {
     expect(flag).toBe(true);
   });
 
-  it(
-    'should only save when triggered with storeOn',
-    fakeAsync(() => {
-      component.savingForm.patchValue({ toppings: 'cheese' });
-      tick(200);
-      component.saveRequests$.next();
-      component.pizza$.pipe(take(1)).subscribe((pizza: any) => {
-        expect(pizza.model.toppings).toBe('cheese');
-      });
-      discardPeriodicTasks();
-    })
-  );
+  it('should only save when triggered with storeOn', () => {
+    component.savingForm.patchValue({ toppings: 'cheese' });
+    component.saveRequests$.next();
+    component.pizza$.pipe(take(1)).subscribe((pizza: any) => {
+      expect(pizza.model.toppings).toBe('cheese');
+    });
+  });
 });

--- a/integration/app/app.component.spec.ts
+++ b/integration/app/app.component.spec.ts
@@ -108,11 +108,15 @@ describe('AppComponent', () => {
     expect(flag).toBe(true);
   });
 
-  it('should only save when triggered with storeOn', () => {
-    component.savingForm.patchValue({ toppings: 'cheese' });
-    component.saveRequests$.next();
-    component.pizza$.pipe(take(1)).subscribe((pizza: any) => {
-      expect(pizza.model.toppings).toBe('cheese');
-    });
-  });
+  it(
+    'should only save when triggered with storeOn',
+    fakeAsync(() => {
+      component.savingForm.patchValue({ toppings: 'cheese' });
+      component.saveRequests$.next();
+      component.pizza$.pipe(take(1)).subscribe((pizza: any) => {
+        expect(pizza.model.toppings).toBe('cheese');
+      });
+      discardPeriodicTasks();
+    })
+  );
 });

--- a/integration/app/app.component.ts
+++ b/integration/app/app.component.ts
@@ -1,9 +1,9 @@
 import { Component, ViewEncapsulation } from '@angular/core';
-import { Store, Select } from '@ngxs/store';
-import { Observable } from 'rxjs';
-import { FormBuilder, FormArray } from '@angular/forms';
+import { Select, Store } from '@ngxs/store';
+import { Observable, Subject } from 'rxjs';
+import { FormArray, FormBuilder } from '@angular/forms';
 
-import { AddTodo, RemoveTodo, TodoState, SetPrefix, TodosState, LoadData } from './todo.state';
+import { AddTodo, LoadData, RemoveTodo, SetPrefix, TodosState, TodoState } from './todo.state';
 
 @Component({
   selector: 'app-root',
@@ -12,21 +12,40 @@ import { AddTodo, RemoveTodo, TodoState, SetPrefix, TodosState, LoadData } from 
       <div>
         <h3>Reactive Form</h3>
         <form [formGroup]="pizzaForm" novalidate (ngSubmit)="onSubmit()" ngxsForm="todos.pizza">
-            Toppings: <input type="text" formControlName="toppings" />
-            <br>
-            Crust <input type="text" formControlName="crust" />
-            <br>
-            Extras
-            <span *ngFor='let extra of extras; let i=index'>
+          Toppings: <input type="text" formControlName="toppings"/>
+          <br>
+          Crust <input type="text" formControlName="crust"/>
+          <br>
+          Extras
+          <span *ngFor='let extra of extras; let i=index'>
               <input type='checkbox' [formControl]='extra'/> {{allExtras[i].name}}
             </span>
-            <br><hr>
-            <button type="submit">Set Olives</button>
-            <button type="button" (click)="onPrefix()">Set Prfix</button>
-            <button type="button" (click)="onLoadData()">Load Data</button>
+          <br>
+          <hr>
+          <button type="submit">Set Olives</button>
+          <button type="button" (click)="onPrefix()">Set Prfix</button>
+          <button type="button" (click)="onLoadData()">Load Data</button>
         </form>
       </div>
-      <br><br><hr>
+      <br><br>
+      <div>
+      <h3>Save Form with Button click</h3>
+      <form [formGroup]="savingForm" novalidate (ngSubmit)="saveForm()" ngxsForm="todos.pizza" [ngxsFormStoreOn]="saveRequests$">
+        Toppings: <input type="text" formControlName="toppings"/>
+        <br>
+        Crust <input type="text" formControlName="crust"/>
+        <br>
+        Extras
+        <span *ngFor='let extra of extras; let i=index'>
+              <input type='checkbox' [formControl]='extra'/> {{allExtras[i].name}}
+            </span>
+        <br>
+        <hr>
+        <button type="submit">Save</button>
+      </form>
+    </div>
+      <br><br>
+      <hr>
       <h3>Todo Form</h3>
       <div class="add-todo">
         <input placeholder="New Todo" #text>
@@ -34,7 +53,8 @@ import { AddTodo, RemoveTodo, TodoState, SetPrefix, TodosState, LoadData } from 
       </div>
       <ul>
         <li class="todo" *ngFor="let todo of todos$ | async; let i = index">
-          {{todo}} <button (click)="removeTodo(i)">🗑</button>
+          {{todo}}
+          <button (click)="removeTodo(i)">🗑</button>
         </li>
         <li *ngFor="let todo of pandas$ | async">
           🐼
@@ -47,9 +67,12 @@ import { AddTodo, RemoveTodo, TodoState, SetPrefix, TodosState, LoadData } from 
   encapsulation: ViewEncapsulation.None
 })
 export class AppComponent {
-  @Select(TodoState) todos$: Observable<string[]>;
-  @Select(TodoState.pandas) pandas$: Observable<string[]>;
-  @Select(TodosState.pizza) pizza$: Observable<any>;
+  @Select(TodoState)
+  todos$: Observable<string[]>;
+  @Select(TodoState.pandas)
+  pandas$: Observable<string[]>;
+  @Select(TodosState.pizza)
+  pizza$: Observable<any>;
 
   allExtras = [
     { name: 'cheese', selected: false },
@@ -62,6 +85,14 @@ export class AppComponent {
     crust: [{ value: 'thin', disabled: true }],
     extras: this.createExtras()
   });
+
+  savingForm = this.formBuilder.group({
+    toppings: [''],
+    crust: [{ value: 'thin', disabled: true }],
+    extras: this.createExtras()
+  });
+
+  saveRequests$ = new Subject<void>();
 
   constructor(private store: Store, private formBuilder: FormBuilder) {}
 
@@ -91,6 +122,10 @@ export class AppComponent {
     this.pizzaForm.patchValue({
       toppings: 'olives'
     });
+  }
+
+  saveForm() {
+    this.saveRequests$.next();
   }
 
   onPrefix() {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added
- [x] Docs have been added / updated

(I'm unsure how to write a test for this feature and would appreciate some help.)

## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When using the form directive all input values will automatically be stored.

## What is the new behavior?

This PR introduces the option to control this behaviour with an observable, to allow saving via button clicks or similar events. With this implementation it replaces the auto-saving behaviour.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

Here's an example for how this can be used (based on the integration app)

#### app.component.ts (relevant parts)

```typescript
@Component({
  selector: 'app-root',
  template: `
        <form [formGroup]="pizzaForm" novalidate (ngSubmit)="onSubmit()" ngxsForm="todos.pizza" [ngxsFormStoreOn]="saveRequests$">
  `
})
export class AppComponent {
  saveRequests$ = new Subject<void>();

  onSubmit() {
    this.saveRequests$.next();
  }
}
```