### PR TITLE
fix(websocket-plugin): Server/network error triggered close should dispatch WebSocketDisconnected

### DIFF
--- a/packages/websocket-plugin/src/websocket-handler.ts
+++ b/packages/websocket-plugin/src/websocket-handler.ts
@@ -37,7 +37,10 @@ export class WebSocketHandler {
         }
         store.dispatch({ ...msg, type });
       },
-      err => store.dispatch(new WebsocketMessageError(err)),
+      err =>
+        err instanceof CloseEvent
+          ? store.dispatch(new WebSocketDisconnected())
+          : store.dispatch(new WebsocketMessageError(err)),
       () => store.dispatch(new WebSocketDisconnected())
     );
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behaviour?
currently client triggered websocket disconnect will dispatch WebSocketDisconnected where as server/network err triggered disconnect dispatches WebsocketMessageError (this is how rxjs websocket subject works). NGXS websocket plugin's API consumer should not have to deal with these low level scenarios, and any type of disconnecting should dispatch WebSocketDisconnected

Issue Number: N/A


## What is the new behavior?

With this change, server disconnect will also trigger WebSocketDisconnected

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
improvement to PR #825 