### PR TITLE
fix(storage-plugin): Remove the 'key' feature from the 'StorageEngine' interface

### DIFF
--- a/docs/plugins/storage.md
+++ b/docs/plugins/storage.md
@@ -63,10 +63,6 @@ export class MyStorageEngine implements StorageEngine {
   clear(): void {
     // Your logic here
   }
-  
-  key(val: number): string {
-    // Your logic here
-  }
 }
 
 @NgModule({

--- a/packages/storage-plugin/src/symbols.ts
+++ b/packages/storage-plugin/src/symbols.ts
@@ -64,5 +64,4 @@ export interface StorageEngine {
   setItem(key: string, val: any): void;
   removeItem(key: string): void;
   clear(): void;
-  key(val: number): string;
 }

--- a/packages/storage-plugin/tests/storage.plugin.spec.ts
+++ b/packages/storage-plugin/tests/storage.plugin.spec.ts
@@ -305,10 +305,6 @@ describe('NgxsStoragePlugin', () => {
       clear() {
         CustomStorage.Storage = {};
       }
-
-      key(index: number) {
-        return Object.keys(CustomStorage.Storage)[index];
-      }
     }
 
     TestBed.configureTestingModule({


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Issue Number: #771


## What is the new behavior?
The StorageEngine interface doesn't require implementing the `key` method.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```



## Other information