### PR TITLE
revert: fix(store): improve type signatures of store select methods

### DIFF
--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -1,5 +1,5 @@
 // tslint:disable:unified-signatures
-import { Injectable, Type } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { Observable, of, Subscription } from 'rxjs';
 import { catchError, distinctUntilChanged, map, take } from 'rxjs/operators';
 
@@ -32,7 +32,7 @@ export class Store {
    * Selects a slice of data from the store.
    */
   select<T>(selector: (state: any, ...states: any[]) => T): Observable<T>;
-  select<T = any>(selector: string | Type<unknown>): Observable<T>;
+  select(selector: string | any): Observable<any>;
   select(selector: any): Observable<any> {
     const selectorFn = getSelectorFn(selector);
     return this._stateStream.pipe(
@@ -54,9 +54,8 @@ export class Store {
   /**
    * Select one slice of data from the store.
    */
-
   selectOnce<T>(selector: (state: any, ...states: any[]) => T): Observable<T>;
-  selectOnce<T = any>(selector: string | Type<unknown>): Observable<T>;
+  selectOnce(selector: string | any): Observable<any>;
   selectOnce(selector: any): Observable<any> {
     return this.select(selector).pipe(take(1));
   }
@@ -65,7 +64,7 @@ export class Store {
    * Select a snapshot from the state.
    */
   selectSnapshot<T>(selector: (state: any, ...states: any[]) => T): T;
-  selectSnapshot<T = any>(selector: string | Type<unknown>): T;
+  selectSnapshot(selector: string | any): any;
   selectSnapshot(selector: any): any {
     const selectorFn = getSelectorFn(selector);
     return selectorFn(this._stateStream.getValue());


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Reverts PR #709.
`unknown` type, introduced in TypeScript 3, is a breaking change for Angular 6 (that uses TypeScript 2.*).
`unknown` is also used in hmr-plugin and state/operators, that also should be addressed. This one is the most important, as already discussed in slack.
```bash
ERROR in node_modules/@ngxs/store/src/store.d.ts(21,45): error TS2304: Cannot find name 'unknown'.
node_modules/@ngxs/store/src/store.d.ts(26,49): error TS2304: Cannot find name 'unknown'.
node_modules/@ngxs/store/src/store.d.ts(31,53): error TS2304: Cannot find name 'unknown'.
```

## What is the new behavior?
We lose the type saftey, maybe we should add this for v4 and add to the breaking changes list. #827 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```