### PR TITLE
fix(store): avoid eval when strictContentSecurityPolicy compatibility

### DIFF
--- a/packages/store/src/decorators/select.ts
+++ b/packages/store/src/decorators/select.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
 
 import { Store } from '../store';
-import { fastPropGetter } from '../internal/internals';
-import { META_KEY } from '../symbols';
+import { propGetter } from '../internal/internals';
+import { META_KEY, NgxsConfig } from '../symbols';
 
 /**
  * Allows the select decorator to get access to the DI store.
@@ -11,8 +11,10 @@ import { META_KEY } from '../symbols';
 @Injectable()
 export class SelectFactory {
   static store: Store | undefined = undefined;
-  constructor(store: Store) {
+  static config: NgxsConfig | undefined = undefined;
+  constructor(store: Store, config: NgxsConfig) {
     SelectFactory.store = store;
+    SelectFactory.config = config;
   }
 }
 
@@ -39,12 +41,13 @@ export function Select(selectorOrFeature?, ...paths: string[]) {
     };
 
     const createSelector = () => {
+      const config = SelectFactory.config;
       if (typeof selectorOrFeature === 'string') {
         const propsArray = paths.length ? [selectorOrFeature, ...paths] : selectorOrFeature.split('.');
 
-        return fastPropGetter(propsArray);
+        return propGetter(propsArray, config);
       } else if (selectorOrFeature[META_KEY] && selectorOrFeature[META_KEY].path) {
-        return fastPropGetter(selectorOrFeature[META_KEY].path.split('.'));
+        return propGetter(selectorOrFeature[META_KEY].path.split('.'), config);
       } else {
         return selectorOrFeature;
       }

--- a/packages/store/src/internal/internals.ts
+++ b/packages/store/src/internal/internals.ts
@@ -1,4 +1,4 @@
-import { META_KEY, ActionOptions, SELECTOR_META_KEY } from '../symbols';
+import { META_KEY, ActionOptions, SELECTOR_META_KEY, NgxsConfig } from '../symbols';
 import { Observable } from 'rxjs';
 
 export interface ObjectKeyMap<T> {
@@ -120,7 +120,7 @@ export function getSelectorMetadata(target): SelectorMetaDataModel {
  *
  * @ignore
  */
-export function compliantPropGetter(paths: string[]): (x: any) => any {
+function compliantPropGetter(paths: string[]): (x: any) => any {
   const copyOfPaths = [...paths];
   return obj => copyOfPaths.reduce((acc: any, part: string) => acc && acc[part], obj);
 }
@@ -132,7 +132,7 @@ export function compliantPropGetter(paths: string[]): (x: any) => any {
  *
  * @ignore
  */
-export function fastPropGetter(paths: string[]): (x: any) => any {
+function fastPropGetter(paths: string[]): (x: any) => any {
   const segments = paths;
   let seg = 'store.' + segments[0];
   let i = 0;
@@ -146,6 +146,21 @@ export function fastPropGetter(paths: string[]): (x: any) => any {
   const fn = new Function('store', 'return ' + expr + ';');
 
   return <(x: any) => any>fn;
+}
+
+/**
+ * Get a deeply nested value. Example:
+ *
+ *    getValue({ foo: bar: [] }, 'foo.bar') //=> []
+ *
+ * @ignore
+ */
+export function propGetter(paths: string[], config: NgxsConfig) {
+  if (config && config.compatibility && config.compatibility.strictContentSecurityPolicy) {
+    return compliantPropGetter(paths);
+  } else {
+    return fastPropGetter(paths);
+  }
 }
 
 /**

--- a/packages/store/src/internal/state-factory.ts
+++ b/packages/store/src/internal/state-factory.ts
@@ -8,8 +8,7 @@ import {
   buildGraph,
   findFullParentPath,
   nameToState,
-  compliantPropGetter,
-  fastPropGetter,
+  propGetter,
   isObject,
   StateClass,
   MappedStore
@@ -73,12 +72,7 @@ export class StateFactory {
       let { defaults } = stateClass[META_KEY];
 
       stateClass[META_KEY].path = depth;
-
-      if (this._config && this._config.compatibility && this._config.compatibility.strictContentSecurityPolicy) {
-        stateClass[META_KEY].selectFromAppState = compliantPropGetter(depth.split('.'));
-      } else {
-        stateClass[META_KEY].selectFromAppState = fastPropGetter(depth.split('.'));
-      }
+      stateClass[META_KEY].selectFromAppState = propGetter(depth.split('.'), this._config);
 
       // ensure our store hasn't already been added
       // but dont throw since it could be lazy


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #516 


## What is the new behavior?
All places that use `new Function('...')` now respect the `strictContentSecurityPolicy` compatibility setting.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
