### PR TITLE
fix(store): improve type signatures of store select methods

### DIFF
--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -8,6 +8,10 @@ import { InternalStateOperations } from './internal/state-operations';
 import { StateStream } from './internal/state-stream';
 import { enterZone } from './operators/zone';
 
+export interface StateClass {
+  new (...args: any[]): any;
+}
+
 @Injectable()
 export class Store {
   constructor(
@@ -27,7 +31,7 @@ export class Store {
    * Selects a slice of data from the store.
    */
   select<T>(selector: (state: any, ...states: any[]) => T): Observable<T>;
-  select(selector: string | any): Observable<any>;
+  select(selector: StateClass): Observable<any>;
   select(selector: any): Observable<any> {
     const selectorFn = getSelectorFn(selector);
     return this._stateStream.pipe(
@@ -49,8 +53,9 @@ export class Store {
   /**
    * Select one slice of data from the store.
    */
+
   selectOnce<T>(selector: (state: any, ...states: any[]) => T): Observable<T>;
-  selectOnce(selector: string | any): Observable<any>;
+  selectOnce(selector: StateClass): Observable<any>;
   selectOnce(selector: any): Observable<any> {
     return this.select(selector).pipe(take(1));
   }
@@ -59,8 +64,8 @@ export class Store {
    * Select a snapshot from the state.
    */
   selectSnapshot<T>(selector: (state: any, ...states: any[]) => T): T;
-  selectSnapshot(selector: string | any): any;
-  selectSnapshot(selector: any): any {
+  selectSnapshot(selector: StateClass): any;
+  selectSnapshot(selector: any): Observable<any> {
     const selectorFn = getSelectorFn(selector);
     return selectorFn(this._stateStream.getValue());
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Issue Number: N/A

Calling store.select(MyState.someSelector) is not correctly inferring the type of the result observable. In particular, it was not working with strict null checks, and allowing an `Observable<T|undefined>` to be assigned to `Observable<T>`. 

See here for some example code: https://stackblitz.com/edit/angular-mdukge


## What is the new behavior?
- remove overload taking string or any and returning Observable<any>
- add overload taking a class definition and returning Obervable<any>

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
[x] Maybe
```

As far as I could tell it was not actually valid to pass a string to the function, which is why I removed it as a valid type to pass. 

Arguably this is a breaking change, but if I'm correct that this wasn't valid to begin with, I would expect it to be ok to go in a patch release (note that the javascript output has not been altered in anyway).

Possibly more concerning is that I've narrowed the accepted type to a function taking a state, or a class. Previously `any` was accepted. This hasn't appeared to be an issue running the test suite, but I don't know the library well enough to be sure that this won't cause issues.

## Other Information
I haven't re-generated the API docs, as when I did this locally it caused a lot of change, and in particular made the docs reference my fork - I'm assuming this is managed on the main repository as a result.

I haven't added any tests, as I don't know of a clean way to test that a particular piece of code will cause a build error. I have tested the fix with a project based off the above stackbliz (note that strict / strictNullChecks should be enabled to see the issue)