### PR TITLE
fix(form-plugin): fix form-plugin to accept form arrays

### DIFF
--- a/packages/form-plugin/src/form.plugin.ts
+++ b/packages/form-plugin/src/form.plugin.ts
@@ -22,9 +22,9 @@ export class NgxsFormPlugin implements NgxsPlugin {
     let nextState = state;
 
     if (type === UpdateFormValue.type || type === UpdateForm.type) {
-      nextState = setValue(nextState, `${event.payload.path}.model`, {
-        ...event.payload.value
-      });
+      const payloadValue = Array.isArray(event.payload.value) ? [...event.payload.value] : { ...event.payload.value };
+
+      nextState = setValue(nextState, `${event.payload.path}.model`, payloadValue);
     }
 
     if (type === UpdateFormStatus.type || type === UpdateForm.type) {

--- a/packages/form-plugin/src/form.plugin.ts
+++ b/packages/form-plugin/src/form.plugin.ts
@@ -22,7 +22,8 @@ export class NgxsFormPlugin implements NgxsPlugin {
     let nextState = state;
 
     if (type === UpdateFormValue.type || type === UpdateForm.type) {
-      const payloadValue = Array.isArray(event.payload.value) ? [...event.payload.value] : { ...event.payload.value };
+      const { value } = event.payload;
+      const payloadValue = Array.isArray(value) ? [...value] : { ...value };
 
       nextState = setValue(nextState, `${event.payload.path}.model`, payloadValue);
     }

--- a/packages/form-plugin/tests/form.plugin.spec.ts
+++ b/packages/form-plugin/tests/form.plugin.spec.ts
@@ -46,11 +46,9 @@ describe('NgxsFormPlugin', () => {
     const store = TestBed.get(Store);
     store.dispatch(new SetFormDirty('actions.studentForm'));
 
-    store
-      .select(state => state.actions.studentForm)
-      .subscribe((form: Form) => {
-        expect(form.dirty).toBe(true);
-      });
+    store.select(state => state.actions.studentForm).subscribe((form: Form) => {
+      expect(form.dirty).toBe(true);
+    });
   });
 
   it('should set form pristine', () => {
@@ -59,22 +57,18 @@ describe('NgxsFormPlugin', () => {
     store.dispatch(new SetFormDirty('actions.studentForm'));
     store.dispatch(new SetFormPristine('actions.studentForm'));
 
-    store
-      .select(state => state.actions.studentForm)
-      .subscribe((form: Form) => {
-        expect(form.dirty).toBe(false);
-      });
+    store.select(state => state.actions.studentForm).subscribe((form: Form) => {
+      expect(form.dirty).toBe(false);
+    });
   });
 
   it('should set form disabled', () => {
     const store = TestBed.get(Store);
     store.dispatch(new SetFormDisabled('actions.studentForm'));
 
-    store
-      .select(state => state.actions.studentForm)
-      .subscribe((form: Form) => {
-        expect(form.disabled).toBe(true);
-      });
+    store.select(state => state.actions.studentForm).subscribe((form: Form) => {
+      expect(form.disabled).toBe(true);
+    });
   });
 
   it('should set form enabled', () => {
@@ -83,33 +77,27 @@ describe('NgxsFormPlugin', () => {
     store.dispatch(new SetFormDisabled('actions.studentForm'));
     store.dispatch(new SetFormEnabled('actions.studentForm'));
 
-    store
-      .select(state => state.actions.studentForm)
-      .subscribe((form: Form) => {
-        expect(form.disabled).toBe(false);
-      });
+    store.select(state => state.actions.studentForm).subscribe((form: Form) => {
+      expect(form.disabled).toBe(false);
+    });
   });
 
   it('should update form dirty', () => {
     const store = TestBed.get(Store);
     store.dispatch(new UpdateFormDirty({ path: 'actions.studentForm', dirty: true }));
 
-    store
-      .select(state => state.actions.studentForm)
-      .subscribe((form: Form) => {
-        expect(form.dirty).toBe(true);
-      });
+    store.select(state => state.actions.studentForm).subscribe((form: Form) => {
+      expect(form.dirty).toBe(true);
+    });
   });
 
   it('should update form status', () => {
     const store = TestBed.get(Store);
     store.dispatch(new UpdateFormStatus({ path: 'actions.studentForm', status: 'VALID' }));
 
-    store
-      .select(state => state.actions.studentForm)
-      .subscribe((form: Form) => {
-        expect(form.status).toBe('VALID');
-      });
+    store.select(state => state.actions.studentForm).subscribe((form: Form) => {
+      expect(form.status).toBe('VALID');
+    });
   });
 
   it('should update form errors', () => {
@@ -121,12 +109,10 @@ describe('NgxsFormPlugin', () => {
       })
     );
 
-    store
-      .select(state => state.actions.studentForm)
-      .subscribe((form: Form) => {
-        expect(form.errors.name).toBe('empty not allowed');
-        expect(form.errors.address).toBe('address is too long');
-      });
+    store.select(state => state.actions.studentForm).subscribe((form: Form) => {
+      expect(form.errors.name).toBe('empty not allowed');
+      expect(form.errors.address).toBe('address is too long');
+    });
   });
 
   it('should update form value', () => {
@@ -138,12 +124,25 @@ describe('NgxsFormPlugin', () => {
       })
     );
 
-    store
-      .select(state => state.actions.studentForm)
-      .subscribe((form: Form) => {
-        expect(form.model.name).toBe('Lou Grant');
-        expect(form.model.address).toBe('waterloo, ontario');
-      });
+    store.select(state => state.actions.studentForm).subscribe((form: Form) => {
+      expect(form.model.name).toBe('Lou Grant');
+      expect(form.model.address).toBe('waterloo, ontario');
+    });
+  });
+
+  it('should update form array value', () => {
+    const store = TestBed.get(Store);
+    store.dispatch(
+      new UpdateFormValue({
+        value: ['waterloo, ontario', 'Lou Grant'],
+        path: 'actions.studentForm'
+      })
+    );
+
+    store.select(state => state.actions.studentForm).subscribe((form: Form) => {
+      expect(Array.isArray(form.model)).toBeTruthy();
+      expect(form.model).toEqual(['waterloo, ontario', 'Lou Grant']);
+    });
   });
 
   it('should update form', () => {
@@ -158,15 +157,13 @@ describe('NgxsFormPlugin', () => {
       })
     );
 
-    store
-      .select(state => state.actions.studentForm)
-      .subscribe((form: Form) => {
-        expect(form.status).toBe('INVALID');
-        expect(form.dirty).toBe(true);
-        expect(form.errors.name).toBe('empty not allowed');
-        expect(form.errors.address).toBe('address is too long');
-        expect(form.model.name).toBe('Lou Grant');
-        expect(form.model.address).toBe('waterloo, ontario');
-      });
+    store.select(state => state.actions.studentForm).subscribe((form: Form) => {
+      expect(form.status).toBe('INVALID');
+      expect(form.dirty).toBe(true);
+      expect(form.errors.name).toBe('empty not allowed');
+      expect(form.errors.address).toBe('address is too long');
+      expect(form.model.name).toBe('Lou Grant');
+      expect(form.model.address).toBe('waterloo, ontario');
+    });
   });
 });

--- a/packages/form-plugin/tests/form.plugin.spec.ts
+++ b/packages/form-plugin/tests/form.plugin.spec.ts
@@ -49,8 +49,8 @@ describe('NgxsFormPlugin', () => {
     store
       .select(state => state.actions.studentForm)
       .subscribe((form: Form) => {
-      expect(form.dirty).toBe(true);
-    });
+        expect(form.dirty).toBe(true);
+      });
   });
 
   it('should set form pristine', () => {
@@ -63,7 +63,7 @@ describe('NgxsFormPlugin', () => {
       .select(state => state.actions.studentForm)
       .subscribe((form: Form) => {
         expect(form.dirty).toBe(false);
-    });
+      });
   });
 
   it('should set form disabled', () => {
@@ -74,7 +74,7 @@ describe('NgxsFormPlugin', () => {
       .select(state => state.actions.studentForm)
       .subscribe((form: Form) => {
         expect(form.disabled).toBe(true);
-    });
+      });
   });
 
   it('should set form enabled', () => {
@@ -87,7 +87,7 @@ describe('NgxsFormPlugin', () => {
       .select(state => state.actions.studentForm)
       .subscribe((form: Form) => {
         expect(form.disabled).toBe(false);
-    });
+      });
   });
 
   it('should update form dirty', () => {
@@ -98,7 +98,7 @@ describe('NgxsFormPlugin', () => {
       .select(state => state.actions.studentForm)
       .subscribe((form: Form) => {
         expect(form.dirty).toBe(true);
-    });
+      });
   });
 
   it('should update form status', () => {
@@ -109,7 +109,7 @@ describe('NgxsFormPlugin', () => {
       .select(state => state.actions.studentForm)
       .subscribe((form: Form) => {
         expect(form.status).toBe('VALID');
-    });
+      });
   });
 
   it('should update form errors', () => {
@@ -126,7 +126,7 @@ describe('NgxsFormPlugin', () => {
       .subscribe((form: Form) => {
         expect(form.errors.name).toBe('empty not allowed');
         expect(form.errors.address).toBe('address is too long');
-    });
+      });
   });
 
   it('should update form value', () => {
@@ -143,7 +143,7 @@ describe('NgxsFormPlugin', () => {
       .subscribe((form: Form) => {
         expect(form.model.name).toBe('Lou Grant');
         expect(form.model.address).toBe('waterloo, ontario');
-    });
+      });
   });
 
   it('should update form array value', () => {
@@ -160,7 +160,7 @@ describe('NgxsFormPlugin', () => {
       .subscribe((form: Form) => {
         expect(Array.isArray(form.model)).toBeTruthy();
         expect(form.model).toEqual(['waterloo, ontario', 'Lou Grant']);
-    });
+      });
   });
 
   it('should update form', () => {
@@ -184,6 +184,6 @@ describe('NgxsFormPlugin', () => {
         expect(form.errors.address).toBe('address is too long');
         expect(form.model.name).toBe('Lou Grant');
         expect(form.model.address).toBe('waterloo, ontario');
-    });
+      });
   });
 });

--- a/packages/form-plugin/tests/form.plugin.spec.ts
+++ b/packages/form-plugin/tests/form.plugin.spec.ts
@@ -46,7 +46,9 @@ describe('NgxsFormPlugin', () => {
     const store = TestBed.get(Store);
     store.dispatch(new SetFormDirty('actions.studentForm'));
 
-    store.select(state => state.actions.studentForm).subscribe((form: Form) => {
+    store
+      .select(state => state.actions.studentForm)
+      .subscribe((form: Form) => {
       expect(form.dirty).toBe(true);
     });
   });
@@ -57,8 +59,10 @@ describe('NgxsFormPlugin', () => {
     store.dispatch(new SetFormDirty('actions.studentForm'));
     store.dispatch(new SetFormPristine('actions.studentForm'));
 
-    store.select(state => state.actions.studentForm).subscribe((form: Form) => {
-      expect(form.dirty).toBe(false);
+    store
+      .select(state => state.actions.studentForm)
+      .subscribe((form: Form) => {
+        expect(form.dirty).toBe(false);
     });
   });
 
@@ -66,8 +70,10 @@ describe('NgxsFormPlugin', () => {
     const store = TestBed.get(Store);
     store.dispatch(new SetFormDisabled('actions.studentForm'));
 
-    store.select(state => state.actions.studentForm).subscribe((form: Form) => {
-      expect(form.disabled).toBe(true);
+    store
+      .select(state => state.actions.studentForm)
+      .subscribe((form: Form) => {
+        expect(form.disabled).toBe(true);
     });
   });
 
@@ -77,8 +83,10 @@ describe('NgxsFormPlugin', () => {
     store.dispatch(new SetFormDisabled('actions.studentForm'));
     store.dispatch(new SetFormEnabled('actions.studentForm'));
 
-    store.select(state => state.actions.studentForm).subscribe((form: Form) => {
-      expect(form.disabled).toBe(false);
+    store
+      .select(state => state.actions.studentForm)
+      .subscribe((form: Form) => {
+        expect(form.disabled).toBe(false);
     });
   });
 
@@ -86,8 +94,10 @@ describe('NgxsFormPlugin', () => {
     const store = TestBed.get(Store);
     store.dispatch(new UpdateFormDirty({ path: 'actions.studentForm', dirty: true }));
 
-    store.select(state => state.actions.studentForm).subscribe((form: Form) => {
-      expect(form.dirty).toBe(true);
+    store
+      .select(state => state.actions.studentForm)
+      .subscribe((form: Form) => {
+        expect(form.dirty).toBe(true);
     });
   });
 
@@ -95,8 +105,10 @@ describe('NgxsFormPlugin', () => {
     const store = TestBed.get(Store);
     store.dispatch(new UpdateFormStatus({ path: 'actions.studentForm', status: 'VALID' }));
 
-    store.select(state => state.actions.studentForm).subscribe((form: Form) => {
-      expect(form.status).toBe('VALID');
+    store
+      .select(state => state.actions.studentForm)
+      .subscribe((form: Form) => {
+        expect(form.status).toBe('VALID');
     });
   });
 
@@ -109,9 +121,11 @@ describe('NgxsFormPlugin', () => {
       })
     );
 
-    store.select(state => state.actions.studentForm).subscribe((form: Form) => {
-      expect(form.errors.name).toBe('empty not allowed');
-      expect(form.errors.address).toBe('address is too long');
+    store
+      .select(state => state.actions.studentForm)
+      .subscribe((form: Form) => {
+        expect(form.errors.name).toBe('empty not allowed');
+        expect(form.errors.address).toBe('address is too long');
     });
   });
 
@@ -124,9 +138,11 @@ describe('NgxsFormPlugin', () => {
       })
     );
 
-    store.select(state => state.actions.studentForm).subscribe((form: Form) => {
-      expect(form.model.name).toBe('Lou Grant');
-      expect(form.model.address).toBe('waterloo, ontario');
+    store
+      .select(state => state.actions.studentForm)
+      .subscribe((form: Form) => {
+        expect(form.model.name).toBe('Lou Grant');
+        expect(form.model.address).toBe('waterloo, ontario');
     });
   });
 
@@ -139,9 +155,11 @@ describe('NgxsFormPlugin', () => {
       })
     );
 
-    store.select(state => state.actions.studentForm).subscribe((form: Form) => {
-      expect(Array.isArray(form.model)).toBeTruthy();
-      expect(form.model).toEqual(['waterloo, ontario', 'Lou Grant']);
+    store
+      .select(state => state.actions.studentForm)
+      .subscribe((form: Form) => {
+        expect(Array.isArray(form.model)).toBeTruthy();
+        expect(form.model).toEqual(['waterloo, ontario', 'Lou Grant']);
     });
   });
 
@@ -157,13 +175,15 @@ describe('NgxsFormPlugin', () => {
       })
     );
 
-    store.select(state => state.actions.studentForm).subscribe((form: Form) => {
-      expect(form.status).toBe('INVALID');
-      expect(form.dirty).toBe(true);
-      expect(form.errors.name).toBe('empty not allowed');
-      expect(form.errors.address).toBe('address is too long');
-      expect(form.model.name).toBe('Lou Grant');
-      expect(form.model.address).toBe('waterloo, ontario');
+    store
+      .select(state => state.actions.studentForm)
+      .subscribe((form: Form) => {
+        expect(form.status).toBe('INVALID');
+        expect(form.dirty).toBe(true);
+        expect(form.errors.name).toBe('empty not allowed');
+        expect(form.errors.address).toBe('address is too long');
+        expect(form.model.name).toBe('Lou Grant');
+        expect(form.model.address).toBe('waterloo, ontario');
     });
   });
 });


### PR DESCRIPTION
add check in form.plugin.ts to check if payload value is an array and process it accordingly 

no breaking change

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #655 


## What is the new behavior?
It will now accept forms that are form array
Example:
```
this.form = this.fb.array([
      this.fb.control(null),
      this.fb.control(null)
   ]);
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
