### PR TITLE
docs(store): add basic docs for structure returned by ofActionCompleted

### DIFF
--- a/docs/advanced/action-handlers.md
+++ b/docs/advanced/action-handlers.md
@@ -24,7 +24,19 @@ Since it's an Observable, we can use the following four pipes:
 * `ofActionSuccessful`: triggers when an action has been completed successfully
 * `ofActionCanceled`: triggers when an action has been canceled
 * `ofActionErrored`: triggers when an action has caused an error to be thrown
-* `ofActionCompleted`: triggers when an action has been completed whether it was successful or not
+* `ofActionCompleted`: triggers when an action has been completed whether it was successful or not (returns completion summary)
+
+All of the above pipes return the original `action` in the observable except for the `ofActionCompleted` pipe which returns some summary information for the completed action. This summary is an object with the following interface:
+```TS
+interface ActionCompletion<T = any> {
+  action: T;
+  result: {
+    successful: boolean;
+    canceled: boolean;
+    error?: Error;
+  };
+}
+```
 
 Below is a action handler that filters for `RouteNavigate` actions and then tells the router to navigate to that
 route.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Missing information about the interface returned by `ofActionCompleted` in the docs.
Issue Number: #718


## What is the new behavior?
Added some basic information about the returned object.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```
