### PR TITLE
fix(hmr): add default behaviour and trim down hmr interfaces

### DIFF
--- a/docs/plugins/hmr.md
+++ b/docs/plugins/hmr.md
@@ -124,7 +124,7 @@ if (environment.hmr) {
 }
 ```
 
-### Update src/app/app.module.ts to manage the state in HMR lifecycle:
+### (OPTIONAL) Update src/app/app.module.ts to manage the state in HMR lifecycle:
 
 ```ts
 import { StateContext } from '@ngxs/store';

--- a/packages/hmr-plugin/src/hmr-bootstrap.ts
+++ b/packages/hmr-plugin/src/hmr-bootstrap.ts
@@ -6,12 +6,13 @@ import {
   WebpackModule
 } from './symbols';
 import { HmrManager } from './hmr-manager';
+import { NgModuleRef } from '@angular/core';
 
-export async function hmr<T extends NgxsHmrLifeCycle<S>, S = NgxsHmrSnapshot>(
+export async function hmr<T extends Partial<NgxsHmrLifeCycle<S>>, S = NgxsHmrSnapshot>(
   module: WebpackModule,
   bootstrap: BootstrapModuleType<T>,
-  options: NgxsHmrOptions<T, S> = {}
-) {
+  options: NgxsHmrOptions = {}
+): Promise<NgModuleRef<T>> {
   const manager = new HmrManager<T, S>(module, options);
 
   module.hot.accept();

--- a/packages/hmr-plugin/src/hmr-bootstrap.ts
+++ b/packages/hmr-plugin/src/hmr-bootstrap.ts
@@ -1,23 +1,17 @@
-import {
-  NgxsHmrLifeCycle,
-  NgxsHmrOptions,
-  NgxsHmrSnapshot,
-  BootstrapModuleType,
-  WebpackModule
-} from './symbols';
+import { NgxsHmrOptions, BootstrapModuleFn, WebpackModule } from './symbols';
 import { HmrManager } from './hmr-manager';
 import { NgModuleRef } from '@angular/core';
 
-export async function hmr<T extends Partial<NgxsHmrLifeCycle<S>>, S = NgxsHmrSnapshot>(
+export async function hmr<T>(
   module: WebpackModule,
-  bootstrap: BootstrapModuleType<T>,
+  bootstrapFn: BootstrapModuleFn<T>,
   options: NgxsHmrOptions = {}
 ): Promise<NgModuleRef<T>> {
-  const manager = new HmrManager<T, S>(module, options);
+  const manager = new HmrManager<T>(module, options);
 
   module.hot.accept();
 
-  return await manager.hmrModule(bootstrap, () => {
+  return await manager.hmrModule(bootstrapFn, () => {
     manager.beforeModuleBootstrap();
 
     module.hot.dispose(async () => {

--- a/packages/hmr-plugin/src/hmr-manager.ts
+++ b/packages/hmr-plugin/src/hmr-manager.ts
@@ -3,7 +3,7 @@ import { createNewHosts, hmrModule } from '@angularclass/hmr';
 import { NgxsBootstrapper } from '@ngxs/store/internals';
 
 import {
-  BootstrapModuleType,
+  BootstrapModuleFn,
   NgxsHmrLifeCycle,
   NgxsHmrOptions,
   NgxsHmrSnapshot,
@@ -31,10 +31,10 @@ export class HmrManager<T extends Partial<NgxsHmrLifeCycle<S>>, S = NgxsHmrSnaps
   }
 
   public async hmrModule(
-    bootstrap: BootstrapModuleType<T>,
+    bootstrapFn: BootstrapModuleFn<T>,
     tick: () => void
   ): Promise<NgModuleRef<T>> {
-    this.ngModule = await bootstrap();
+    this.ngModule = await bootstrapFn();
     this.context = new HmrStateContextFactory(this.ngModule);
     this.lifecycle = this.createLifecycle();
 

--- a/packages/hmr-plugin/src/internal/hmr-options-builder.ts
+++ b/packages/hmr-plugin/src/internal/hmr-options-builder.ts
@@ -1,10 +1,10 @@
 import { NgxsHmrLifeCycle, NgxsHmrOptions } from '../symbols';
 
-export class HmrOptionBuilder<T extends NgxsHmrLifeCycle<S>, S> {
+export class HmrOptionBuilder {
   public readonly deferTime: number;
   public readonly autoClearLogs: boolean;
 
-  constructor({ deferTime, autoClearLogs }: NgxsHmrOptions<T, S>) {
+  constructor({ deferTime, autoClearLogs }: NgxsHmrOptions) {
     this.deferTime = deferTime || 100;
     this.autoClearLogs = autoClearLogs === undefined ? true : autoClearLogs;
   }

--- a/packages/hmr-plugin/src/public_api.ts
+++ b/packages/hmr-plugin/src/public_api.ts
@@ -1,4 +1,4 @@
-export { HmrInitAction } from './actions/hmr-init.action';
 export { NgxsHmrLifeCycle, NgxsHmrOptions, NgxsHmrSnapshot } from './symbols';
+export { HmrInitAction } from './actions/hmr-init.action';
 export { HmrBeforeDestroyAction } from './actions/hmr-before-destroy.action';
 export { hmr } from './hmr-bootstrap';

--- a/packages/hmr-plugin/src/symbols.ts
+++ b/packages/hmr-plugin/src/symbols.ts
@@ -25,7 +25,7 @@ export interface NgxsHmrLifeCycle<T = NgxsHmrSnapshot> {
 export type HmrCallback<T> = (ctx: StateContext<T>, state: Partial<T>) => void;
 export type BootstrapModuleType<T> = () => Promise<NgModuleRef<T>>;
 
-export interface NgxsHmrOptions<T extends NgxsHmrLifeCycle<S>, S = NgxsHmrSnapshot> {
+export interface NgxsHmrOptions {
   /**
    * @description
    * clear log after each hmr update

--- a/packages/hmr-plugin/src/symbols.ts
+++ b/packages/hmr-plugin/src/symbols.ts
@@ -23,7 +23,7 @@ export interface NgxsHmrLifeCycle<T = NgxsHmrSnapshot> {
 }
 
 export type HmrCallback<T> = (ctx: StateContext<T>, state: Partial<T>) => void;
-export type BootstrapModuleType<T> = () => Promise<NgModuleRef<T>>;
+export type BootstrapModuleFn<T> = () => Promise<NgModuleRef<T>>;
 
 export interface NgxsHmrOptions {
   /**

--- a/packages/hmr-plugin/src/tests/hmr-manager.spec.ts
+++ b/packages/hmr-plugin/src/tests/hmr-manager.spec.ts
@@ -7,7 +7,7 @@ import { Actions, ofActionDispatched, Store } from '@ngxs/store';
 import { Type } from '@angular/core';
 
 import { hmr } from '../hmr-bootstrap';
-import { BootstrapModuleFn, NGXS_HMR_SNAPSHOT_KEY, NgxsHmrSnapshot } from '../symbols';
+import { BootstrapModuleFn, NGXS_HMR_SNAPSHOT_KEY } from '../symbols';
 import {
   AppMockModule,
   MockState,

--- a/packages/hmr-plugin/src/tests/hmr-manager.spec.ts
+++ b/packages/hmr-plugin/src/tests/hmr-manager.spec.ts
@@ -1,110 +1,246 @@
-import { fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, getTestBed, TestBed, tick, flushMicrotasks } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
 import { Actions, ofActionDispatched, Store } from '@ngxs/store';
-import { NgModuleRef } from '@angular/core';
+import { Type } from '@angular/core';
 
 import { hmr } from '../hmr-bootstrap';
-import { BootstrapModuleType, NGXS_HMR_SNAPSHOT_KEY, NgxsHmrSnapshot } from '../symbols';
-import { AppMockModule, MockState, mockWebpackModule } from './hmr-mock';
+import { BootstrapModuleFn, NGXS_HMR_SNAPSHOT_KEY, NgxsHmrSnapshot } from '../symbols';
+import {
+  AppMockModule,
+  MockState,
+  mockWebpackModule,
+  AppMockModuleNoHmrLifeCycle
+} from './hmr-mock';
 import { HmrInitAction } from '../actions/hmr-init.action';
 import { HmrBeforeDestroyAction } from '../actions/hmr-before-destroy.action';
 
 describe('HMR Plugin', () => {
-  let bootstrap: BootstrapModuleType<AppMockModule>;
-  let hmrSnapshot: Partial<NgxsHmrSnapshot> | any = null;
-  let actions$: Actions;
-
-  beforeEach(() => {
+  function setup<T>(moduleType: Type<T>, options: { storedValue?: any } = {}) {
     TestBed.resetTestEnvironment();
     TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
-  });
-
-  beforeEach(() => {
-    bootstrap = () => getTestBed().platform.bootstrapModule(AppMockModule);
-    sessionStorage.setItem(NGXS_HMR_SNAPSHOT_KEY, '');
+    const bootstrap: BootstrapModuleFn<T> = () =>
+      getTestBed().platform.bootstrapModule(moduleType);
+    const storedValue = options.storedValue;
+    const storageValue = options.storedValue ? JSON.stringify(storedValue) : '';
+    sessionStorage.setItem(NGXS_HMR_SNAPSHOT_KEY, storageValue);
     MockState.clear();
-    hmrSnapshot = null;
-  });
+    return { bootstrap };
+  }
 
-  it('should be correct initialize AppMockModule', async () => {
+  async function setupAndRun<T>(moduleType: Type<T>, options: { storedValue?: any } = {}) {
+    const { bootstrap } = setup(moduleType, options);
+    const appModule = await hmr(mockWebpackModule, bootstrap);
+    const actions$ = appModule.injector.get<Actions>(Actions);
+    const store = appModule.injector.get<Store>(Store);
+    const getStoredValue = () =>
+      JSON.parse(sessionStorage.getItem(NGXS_HMR_SNAPSHOT_KEY) || '{}');
+    return { appModule, actions$, store, getStoredValue };
+  }
+
+  it('should initialize AppMockModule', async () => {
+    // Arrange
+    const { bootstrap } = setup(AppMockModule);
+    // Act
     const moduleRef = await (await bootstrap)();
+    // Assert
     expect(moduleRef.instance.constructor.name).toEqual('AppMockModule');
   });
 
-  it('should be correct bootstrap hmr module when empty snapshot', fakeAsync(async () => {
-    const appModule: NgModuleRef<AppMockModule> = await hmr(mockWebpackModule, bootstrap);
-    actions$ = appModule.injector.get(Actions);
-
+  it('should skip HmrInitAction when empty snapshot', fakeAsync(async () => {
+    // Arrange
+    const { actions$ } = await setupAndRun(AppMockModule);
+    let hmrSnapshot: any = 'No value init';
+    // Act
     actions$
       .pipe(ofActionDispatched(HmrInitAction))
       .subscribe(({ payload }) => (hmrSnapshot = payload));
 
     tick(1000);
-    expect(hmrSnapshot).toBeNull();
+    // Assert
+    expect(hmrSnapshot).toEqual('No value init');
   }));
 
-  it('should be correct invoke hmrNgxsStoreOnInit', fakeAsync(async () => {
-    sessionStorage.setItem(NGXS_HMR_SNAPSHOT_KEY, JSON.stringify({ works: true }));
-    const appModule: NgModuleRef<AppMockModule> = await hmr(mockWebpackModule, bootstrap);
-    actions$ = appModule.injector.get(Actions);
+  it('should dispatch HmrInitAction', fakeAsync(async () => {
+    // Arrange
+    const { actions$ } = await setupAndRun(AppMockModule, {
+      storedValue: { works: true }
+    });
+    let hmrSnapshot: any;
 
+    // Act
     actions$
       .pipe(ofActionDispatched(HmrInitAction))
       .subscribe(({ payload }) => (hmrSnapshot = payload));
 
+    flushMicrotasks();
     tick(1000);
 
+    // Assert
     expect(hmrSnapshot).toEqual({ works: true });
   }));
 
-  it('should be correct invoke hmrNgxsStoreBeforeOnDestroy', fakeAsync(async () => {
-    sessionStorage.setItem(NGXS_HMR_SNAPSHOT_KEY, JSON.stringify({ status: 'working' }));
-    const appModule: NgModuleRef<AppMockModule> = await hmr(mockWebpackModule, bootstrap);
+  it('should still dispatch HmrInitAction if hmrNgxsStoreOnInit not implemented', fakeAsync(async () => {
+    // Arrange
+    const { actions$ } = await setupAndRun(AppMockModuleNoHmrLifeCycle, {
+      storedValue: { works: true }
+    });
+    let hmrSnapshot: any;
 
-    const store = appModule.injector.get(Store);
-    actions$ = appModule.injector.get(Actions);
-
+    // Act
     actions$
       .pipe(ofActionDispatched(HmrInitAction))
       .subscribe(({ payload }) => (hmrSnapshot = payload));
 
     tick(1000);
+    // Assert
+    expect(hmrSnapshot).toEqual({ works: true });
+  }));
 
-    expect(hmrSnapshot).toEqual({ status: 'working' });
-    expect(store.snapshot()).toEqual({
-      mock_state: { value: 'test' },
-      status: 'working'
+  it('should dispatch HmrBeforeDestroyAction with store state by default', fakeAsync(async () => {
+    // Arrange
+    const { actions$ } = await setupAndRun(AppMockModuleNoHmrLifeCycle, {
+      storedValue: { status: 'working' }
     });
-
-    tick(1000);
-    hmrSnapshot = null;
-
+    tick(2000);
+    let hmrSnapshot: any;
     actions$
       .pipe(ofActionDispatched(HmrBeforeDestroyAction))
       .subscribe(({ payload }) => (hmrSnapshot = payload));
 
+    // Act
     await mockWebpackModule.destroyModule();
     tick(1000);
 
+    // Assert
     expect(hmrSnapshot).toEqual({
       mock_state: { value: 'test' },
       status: 'working'
     });
   }));
 
-  it('should be correct custom lifecycle', fakeAsync(async () => {
-    sessionStorage.setItem(NGXS_HMR_SNAPSHOT_KEY, JSON.stringify({ test: 'test' }));
-    await hmr(mockWebpackModule, bootstrap);
+  it('should dispatch HmrBeforeDestroyAction with custom state if present', fakeAsync(async () => {
+    // Arrange
+    const { actions$ } = await setupAndRun(AppMockModule, {
+      storedValue: { status: 'working' }
+    });
+    tick(2000);
+    let hmrSnapshot: any;
+    actions$
+      .pipe(ofActionDispatched(HmrBeforeDestroyAction))
+      .subscribe(({ payload }) => (hmrSnapshot = payload));
 
-    tick(1000);
-    expect(MockState.init).toEqual(true);
-
+    // Act
     await mockWebpackModule.destroyModule();
     tick(1000);
 
+    // Assert
+    expect(hmrSnapshot).toEqual({
+      mock_state: { value: 'test' },
+      status: 'working',
+      customOut: 'abc',
+      custom: 123
+    });
+  }));
+
+  it('should provide default state patch behaviour if hmrNgxsStoreOnInit not implemented', fakeAsync(async () => {
+    // Arrange
+    const { store } = await setupAndRun(AppMockModuleNoHmrLifeCycle, {
+      storedValue: { status: 'working' }
+    });
+
+    // Act
+    tick(1000);
+
+    // Assert
+    expect(store.snapshot()).toEqual({
+      mock_state: { value: 'test' },
+      status: 'working'
+    });
+  }));
+
+  it('should use custom hmrNgxsStoreOnInit to setup state', fakeAsync(async () => {
+    // Arrange
+    const { store } = await setupAndRun(AppMockModule, {
+      storedValue: { status: 'working' }
+    });
+
+    // Act
+    tick(1000);
+
+    // Assert
+    expect(store.snapshot()).toEqual({
+      mock_state: { value: 'test' },
+      status: 'working',
+      custom: 123
+    });
+  }));
+
+  it('should store all state by default when no hmrNgxsStoreBeforeOnDestroy implemented', fakeAsync(async () => {
+    // Arrange
+    const { getStoredValue } = await setupAndRun(AppMockModuleNoHmrLifeCycle, {
+      storedValue: { status: 'working' }
+    });
+    tick(2000);
+
+    // Act
+    await mockWebpackModule.destroyModule();
+    tick(1000);
+
+    // Assert
+    const storageValue = getStoredValue();
+    expect(storageValue).toEqual({
+      mock_state: { value: 'test' },
+      status: 'working'
+    });
+  }));
+
+  it('should store state provided by hmrNgxsStoreBeforeOnDestroy', fakeAsync(async () => {
+    // Arrange
+    const { getStoredValue } = await setupAndRun(AppMockModule, {
+      storedValue: { status: 'working' }
+    });
+    tick(2000);
+
+    // Act
+    await mockWebpackModule.destroyModule();
+    tick(1000);
+
+    // Assert
+    const storageValue = getStoredValue();
+    expect(storageValue).toEqual({
+      mock_state: { value: 'test' },
+      status: 'working',
+      custom: 123,
+      customOut: 'abc'
+    });
+  }));
+
+  it('should allow state to capture HmrInitAction lifecycle action', fakeAsync(async () => {
+    // Arrange
+    MockState.clear();
+    await setupAndRun(AppMockModule, {
+      storedValue: { test: 'test' }
+    });
+    // Act
+    tick(1000);
+    // Assert
+    expect(MockState.init).toEqual(true);
+  }));
+
+  it('should allow state to capture HmrBeforeDestroyAction lifecycle action', fakeAsync(async () => {
+    // Arrange
+    await setupAndRun(AppMockModule, {
+      storedValue: { test: 'test' }
+    });
+    MockState.clear();
+    tick(1000);
+    // Act
+    await mockWebpackModule.destroyModule();
+    tick(1000);
+    // Assert
     expect(MockState.destroy).toEqual(true);
   }));
 });

--- a/packages/hmr-plugin/src/tests/hmr-mock.ts
+++ b/packages/hmr-plugin/src/tests/hmr-mock.ts
@@ -55,11 +55,28 @@ export class AppMockModule implements NgxsHmrLifeCycle {
   }
 
   public hmrNgxsStoreOnInit(ctx: StateContext<Snapshot>, snapshot: Partial<Snapshot>) {
-    ctx.patchState(snapshot);
+    ctx.patchState({ ...snapshot, custom: 123 });
   }
 
   public hmrNgxsStoreBeforeOnDestroy(ctx: StateContext<Snapshot>): Partial<Snapshot> {
-    return ctx.getState();
+    return { ...ctx.getState(), customOut: 'abc' };
+  }
+}
+
+@Component({
+  selector: 'app-root',
+  template: ''
+})
+export class AppMockComponent2 {}
+
+@NgModule({
+  imports: [BrowserModule, NgxsModule.forRoot([MockState])],
+  declarations: [AppMockComponent2],
+  bootstrap: [AppMockComponent2]
+})
+export class AppMockModuleNoHmrLifeCycle {
+  constructor() {
+    createRootNode();
   }
 }
 

--- a/packages/store/tests/zone.spec.ts
+++ b/packages/store/tests/zone.spec.ts
@@ -189,7 +189,6 @@ describe('zone', () => {
     const store: Store = TestBed.get(Store);
     const ngZone: NgZone = TestBed.get(NgZone);
     ngZone.run(() => {
-      console.log({ isInAngularZone: NgZone.isInAngularZone() });
       store.dispatch(new FooAction());
     });
   });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A
Many of the hmr plugin interfaces had type parameters that were not necessary and were left over from earlier development on the plugin. These were making the interfaces confusing.

Also, if the `NgxsHmrLifeCycle` was not implemented by the `AppModule` then hmr would not persist or load anything.

## What is the new behavior?

Trimmed down interfaces.
Added default behaviour if the `NgxsHmrLifeCycle` was not implemented by the `AppModule`.
The plugin will now persist and load the entire state by default.

Also cleaned up tests quite drastically to follow the AAA unit test syntax and to test the new default behaviour.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
