### PR TITLE
feat(store): add @Selector parameter to optimize updates on state class

### DIFF
--- a/docs/concepts/select.md
+++ b/docs/concepts/select.md
@@ -268,6 +268,25 @@ When using the `Selector` decorator along with a state class, it will still
 inject the state class's state first followed by the other selectors in the order
 they were passed in the signature.
 
+#### Optimizing Selectors
+By default the state class's state is always injected first, causing your selector
+value to be updated on each state's change.
+
+You can change this behavior passing `true` as the second selector parameter, to
+only inject the selectors you need and therefore limit updates.
+
+```TS
+@State<string[]>({ ... })
+export class ZooState {
+
+  @Selector([ZooState.pandas('baby')], true)
+  static babyPandasCounter(babyPandas: string[]) {
+    return babyPandas.length;
+  }
+
+}
+```
+
 ### Meta Selectors
 By default selectors in NGXS are bound to a state. Sometimes you need the ability
 to join to un-related states in a high-performance re-usable fashion. A meta selector

--- a/packages/store/src/decorators/selector.ts
+++ b/packages/store/src/decorators/selector.ts
@@ -3,7 +3,7 @@ import { createSelector } from '../utils/selector-utils';
 /**
  * Decorator for memoizing a state selector.
  */
-export function Selector(selectors?: any[]) {
+export function Selector(selectors?: any[], skipContainerSelector: boolean = false) {
   return (target: any, methodName: string, descriptor: PropertyDescriptor) => {
     if (descriptor.value !== null) {
       const originalFn = descriptor.value;
@@ -11,7 +11,9 @@ export function Selector(selectors?: any[]) {
       const memoizedFn = createSelector(
         selectors,
         originalFn.bind(target),
-        { containerClass: target, selectorName: methodName }
+        skipContainerSelector
+          ? undefined
+          : { containerClass: target, selectorName: methodName }
       );
 
       return {

--- a/packages/store/tests/selector.spec.ts
+++ b/packages/store/tests/selector.spec.ts
@@ -37,6 +37,11 @@ describe('Selector', () => {
     static fooBar(myState2: any, foo: any) {
       return foo + myState2.bar;
     }
+
+    @Selector([MyState2.foo], true)
+    static fooOnly(foo: any) {
+      return foo;
+    }
   }
 
   class MetaSelector {
@@ -96,6 +101,16 @@ describe('Selector', () => {
       const store: Store = TestBed.get(Store);
       const slice = store.selectSnapshot(MyState2.fooBar);
       expect(slice).toBe('HelloHelloWorld');
+    }));
+
+    it('should select only specified', async(() => {
+      TestBed.configureTestingModule({
+        imports: [NgxsModule.forRoot([MyState, MyState2])]
+      });
+
+      const store: Store = TestBed.get(Store);
+      const slice = store.selectSnapshot(MyState2.fooOnly);
+      expect(slice).toBe('HelloHello');
     }));
 
     it('context should be defined inside selector', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

By default, the `Selector` decorator always inject the container state class as its first parameter, causing unwanted update when selectors are chained.

Here's an example use case:
```ts
@Selector()
static items(state: ItemStateModel): Item[] {  return state.items;  }

@Selector([ItemState.items])
static filteredItems(_state: ItemStateModel, items: Item[]): Item[] { // ... (filter items) }

@Selector([ItemState.filteredItems])
static sortedItems(_state: ItemStateModel, filteredItems: Item[]): Item[] { //  ... (sort filtered items)  }
```
There is actually no way to get rid of `_state: ItemStateModel` injection while keeping these selectors in the `ItemState` class. Worse, it degrades performance as all these 3 selectors gets recomputed when any of the properties on the `ItemState` changes.

Issue Number: N/A


## What is the new behavior?

This PR introduces a second argument to the `Selector` decorator, allowing to skip injection of container class, allowing desired behavior:
```ts
@Selector()
static items(state: ItemStateModel): Item[] {  return state.items;  }

@Selector([ItemState.items], true)
static filteredItems(items: Item[]): Item[] { // ... (filter items) }

@Selector([ItemState.filteredItems], true)
static sortedItems(filteredItems: Item[]): Item[] { //  ... (sort filtered items)  }
```
Now `filteredItems` and `sortedItems` only gets recomputed if `items` and `filteredItems` change respectively, not on any state property change.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Let me know if you prefer to change the boolean parameter by an explicit parameter object like `{ skipContainerInjection: true }`