### PR TITLE
Feature/reset plugin

### DIFF
--- a/docs/plugins/reset.md
+++ b/docs/plugins/reset.md
@@ -1,0 +1,80 @@
+# Reset Plugin
+
+Erase the whole state tree anytime you want while keeping the state(s) you need. Reset a single state or multiple states easily back to default value(s).
+
+## Installation
+
+```bash
+npm install @ngxs/reset-plugin --save
+
+# or if you are using yarn
+yarn add @ngxs/reset-plugin
+```
+
+## Usage
+
+Import `NgxsResetPluginModule` into your root module like:
+
+```TS
+import { NgxsModule } from '@ngxs/store';
+import { NgxsResetPluginModule } from '@ngxs/reset-plugin';
+
+@NgModule({
+  imports: [
+    NgxsModule.forRoot([ /* Your states here */ ]),
+    NgxsResetPluginModule.forRoot()
+  ]
+})
+export class AppModule {}
+```
+
+### Options
+
+The plugin supports no options. Action payloads will define how it behaves.
+
+### Actions
+
+The reset plugin comes with the following `actions` out of the box:
+
+- `StateErase(payload?: StateClass | StateClasses[])` - Erases all states, but keeps given state(s)
+- `StateReset(payload: StateClass | StateClasses[])` - Resets given state(s) to defaults
+
+## Recipes
+
+You can find possible action variations with some use cases below.
+
+### Erase states on session end
+
+To clear all states (on logout for example):
+
+```TS
+this.store.dispatch(new StateErase());
+```
+
+To remove all states but one: \*
+
+```TS
+this.store.dispatch(new StateErase(SessionState));
+```
+
+To remove all states but some: \*
+
+```TS
+this.store.dispatch(new StateErase([SessionState, PreferencesState]));
+```
+
+\* Keeping states while deleting others is useful especially combined with [`@ngxs/storage-plugin`](https://npmjs.com/package/@ngxs/storage-plugin)
+
+### Reset states when needed
+
+To reset a single state to its defaults on certain events (such as route change):
+
+```TS
+this.store.dispatch(new StateReset(SessionState));
+```
+
+To reset multiple states to their defaults (may prove useful in distributed scenarios):
+
+```TS
+this.store.dispatch(new StateReset([SessionState, PreferencesState]));
+```

--- a/packages/reset-plugin/README.md
+++ b/packages/reset-plugin/README.md
@@ -1,0 +1,3 @@
+# @ngxs/reset-plugin
+
+Reset plugin for NGXS. See [repo](https://github.com/ngxs/store) for more info.

--- a/packages/reset-plugin/index.ts
+++ b/packages/reset-plugin/index.ts
@@ -1,0 +1,4 @@
+/**
+ * The public api for consumers of @ngxs/reset-plugin
+ */
+export * from './src/public_api';

--- a/packages/reset-plugin/package.json
+++ b/packages/reset-plugin/package.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../../node_modules/ng-packagr/package.schema.json",
+  "name": "@ngxs/reset-plugin",
+  "description": "state reset plugin for @ngxs/store",
+  "version": "0.0.0",
+  "sideEffects": true,
+  "peerDependencies": {
+    "@ngxs/store": "^0.0.0",
+    "@angular/core": ">=5.0.0 <8.0.0",
+    "rxjs": ">=6.0.0 || ^5.6.0-forward-compat.4"
+  },
+  "ngPackage": {
+    "lib": {
+      "flatModuleFile": "ngxs-reset-plugin",
+      "entryFile": "index.ts",
+      "umdModuleIds": {
+        "@ngxs/store": "ngxs-store"
+      }
+    },
+    "dest": "../../@ngxs/reset-plugin"
+  }
+}

--- a/packages/reset-plugin/src/internals.ts
+++ b/packages/reset-plugin/src/internals.ts
@@ -1,0 +1,4 @@
+import { MetaDataModel, StateClass } from '../../store/src/internal/internals';
+import { getValue, setValue } from '../../store/src/utils/utils';
+
+export { getValue, MetaDataModel, setValue, StateClass };

--- a/packages/reset-plugin/src/public_api.ts
+++ b/packages/reset-plugin/src/public_api.ts
@@ -1,0 +1,3 @@
+export { NgxsResetPluginModule } from './reset.module';
+export { NgxsResetPlugin } from './reset.plugin';
+export * from './symbols';

--- a/packages/reset-plugin/src/reset.module.ts
+++ b/packages/reset-plugin/src/reset.module.ts
@@ -1,0 +1,19 @@
+import { ModuleWithProviders, NgModule } from '@angular/core';
+import { NGXS_PLUGINS } from '@ngxs/store';
+import { NgxsResetPlugin } from './reset.plugin';
+
+@NgModule()
+export class NgxsResetPluginModule {
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: NgxsResetPluginModule,
+      providers: [
+        {
+          provide: NGXS_PLUGINS,
+          useClass: NgxsResetPlugin,
+          multi: true
+        }
+      ]
+    };
+  }
+}

--- a/packages/reset-plugin/src/reset.plugin.ts
+++ b/packages/reset-plugin/src/reset.plugin.ts
@@ -1,9 +1,78 @@
-import { Injectable } from '@angular/core';
-import { NgxsNextPluginFn, NgxsPlugin } from '@ngxs/store';
+import { Injectable, isDevMode } from '@angular/core';
+import {
+  getActionTypeFromInstance,
+  getStoreMetadata,
+  NgxsNextPluginFn,
+  NgxsPlugin
+} from '@ngxs/store';
+import { getValue, MetaDataModel, setValue, StateClass } from './internals';
+import { StateErase, StateReset } from './symbols';
 
 @Injectable()
 export class NgxsResetPlugin implements NgxsPlugin {
+  private getErasedState(state: any, statesToKeep: MetaDataModel[]): any {
+    return statesToKeep
+      .map(meta => getPath(meta))
+      .map(path => ({
+        parts: path.split('.'),
+        value: getValue(state, path)
+      }))
+      .reduce(
+        (obj, { parts, value }) =>
+          parts.reduceRight(
+            (acc, part) =>
+              part in obj
+                ? {
+                    [part]: {
+                      ...obj[part],
+                      ...acc
+                    }
+                  }
+                : { [part]: acc },
+            value
+          ),
+        {} as any
+      );
+  }
+
+  private resetStates(state: any, statesToReset: MetaDataModel[]): any {
+    statesToReset.forEach(meta => {
+      if (meta.name && 'defaults' in meta) {
+        state = setValue(state, getPath(meta), meta.defaults);
+      } else if (isDevMode()) {
+        console.warn(`Reset Failed: ${meta.name} is not a state class.`);
+      }
+    });
+
+    return state;
+  }
+
   handle(state: any, action: any, next: NgxsNextPluginFn) {
+    const type: string = getActionTypeFromInstance(action) || '';
+
+    switch (type) {
+      case StateErase.type:
+        state = this.getErasedState(state, convertToMetaDataList(action.statesToKeep || []));
+        break;
+
+      case StateReset.type:
+        state = this.resetStates(state, convertToMetaDataList(action.statesToReset));
+        break;
+
+      default:
+        break;
+    }
+
     return next(state, action);
   }
+}
+
+function convertToMetaDataList(classes: StateClass | StateClass[]): MetaDataModel[] {
+  return (Array.isArray(classes) ? classes : [classes]).map(
+    stateClass => new Object(getStoreMetadata(stateClass)) as MetaDataModel
+  );
+}
+
+function getPath(meta: MetaDataModel): string {
+  return meta.path || '';
 }

--- a/packages/reset-plugin/src/reset.plugin.ts
+++ b/packages/reset-plugin/src/reset.plugin.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@angular/core';
+import { NgxsNextPluginFn, NgxsPlugin } from '@ngxs/store';
+
+@Injectable()
+export class NgxsResetPlugin implements NgxsPlugin {
+  handle(state: any, action: any, next: NgxsNextPluginFn) {
+    return next(state, action);
+  }
+}

--- a/packages/reset-plugin/src/symbols.ts
+++ b/packages/reset-plugin/src/symbols.ts
@@ -1,0 +1,17 @@
+import { StateClass } from '../../store/src/internal/internals';
+
+/**
+ * Action to erase all state
+ */
+export class StateErase {
+  static readonly type = '@@ERASE_STATE';
+  constructor(public readonly statesToKeep?: StateClass | StateClass[]) {}
+}
+
+/**
+ * Action to reset a state
+ */
+export class StateReset {
+  static readonly type = '@@RESET_STATE';
+  constructor(public readonly statesToReset: StateClass | StateClass[]) {}
+}

--- a/packages/reset-plugin/tests/reset.plugin.spec.ts
+++ b/packages/reset-plugin/tests/reset.plugin.spec.ts
@@ -1,0 +1,35 @@
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { Actions, NgxsModule, Store } from '@ngxs/store';
+import { NgxsResetPluginModule } from '../';
+import { AppState, PreferencesState, SessionState, ToDoState } from './test-states';
+import { ToDoAdd } from './test-symbols';
+
+interface TestModel {
+  actions$: Actions;
+  store: Store;
+}
+
+describe('NgxsResetPlugin', () => {
+  it('should be ready for testing', fakeAsync(() => {
+    setupTest();
+  }));
+});
+
+function setupTest(): TestModel {
+  TestBed.configureTestingModule({
+    imports: [
+      NgxsModule.forRoot([AppState, PreferencesState, SessionState, ToDoState]),
+      NgxsResetPluginModule.forRoot()
+    ]
+  });
+
+  const actions$ = TestBed.get(Actions);
+  const store = TestBed.get(Store);
+
+  store.dispatch(new ToDoAdd('Test'));
+
+  tick();
+  expect(store.selectSnapshot(ToDoState.list)).toEqual([{ description: 'Test', done: false }]);
+
+  return { actions$, store };
+}

--- a/packages/reset-plugin/tests/reset.plugin.spec.ts
+++ b/packages/reset-plugin/tests/reset.plugin.spec.ts
@@ -1,8 +1,8 @@
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { Actions, NgxsModule, Store } from '@ngxs/store';
-import { NgxsResetPluginModule } from '../';
+import { NgxsResetPluginModule, StateErase, StateReset } from '../';
 import { AppState, PreferencesState, SessionState, ToDoState } from './test-states';
-import { ToDoAdd } from './test-symbols';
+import { SessionEnd, ToDoAdd } from './test-symbols';
 
 interface TestModel {
   actions$: Actions;
@@ -10,10 +10,84 @@ interface TestModel {
 }
 
 describe('NgxsResetPlugin', () => {
-  it('should be ready for testing', fakeAsync(() => {
-    setupTest();
+  it('should erase states on StateErase', fakeAsync(() => {
+    const { store } = setupTest();
+
+    store.dispatch(new StateErase());
+    tick();
+
+    expect(store.snapshot()).toEqual({});
+  }));
+
+  it('should erase states on StateErase but keep selected', fakeAsync(() => {
+    const { store } = setupTest();
+
+    store.dispatch(new StateErase(PreferencesState));
+    tick();
+
+    expect(store.snapshot()).toEqual({
+      app: { preferences: { darkmode: false, language: 'en' } }
+    });
+  }));
+
+  it('should erase states on StateErase but keep selected (multi)', fakeAsync(() => {
+    const { store } = setupTest();
+
+    const lastseen = ensureLastSeen(store);
+
+    store.dispatch(new StateErase([PreferencesState, SessionState]));
+    tick();
+
+    expect(store.snapshot()).toEqual({
+      app: { preferences: { darkmode: false, language: 'en' }, session: { lastseen } }
+    });
+  }));
+
+  it('should reset state to defaults on StateReset', fakeAsync(() => {
+    const { store } = setupTest();
+
+    store.dispatch(new StateReset(ToDoState));
+    tick();
+
+    expect(store.selectSnapshot(ToDoState.list)).toEqual([]);
+  }));
+
+  it('should reset state to defaults on StateReset (multi)', fakeAsync(() => {
+    const { store } = setupTest();
+
+    ensureLastSeen(store);
+
+    store.dispatch(new StateReset([SessionState, ToDoState]));
+    tick();
+
+    expect(store.selectSnapshot(SessionState)).toBeUndefined();
+    expect(store.selectSnapshot(ToDoState.list)).toEqual([]);
+  }));
+
+  it('should log a warning on StateReset with wrong payload', fakeAsync(() => {
+    const { store } = setupTest();
+    const state = store.snapshot();
+
+    console.warn = jasmine.createSpy('warning');
+
+    store.dispatch(new StateReset(ToDoAdd));
+    tick();
+
+    expect(console.warn).toHaveBeenCalled();
+    expect(store.snapshot()).toEqual(state);
   }));
 });
+
+function ensureLastSeen(store: Store): number {
+  const lastseen = new Date().valueOf();
+
+  store.dispatch(new SessionEnd(lastseen));
+  tick();
+
+  expect(store.selectSnapshot(SessionState)).toEqual({ lastseen });
+
+  return lastseen;
+}
 
 function setupTest(): TestModel {
   TestBed.configureTestingModule({

--- a/packages/reset-plugin/tests/test-states.ts
+++ b/packages/reset-plugin/tests/test-states.ts
@@ -1,0 +1,71 @@
+import { Action, Selector, State, StateContext } from '@ngxs/store';
+import { App, Preferences, Session, SessionEnd, ToDo, ToDoAdd } from './test-symbols';
+
+/**
+ * Test ToDoState
+ */
+@State<ToDo.State>({
+  name: 'todos',
+  defaults: {
+    list: []
+  }
+})
+export class ToDoState {
+  @Selector()
+  static list({ list }: ToDo.State): ToDo.Item[] {
+    return list;
+  }
+
+  @Action(ToDoAdd)
+  addNewTodo({ getState, setState }: StateContext<ToDo.State>, { payload }: ToDoAdd) {
+    const state = getState();
+    setState({
+      list: [
+        ...state.list,
+        {
+          description: payload,
+          done: false
+        }
+      ]
+    });
+  }
+}
+
+/**
+ * Test PreferencesState
+ */
+@State<Preferences.State>({
+  name: 'preferences',
+  defaults: {
+    darkmode: false,
+    language: 'en'
+  }
+})
+export class PreferencesState {}
+
+/**
+ * Test SessionState
+ */
+@State<Session.State>({
+  name: 'session'
+})
+export class SessionState {
+  @Action(SessionEnd)
+  updateLastSeen({ patchState }: StateContext<Session.State>, { payload }: SessionEnd) {
+    patchState({
+      lastseen: payload
+    });
+  }
+}
+
+/**
+ * Test AppState
+ */
+@State<App.State>({
+  name: 'app',
+  defaults: {
+    status: 'ONLINE'
+  },
+  children: [PreferencesState, SessionState, ToDoState]
+})
+export class AppState {}

--- a/packages/reset-plugin/tests/test-symbols.ts
+++ b/packages/reset-plugin/tests/test-symbols.ts
@@ -1,0 +1,61 @@
+/**
+ * Test namespace for App
+ */
+export namespace App {
+  export type Status = 'OFFLINE' | 'ONLINE';
+
+  export interface State {
+    status: Status;
+  }
+}
+
+/**
+ * Test namespace for Preferences
+ */
+export namespace Preferences {
+  export interface State {
+    darkmode: boolean;
+    language: string;
+  }
+}
+
+/**
+ * Test namespace for Session
+ */
+export namespace Session {
+  export interface State {
+    lastseen: number;
+  }
+}
+
+/**
+ * Test namespace for ToDo
+ */
+export namespace ToDo {
+  export interface Item {
+    description: string;
+    done: boolean;
+  }
+
+  export interface State {
+    list: Item[];
+  }
+}
+
+/**
+ * Test action to add a lastseen timestamp
+ */
+export class SessionEnd {
+  static readonly type = '[Session] End';
+
+  constructor(public payload: number) {}
+}
+
+/**
+ * Test action to add a todo item
+ */
+export class ToDoAdd {
+  static readonly type = '[ToDo] Add';
+
+  constructor(public payload: string) {}
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, a meta reducer can be used in order to clear/reset a state. Meta reducers are great, but they have the following drawbacks:
- In order to use a meta reducer, one must prepare and inject it as a plugin to NGXS. This is not as straightforward as importing a module.
- I could not find any blueprint for developers who want to keep some states while clearing others. For instance, when one uses the storage plugin on some states, the obviously intention is to keep them for the next visit. On the other hand, the same person would probably want to clear everything else on logout. I believe it will be nice to offer them a reusable way to do so.
- As far as I know, there is no direct way of resetting states to their defaults. This is a requirement in many cases and I have seen many developers struggling with it. Also, let's not forget sometimes even multiple states may have to be reset.
- There are some internal utils in NGXS which are quite helpful in achieving these 

## What is the new behavior?
With the new reset plugin, there are basically 2 things a developer can do in a direct way that is easy to understand and follow:
- Reset states by dispatching a predefined action with a payload of state classes. Child states will not be a problem thanks to `getValue` and `setValue` utility functions.
- Erase whole state by dispatching a predefined action. If state classes are provided to the action as payload, they will be kept untouched. Again, child states are considered.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```