### PR TITLE
fix(logger): log group not closed on error

### DIFF
--- a/packages/logger-plugin/src/logger.plugin.ts
+++ b/packages/logger-plugin/src/logger.plugin.ts
@@ -1,6 +1,5 @@
 import { Injectable, Inject } from '@angular/core';
 import { tap, finalize, catchError } from 'rxjs/operators';
-import { of } from 'rxjs';
 
 import { NgxsPlugin, getActionTypeFromInstance, NgxsNextPluginFn } from '@ngxs/store';
 

--- a/packages/logger-plugin/src/logger.plugin.ts
+++ b/packages/logger-plugin/src/logger.plugin.ts
@@ -1,9 +1,11 @@
 import { Injectable, Inject } from '@angular/core';
+import { tap, finalize, catchError } from 'rxjs/operators';
+import { of } from 'rxjs';
+
 import { NgxsPlugin, getActionTypeFromInstance, NgxsNextPluginFn } from '@ngxs/store';
 
 import { NGXS_LOGGER_PLUGIN_OPTIONS, NgxsLoggerPluginOptions } from './symbols';
 import { pad } from './internals';
-import { tap } from 'rxjs/operators';
 
 @Injectable()
 export class NgxsLoggerPlugin implements NgxsPlugin {
@@ -43,6 +45,13 @@ export class NgxsLoggerPlugin implements NgxsPlugin {
     return next(state, event).pipe(
       tap(nextState => {
         this.log('next state', 'color: #4CAF50; font-weight: bold', nextState);
+      }),
+      catchError(error => {
+        this.log('error', 'color: #FD8182; font-weight: bold', error);
+
+        throw error;
+      }),
+      finalize(() => {
         try {
           logger.groupEnd();
         } catch (e) {

--- a/packages/logger-plugin/tests/helpers/index.ts
+++ b/packages/logger-plugin/tests/helpers/index.ts
@@ -1,0 +1,2 @@
+export * from './logger-spy';
+export * from './utils';

--- a/packages/logger-plugin/tests/helpers/logger-spy.ts
+++ b/packages/logger-plugin/tests/helpers/logger-spy.ts
@@ -1,0 +1,44 @@
+import { CallStack } from './symbols';
+
+/**
+ * Spy that mimics the required methods for custom logger implementation,
+ *   just like console logger.
+ */
+export class LoggerSpy {
+  private _callStack: CallStack = [];
+
+  static createCallStack(callStack: CallStack): string {
+    return JSON.stringify(callStack);
+  }
+
+  group(...label: any[]) {
+    this._callStack.push(['group', ...label]);
+  }
+
+  groupCollapsed(...label: any[]) {
+    this._callStack.push(['groupCollapsed', ...label]);
+  }
+
+  groupEnd() {
+    this._callStack.push(['groupEnd']);
+  }
+
+  log(message?: any, ...optionalParams: any[]) {
+    this._callStack.push(['log', message, ...optionalParams]);
+  }
+
+  get callStack(): string {
+    const callStackWithoutTime = this._callStack.map(call => {
+      const callSecondParam = call[1] as string;
+
+      // remove formatted time string
+      if (typeof callSecondParam === 'string') {
+        call[1] = callSecondParam.replace(/\d{2}:\d{2}:\d{2}.\d{3}/g, '');
+      }
+
+      return call;
+    });
+
+    return LoggerSpy.createCallStack(callStackWithoutTime);
+  }
+}

--- a/packages/logger-plugin/tests/helpers/symbols.ts
+++ b/packages/logger-plugin/tests/helpers/symbols.ts
@@ -1,0 +1,1 @@
+export type CallStack = (string | {})[][];

--- a/packages/logger-plugin/tests/helpers/utils.ts
+++ b/packages/logger-plugin/tests/helpers/utils.ts
@@ -1,0 +1,31 @@
+import { CallStack } from './symbols';
+
+export class FormatActionCallStackOptions {
+  action: string;
+  prevState: {};
+  nextState?: {};
+  payload?: string;
+  error?: string;
+  collapsed?: boolean;
+}
+
+export function formatActionCallStack(opts: FormatActionCallStackOptions): CallStack {
+  const { action, prevState, nextState, payload, error, collapsed } = opts;
+
+  const formattedPayload = payload
+    ? [['log', '%c payload', 'color: #9E9E9E; font-weight: bold', payload]]
+    : [];
+
+  return [
+    [collapsed ? 'groupCollapsed' : 'group', `action ${action} @ `],
+    ...formattedPayload,
+    ['log', '%c prev state', 'color: #9E9E9E; font-weight: bold', { test: prevState }],
+    [
+      'log',
+      error ? '%c error' : '%c next state',
+      `color: #${error ? 'FD8182' : '4CAF50'}; font-weight: bold`,
+      error ? {} : { test: { ...prevState, ...nextState } }
+    ],
+    ['groupEnd']
+  ];
+}

--- a/packages/logger-plugin/tests/logger.plugin.spec.ts
+++ b/packages/logger-plugin/tests/logger.plugin.spec.ts
@@ -1,0 +1,157 @@
+import { ErrorHandler } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { throwError } from 'rxjs';
+
+import { NgxsModule, Store, State, Action, StateContext, InitState } from '@ngxs/store';
+import { NoopErrorHandler } from '@ngxs/store/tests/helpers/utils';
+
+import { NgxsLoggerPluginModule, NgxsLoggerPluginOptions } from '../';
+import { LoggerSpy, formatActionCallStack } from './helpers';
+
+describe('NgxsLoggerPlugin', () => {
+  const thrownErrorMessage = 'Error';
+  const defaultBarValue = 'baz';
+
+  class UpdateBarAction {
+    static type = 'UPDATE_BAR';
+
+    constructor(public payload?: string) {}
+  }
+
+  class ErrorAction {
+    static type = 'ERROR';
+  }
+
+  interface StateModel {
+    bar: string;
+  }
+
+  const stateModelDefaults: StateModel = {
+    bar: ''
+  };
+
+  @State<StateModel>({
+    name: 'test',
+    defaults: stateModelDefaults
+  })
+  class TestState {
+    @Action(UpdateBarAction)
+    updateBar({ patchState }: StateContext<StateModel>, { payload }: UpdateBarAction) {
+      patchState({ bar: payload || defaultBarValue });
+    }
+
+    @Action(ErrorAction)
+    error() {
+      return throwError(new Error(thrownErrorMessage));
+    }
+  }
+
+  function setup(opts?: NgxsLoggerPluginOptions) {
+    const logger = new LoggerSpy();
+
+    TestBed.configureTestingModule({
+      imports: [
+        NgxsModule.forRoot([TestState]),
+        NgxsLoggerPluginModule.forRoot({
+          ...opts,
+          logger
+        })
+      ],
+      providers: [{ provide: ErrorHandler, useClass: NoopErrorHandler }]
+    });
+
+    return {
+      store: TestBed.get(Store),
+      logger
+    };
+  }
+
+  it('should log success action', () => {
+    const { store, logger } = setup();
+
+    store.dispatch(new UpdateBarAction());
+
+    const expectedCallStack = LoggerSpy.createCallStack([
+      ...formatActionCallStack({ action: InitState.type, prevState: stateModelDefaults }),
+
+      ...formatActionCallStack({
+        action: UpdateBarAction.type,
+        prevState: stateModelDefaults,
+        nextState: { bar: defaultBarValue }
+      })
+    ]);
+
+    expect(logger.callStack).toEqual(expectedCallStack);
+  });
+
+  it('should log success action with payload', () => {
+    const { store, logger } = setup();
+    const payload = 'qux';
+
+    store.dispatch(new UpdateBarAction(payload));
+
+    const expectedCallStack = LoggerSpy.createCallStack([
+      ...formatActionCallStack({ action: InitState.type, prevState: stateModelDefaults }),
+
+      ...formatActionCallStack({
+        action: UpdateBarAction.type,
+        prevState: stateModelDefaults,
+        nextState: { bar: payload },
+        payload
+      })
+    ]);
+
+    expect(logger.callStack).toEqual(expectedCallStack);
+  });
+
+  it('should log error action', () => {
+    const { store, logger } = setup();
+
+    store.dispatch(new ErrorAction());
+
+    const expectedCallStack = LoggerSpy.createCallStack([
+      ...formatActionCallStack({ action: InitState.type, prevState: stateModelDefaults }),
+
+      ...formatActionCallStack({
+        action: ErrorAction.type,
+        prevState: stateModelDefaults,
+        error: thrownErrorMessage
+      })
+    ]);
+
+    expect(logger.callStack).toEqual(expectedCallStack);
+  });
+
+  it('should log collapsed success action', () => {
+    const { store, logger } = setup({ collapsed: true });
+
+    store.dispatch(new UpdateBarAction());
+
+    const expectedCallStack = LoggerSpy.createCallStack([
+      ...formatActionCallStack({
+        action: InitState.type,
+        prevState: stateModelDefaults,
+        collapsed: true
+      }),
+
+      ...formatActionCallStack({
+        action: UpdateBarAction.type,
+        prevState: stateModelDefaults,
+        nextState: { bar: defaultBarValue },
+        collapsed: true
+      })
+    ]);
+
+    expect(logger.callStack).toEqual(expectedCallStack);
+  });
+
+  it('should not log while disabled', () => {
+    const { store, logger } = setup({ disabled: true });
+
+    store.dispatch(new UpdateBarAction());
+
+    const expectedCallStack = LoggerSpy.createCallStack([]);
+
+    expect(logger.callStack).toEqual(expectedCallStack);
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
![image](https://user-images.githubusercontent.com/9721664/52526278-f9ed5600-2cbe-11e9-9572-b5f0f9a13443.png)

Issue Number: #817 

## What is the new behavior?
I added the `error` log in case the error raised is suppressed with a custom error handler after the logger ran.
![image](https://user-images.githubusercontent.com/9721664/52526302-3f118800-2cbf-11e9-92b3-1c5836216c28.png)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```