### PR TITLE
Update peer Dependencies in order for Angular 7 to be in range

### DIFF
--- a/packages/devtools-plugin/package.json
+++ b/packages/devtools-plugin/package.json
@@ -5,7 +5,7 @@
   "sideEffects": true,
   "peerDependencies": {
     "@ngxs/store": "^0.0.0",
-    "@angular/core": ">=5.0.0 <7.0.0",
+    "@angular/core": ">=5.0.0 <8.0.0",
     "rxjs": ">=6.0.0 || ^5.6.0-forward-compat.4"
   }
 }

--- a/packages/form-plugin/package.json
+++ b/packages/form-plugin/package.json
@@ -5,8 +5,8 @@
   "sideEffects": true,
   "peerDependencies": {
     "@ngxs/store": "^0.0.0",
-    "@angular/core": ">=5.0.0 <7.0.0",
-    "@angular/forms": ">=5.0.0 <7.0.0",
+    "@angular/core": ">=5.0.0 <8.0.0",
+    "@angular/forms": ">=5.0.0 <8.0.0",
     "rxjs": ">=6.0.0 || ^5.6.0-forward-compat.4"
   }
 }

--- a/packages/logger-plugin/package.json
+++ b/packages/logger-plugin/package.json
@@ -5,7 +5,7 @@
   "sideEffects": true,
   "peerDependencies": {
     "@ngxs/store": "^0.0.0",
-    "@angular/core": ">=5.0.0 <7.0.0",
+    "@angular/core": ">=5.0.0 <8.0.0",
     "rxjs": ">=6.0.0 || ^5.6.0-forward-compat.4"
   }
 }

--- a/packages/router-plugin/package.json
+++ b/packages/router-plugin/package.json
@@ -5,8 +5,8 @@
   "sideEffects": true,
   "peerDependencies": {
     "@ngxs/store": "^0.0.0",
-    "@angular/core": ">=5.0.0 <7.0.0",
-    "@angular/router": ">=5.0.0 <7.0.0",
+    "@angular/core": ">=5.0.0 <8.0.0",
+    "@angular/router": ">=5.0.0 <8.0.0",
     "rxjs": ">=6.0.0 || ^5.6.0-forward-compat.4"
   }
 }

--- a/packages/storage-plugin/package.json
+++ b/packages/storage-plugin/package.json
@@ -5,7 +5,7 @@
   "sideEffects": true,
   "peerDependencies": {
     "@ngxs/store": "^0.0.0",
-    "@angular/core": ">=5.0.0 <7.0.0",
+    "@angular/core": ">=5.0.0 <8.0.0",
     "rxjs": ">=6.0.0 || ^5.6.0-forward-compat.4"
   }
 }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "sideEffects": true,
   "peerDependencies": {
-    "@angular/core": ">=5.0.0 <7.0.0",
+    "@angular/core": ">=5.0.0 <8.0.0",
     "rxjs": ">=6.0.0 || ^5.6.0-forward-compat.4"
   }
 }

--- a/packages/websocket-plugin/package.json
+++ b/packages/websocket-plugin/package.json
@@ -5,7 +5,7 @@
   "sideEffects": true,
   "peerDependencies": {
     "@ngxs/store": "^0.0.0",
-    "@angular/core": ">=5.0.0 <7.0.0",
+    "@angular/core": ">=5.0.0 <8.0.0",
     "rxjs": ">=6.0.0 || ^5.6.0-forward-compat.4"
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: Update Peer Dependencies
```

## What is the current behavior?
Currently when installed with Angular 7 npm produces warnings, for example:
```bash
npm WARN @ngxs/devtools-plugin@3.2.0 requires a peer of @angular/core@>=5.0.0 <7.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN @ngxs/logger-plugin@3.2.0 requires a peer of @angular/core@>=5.0.0 <7.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN @ngxs/router-plugin@3.2.0 requires a peer of @angular/core@>=5.0.0 <7.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN @ngxs/router-plugin@3.2.0 requires a peer of @angular/router@>=5.0.0 <7.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN @ngxs/storage-plugin@3.2.0 requires a peer of @angular/core@>=5.0.0 <7.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN @ngxs/store@3.2.0 requires a peer of @angular/core@>=5.0.0 <7.0.0 but none is installed. You must install peer dependencies yourself.
```
I did not encounter any problems when using the current version (3.2.0) with Angular 7. 
**Attention**: Only tested with `@ngxs/devtools-plugin`, `@ngxs/logger-plugin`, `@ngxs/router-plugin`, `@ngxs/storage-plugin` and `@ngxs/store`. 
I did **not** test it with `@ngxs/form-plugin` and `@ngxs/websocket-plugin` so it would be good if somebody could leave some feedback regarding those packages.

Issue Number: #609 


## What is the new behavior?
No warnings when installed with Angular 7.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
