### PR TITLE
fix(storage-plugin): lazy loaded slices not initialized

### DIFF
--- a/packages/storage-plugin/src/storage.plugin.ts
+++ b/packages/storage-plugin/src/storage.plugin.ts
@@ -45,7 +45,7 @@ export class NgxsStoragePlugin implements NgxsPlugin {
           if (!isMaster) {
             state = setValue(state, key, val);
           } else {
-            state = Object.assign(state, val);
+            state = { ...state, ...val };
           }
         }
       }

--- a/packages/storage-plugin/src/storage.plugin.ts
+++ b/packages/storage-plugin/src/storage.plugin.ts
@@ -45,7 +45,7 @@ export class NgxsStoragePlugin implements NgxsPlugin {
           if (!isMaster) {
             state = setValue(state, key, val);
           } else {
-            state = val;
+            state = Object.assign(state, val);
           }
         }
       }

--- a/packages/storage-plugin/tests/storage.plugin.spec.ts
+++ b/packages/storage-plugin/tests/storage.plugin.spec.ts
@@ -37,6 +37,12 @@ describe('NgxsStoragePlugin', () => {
     }
   }
 
+  @State<StateModel>({
+    name: 'lazyLoaded',
+    defaults: { count: 0 }
+  })
+  class LazyLoadedStore {}
+
   afterEach(() => {
     localStorage.removeItem('@@STATE');
     sessionStorage.removeItem('@@STATE');
@@ -257,6 +263,24 @@ describe('NgxsStoragePlugin', () => {
       expect(state.count).toBe(105);
 
       expect(CustomStorage.Storage['@@STATE']).toEqual({ counter: { count: 105 } });
+    });
+  });
+
+  it('should merge unloaded data from feature with local storage', () => {
+    localStorage.setItem('@@STATE', JSON.stringify({ counter: { count: 100 } }));
+
+    TestBed.configureTestingModule({
+      imports: [
+        NgxsModule.forRoot([MyStore]),
+        NgxsStoragePluginModule.forRoot(),
+        NgxsModule.forFeature([LazyLoadedStore])
+      ]
+    });
+
+    const store = TestBed.get(Store);
+
+    store.select(state => state).subscribe((state: { counter: StateModel; lazyLoaded: StateModel }) => {
+      expect(state.lazyLoaded).toBeDefined();
     });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
When there is nothing in the store and you are using NgxsPluginModule.forFeature, additional slices that should be initialized in @@UpdateState by the feature are overwritten by the slices in the global state that were saved to storage on the first pass of @@InitState

Issue Number: N/A


## What is the new behavior?
Any slices from a feature that are undefined in the current state are added with their initial value.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
