### PR TITLE
fix(logger): print action properties

### DIFF
--- a/packages/logger-plugin/src/logger.plugin.ts
+++ b/packages/logger-plugin/src/logger.plugin.ts
@@ -35,8 +35,9 @@ export class NgxsLoggerPlugin implements NgxsPlugin {
       console.log(message);
     }
 
-    if (typeof event.payload !== 'undefined') {
-      this.log('payload', 'color: #9E9E9E; font-weight: bold', event.payload);
+    // print payload only if at least one property is supplied
+    if (this._hasPayload(event)) {
+      this.log('payload', 'color: #9E9E9E; font-weight: bold', { ...event });
     }
 
     this.log('prev state', 'color: #9E9E9E; font-weight: bold', state);
@@ -86,5 +87,11 @@ export class NgxsLoggerPlugin implements NgxsPlugin {
     }
 
     return ms_ie;
+  }
+
+  private _hasPayload(event: any) {
+    const nonEmptyProperties = Object.entries(event).filter(([, value]) => !!value);
+
+    return nonEmptyProperties.length > 0;
   }
 }

--- a/packages/logger-plugin/tests/helpers/utils.ts
+++ b/packages/logger-plugin/tests/helpers/utils.ts
@@ -4,7 +4,7 @@ export class FormatActionCallStackOptions {
   action: string;
   prevState: {};
   nextState?: {};
-  payload?: string;
+  payload?: any;
   error?: string;
   collapsed?: boolean;
 }

--- a/packages/logger-plugin/tests/logger.plugin.spec.ts
+++ b/packages/logger-plugin/tests/logger.plugin.spec.ts
@@ -15,7 +15,7 @@ describe('NgxsLoggerPlugin', () => {
   class UpdateBarAction {
     static type = 'UPDATE_BAR';
 
-    constructor(public payload?: string) {}
+    constructor(public bar?: string) {}
   }
 
   class ErrorAction {
@@ -36,8 +36,8 @@ describe('NgxsLoggerPlugin', () => {
   })
   class TestState {
     @Action(UpdateBarAction)
-    updateBar({ patchState }: StateContext<StateModel>, { payload }: UpdateBarAction) {
-      patchState({ bar: payload || defaultBarValue });
+    updateBar({ patchState }: StateContext<StateModel>, { bar }: UpdateBarAction) {
+      patchState({ bar: bar || defaultBarValue });
     }
 
     @Action(ErrorAction)
@@ -97,7 +97,7 @@ describe('NgxsLoggerPlugin', () => {
         action: UpdateBarAction.type,
         prevState: stateModelDefaults,
         nextState: { bar: payload },
-        payload
+        payload: { bar: payload }
       })
     ]);
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
```ts
export class AddTodo {
  public static type = 'AddTodo';
  constructor(public todo: Todo) {}
}
```
The logger doesn't print action's payload if there's no property called `payload`.
![image](https://user-images.githubusercontent.com/9721664/53592575-41208580-3b9f-11e9-817c-5133dbc957d6.png)

Issue Number: #871 


## What is the new behavior?
If the action has at least one property with a value, it will be printed to the console.
![image](https://user-images.githubusercontent.com/9721664/53592500-16363180-3b9f-11e9-8724-829618316e77.png)


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```