### PR TITLE
breaking(store): set new default developmentMode

### DIFF
--- a/packages/store/src/symbols.ts
+++ b/packages/store/src/symbols.ts
@@ -17,7 +17,7 @@ export class NgxsConfig {
   /**
    * Run in development mode. This will add additional debugging features:
    * - Object.freeze on the state and actions to guarantee immutability
-   * (default: false)
+   * (default: true)
    */
   developmentMode: boolean;
   compatibility: {
@@ -30,6 +30,7 @@ export class NgxsConfig {
   };
 
   constructor() {
+    this.developmentMode = true;
     this.compatibility = {
       strictContentSecurityPolicy: false
     };


### PR DESCRIPTION
Many do not know about this property and mutate their states.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

https://github.com/ngxs/store/issues/622


## What is the new behavior?

Many do not know about this property and mutate their states.


## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```
