### PR TITLE
docs: Minor Spelling and Grammar Changes

### DIFF
--- a/docs/concepts/actions.md
+++ b/docs/concepts/actions.md
@@ -53,11 +53,11 @@ Examples:
 * `[Dashboard Page] ArchiveProject`
 
 ### Event examples
-Events are actions that have already happended and we now need to react to them.
+Events are actions that have already happened and we now need to react to them.
 
-The same naming conventions apply as to command, but they should always be in past tense.
+The same naming conventions apply as commands, but they should always be in past tense.
 
-By using `API` in the context part we know that this event was fired because of a async action to an API.
+By using `API` in the context part of the action name we know that this event was fired because of an async action to an API.
 
 Actions are normally dispatched from container components such as router pages.
 By having explicit actions for each page, it's also easier to track where an event came from.

--- a/docs/concepts/state.md
+++ b/docs/concepts/state.md
@@ -20,7 +20,7 @@ In the state decorator, we define some metadata about the state. These options
 include:
 
 - `name`: The name of the state slice. Note: The name is a required parameter and must be unique for the entire application.
-Names must be object property safe, AKA no dashes, dots, etc.
+Names must be object property safe, (e.g. no dashes, dots, etc).
 - `defaults`: Default set of object/array for this state slice.
 - `children`: Child sub state associations.
 
@@ -40,7 +40,7 @@ export class ZooState {
 ```
 
 ## Defining Actions
-Our states listen to actions via a `@Action` decorator. The action decorator
+Our states listen to actions via an `@Action` decorator. The action decorator
 accepts an action class or an array of action classes.
 
 ### Simple Actions
@@ -75,8 +75,8 @@ export class ZooState {
 }
 ```
 
-The `feedAnimal` function has one argument called `StateContext`. This
-context state has a slice pointer and a function to set the state. It's important
+The `feedAnimals` function has one argument called `ctx` with a type of `StateContext<ZooStateModel>`. This
+context state has a slice pointer and a function exposed to set the state. It's important
 to note that the `getState()` method will always return
 the freshest state slice from the global store each time it is accessed. This
 ensures that when we're performing async operations the state

--- a/docs/concepts/store.md
+++ b/docs/concepts/store.md
@@ -105,4 +105,4 @@ the state to be a specific value for isolated testing.
 `store.reset(myNewStateObject)` will reset the entire state to the passed argument without firing
 any actions or life-cycle events.
 
-Warning: Using this can cause unintended side effects if inproperly used and should be used with caution!
+Warning: Using this can cause unintended side effects if improperly used and should be used with caution!


### PR DESCRIPTION
A few quick fixes for the actions, state and store docs.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There were a few grammatical or spelling mistakes in the docs that can be confusing to a reader. I feel the changes will help add to the value of the docs a little.

Issue Number: N/A


## What is the new behavior?
NA


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
