### PR TITLE
fix(store): included underscore in stateNameRegex

### DIFF
--- a/packages/store/src/decorators/state.ts
+++ b/packages/store/src/decorators/state.ts
@@ -1,7 +1,7 @@
 import { ensureStoreMetadata } from '../internal/internals';
 import { StoreOptions, META_KEY } from '../symbols';
 
-const stateNameRegex = new RegExp('^[a-zA-Z0-9]+$');
+const stateNameRegex = new RegExp('^[a-zA-Z0-9_]+$');
 
 /**
  * Error message

--- a/packages/store/tests/store.spec.ts
+++ b/packages/store/tests/store.spec.ts
@@ -14,7 +14,7 @@ describe('Store', () => {
   interface SubStateModel {
     hello: boolean;
     world: boolean;
-    baz?: SubSubStateModel;
+    baz_?: SubSubStateModel;
   }
 
   interface StateModel {
@@ -28,7 +28,7 @@ describe('Store', () => {
   }
 
   @State<SubSubStateModel>({
-    name: 'baz',
+    name: 'baz_',
     defaults: {
       name: 'Danny'
     }
@@ -84,7 +84,7 @@ describe('Store', () => {
           bar: {
             hello: true,
             world: true,
-            baz: {
+            baz_: {
               name: 'Danny'
             }
           }
@@ -109,7 +109,7 @@ describe('Store', () => {
         bar: {
           hello: true,
           world: true,
-          baz: {
+          baz_: {
             name: 'Danny'
           }
         }
@@ -122,7 +122,7 @@ describe('Store', () => {
       expect(state).toEqual({
         hello: true,
         world: true,
-        baz: {
+        baz_: {
           name: 'Danny'
         }
       });
@@ -145,7 +145,7 @@ describe('Store', () => {
       bar: {
         hello: true,
         world: true,
-        baz: {
+        baz_: {
           name: 'Danny'
         }
       }

--- a/packages/store/tests/store.spec.ts
+++ b/packages/store/tests/store.spec.ts
@@ -14,7 +14,7 @@ describe('Store', () => {
   interface SubStateModel {
     hello: boolean;
     world: boolean;
-    baz_?: SubSubStateModel;
+    baz?: SubSubStateModel;
   }
 
   interface StateModel {
@@ -23,12 +23,16 @@ describe('Store', () => {
     bar?: SubStateModel;
   }
 
+  interface OtherStateModel {
+    under: string;
+  }
+
   class FooIt {
     static type = 'FooIt';
   }
 
   @State<SubSubStateModel>({
-    name: 'baz_',
+    name: 'baz',
     defaults: {
       name: 'Danny'
     }
@@ -65,11 +69,19 @@ describe('Store', () => {
     }
   }
 
+  @State<OtherStateModel>({
+    name: 'under_',
+    defaults: {
+      under: 'score'
+    }
+  })
+  class MyOtherState {}
+
   let store: Store;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [NgxsModule.forRoot([MySubState, MySubSubState, MyState])]
+      imports: [NgxsModule.forRoot([MySubState, MySubSubState, MyState, MyOtherState])]
     });
 
     store = TestBed.get(Store);
@@ -84,10 +96,13 @@ describe('Store', () => {
           bar: {
             hello: true,
             world: true,
-            baz_: {
+            baz: {
               name: 'Danny'
             }
           }
+        },
+        under_: {
+          under: 'score'
         }
       });
     });
@@ -109,7 +124,7 @@ describe('Store', () => {
         bar: {
           hello: true,
           world: true,
-          baz_: {
+          baz: {
             name: 'Danny'
           }
         }
@@ -122,7 +137,7 @@ describe('Store', () => {
       expect(state).toEqual({
         hello: true,
         world: true,
-        baz_: {
+        baz: {
           name: 'Danny'
         }
       });
@@ -145,10 +160,17 @@ describe('Store', () => {
       bar: {
         hello: true,
         world: true,
-        baz_: {
+        baz: {
           name: 'Danny'
         }
       }
+    });
+  }));
+
+  it('should select state with an underscore in name', async(() => {
+    const state = store.selectSnapshot(MyOtherState);
+    expect(state).toEqual({
+      under: 'score'
     });
   }));
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

underscores in state name return an error saying the state name isn't valid because it is not a 'valid object property name'

## What is the new behavior?
underscores are allowed in state name


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
