### PR TITLE
fix(store): remove TestBed ref to reduce bundle size

### DIFF
--- a/packages/store/src/internal/state-operations.ts
+++ b/packages/store/src/internal/state-operations.ts
@@ -1,11 +1,11 @@
-import { Injectable, isDevMode, Optional } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
+import { Injectable, isDevMode } from '@angular/core';
 
 import { StateOperations } from '../internal/internals';
 import { InternalDispatcher } from '../internal/dispatcher';
 import { StateStream } from './state-stream';
 import { NgxsConfig } from '../symbols';
 import { deepFreeze } from '../utils/freeze';
+import { isAngularInTestMode } from '../utils/angular';
 
 /**
  * State Context factory class
@@ -16,8 +16,7 @@ export class InternalStateOperations {
   constructor(
     private _stateStream: StateStream,
     private _dispatcher: InternalDispatcher,
-    private _config: NgxsConfig,
-    @Optional() private _testBed: TestBed
+    private _config: NgxsConfig
   ) {
     this.verifyDevMode();
   }
@@ -40,8 +39,7 @@ export class InternalStateOperations {
   }
 
   private verifyDevMode() {
-    const isTestMode = this._testBed !== null;
-    if (isTestMode) return;
+    if (isAngularInTestMode()) return;
 
     const isNgxsDevMode = this._config.developmentMode;
     const isNgDevMode = isDevMode();

--- a/packages/store/src/utils/angular.ts
+++ b/packages/store/src/utils/angular.ts
@@ -1,0 +1,21 @@
+import { getPlatform, COMPILER_OPTIONS, CompilerOptions, PlatformRef } from '@angular/core';
+import { memoize } from './memoize';
+
+function _isAngularInTestMode() {
+  const platformRef: PlatformRef | null = getPlatform();
+  if (!platformRef) return false;
+  const compilerOptions = platformRef.injector.get(COMPILER_OPTIONS, null);
+  if (!compilerOptions) return false;
+  const isInTestMode = compilerOptions.some((item: CompilerOptions) => {
+    const providers = (item && item.providers) || [];
+    return providers.some((provider: any) => {
+      return (
+        (provider && provider.provide && provider.provide.name === 'MockNgModuleResolver') ||
+        false
+      );
+    });
+  });
+  return isInTestMode;
+}
+
+export const isAngularInTestMode = memoize(_isAngularInTestMode);

--- a/packages/store/tests/utils/angular.spec.ts
+++ b/packages/store/tests/utils/angular.spec.ts
@@ -1,0 +1,82 @@
+import { isAngularInTestMode } from '../../src/utils/angular';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { getPlatform, platformCore } from '@angular/core';
+import { platformBrowser } from '@angular/platform-browser';
+import {
+  platformBrowserDynamicTesting,
+  BrowserDynamicTestingModule
+} from '@angular/platform-browser-dynamic/testing';
+import { getTestBed } from '@angular/core/testing';
+
+describe('[utils/angular]', () => {
+  describe('isAngularInTestMode', () => {
+    function resetEnv() {
+      const fn = <any>isAngularInTestMode;
+      // Reset the memoization
+      fn && fn.reset && fn.reset();
+
+      // Reset the angular platform
+      const p = <any>getPlatform();
+      p && p.destroy && p.destroy();
+    }
+
+    beforeEach(() => {
+      resetEnv();
+    });
+
+    afterEach(() => {
+      resetEnv();
+
+      getTestBed().resetTestEnvironment();
+      getTestBed().initTestEnvironment(
+        BrowserDynamicTestingModule,
+        platformBrowserDynamicTesting()
+      );
+    });
+
+    it(`should return true if the Angular Test Module has been bootstrapped`, () => {
+      // Arrange
+      platformBrowserDynamicTesting();
+      // Act
+      const result = isAngularInTestMode();
+      // Assert
+      expect(result).toEqual(true);
+    });
+
+    it(`should return false if Angular has not been bootstrapped`, () => {
+      // Arrange
+
+      // Act
+      const result = isAngularInTestMode();
+      // Assert
+      expect(result).toEqual(false);
+    });
+
+    it(`should return false if the Angular platformBrowserDynamic has been bootstrapped`, async () => {
+      // Arrange
+      platformBrowserDynamic();
+      // Act
+      const result = isAngularInTestMode();
+      // Assert
+      expect(result).toEqual(false);
+    });
+
+    it(`should return false if the Angular platformBrowser has been bootstrapped`, async () => {
+      // Arrange
+      platformBrowser();
+      // Act
+      const result = isAngularInTestMode();
+      // Assert
+      expect(result).toEqual(false);
+    });
+
+    it(`should return false if the Angular platformCore has been bootstrapped`, async () => {
+      // Arrange
+      platformCore();
+      // Act
+      const result = isAngularInTestMode();
+      // Assert
+      expect(result).toEqual(false);
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
We wanted to remove the console hints if Angular was in testing mode.
In order to detect if Angular is in testing mode we injected TestBed but this has increased the production bundle size by 78kb!

Issue Number: #722 #706 #701 


## What is the new behavior?
Removed ref to TestBed and used a different machanism to determine test mode.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
