### PR TITLE
fix(form-plugin): respect store value of 'dirty' flag (#861)

### DIFF
--- a/packages/form-plugin/src/directive.ts
+++ b/packages/form-plugin/src/directive.ts
@@ -41,6 +41,20 @@ export class FormDirective implements OnInit, OnDestroy {
       this._cd.markForCheck();
     });
 
+    this.getStateStream(`${this.path}.dirty`).subscribe(dirty => {
+      if (this.form.dirty === dirty || typeof dirty !== 'boolean') {
+        return;
+      }
+
+      if (dirty) {
+        this.form.markAsDirty();
+      } else {
+        this.form.markAsPristine();
+      }
+
+      this._cd.markForCheck();
+    });
+
     // On first state change, sync form model, status and dirty with state
     this._store
       .selectOnce(state => getValue(state, this.path))
@@ -60,20 +74,6 @@ export class FormDirective implements OnInit, OnDestroy {
           })
         ]);
       });
-
-    this.getStateStream(`${this.path}.dirty`).subscribe(dirty => {
-      if (this.form.dirty === dirty || typeof dirty !== 'boolean') {
-        return;
-      }
-
-      if (dirty) {
-        this.form.markAsDirty();
-      } else {
-        this.form.markAsPristine();
-      }
-
-      this._cd.markForCheck();
-    });
 
     this.getStateStream(`${this.path}.disabled`).subscribe(disabled => {
       if (this.form.disabled === disabled || typeof disabled !== 'boolean') {

--- a/packages/form-plugin/tests/form.plugin.spec.ts
+++ b/packages/form-plugin/tests/form.plugin.spec.ts
@@ -198,7 +198,8 @@ describe('NgxsFormPlugin', () => {
           todosForm: {
             model: {
               text: 'Buy some coffee'
-            }
+            },
+            dirty: true
           }
         }
       })
@@ -231,6 +232,7 @@ describe('NgxsFormPlugin', () => {
       fixture.detectChanges();
 
       const input = fixture.debugElement.query(By.css('form input')).nativeElement;
+      expect(fixture.componentInstance.form.dirty).toBe(true);
       expect(input.value).toBe('Buy some coffee');
     });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #861


## What is the new behavior?

The FormGroup value of the 'dirty' flag is now equal to the store value on first rendering. Switching the order of the subscriptions around in ngOnInit of the ngxsForm directive ensures that the current store value is reflected in the FormGroup before the actions that update the store are dispatched.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

