### PR TITLE
fix(router-plugin): add state selector with generic

### DIFF
--- a/packages/router-plugin/src/router.state.ts
+++ b/packages/router-plugin/src/router.state.ts
@@ -43,7 +43,7 @@ export class RouterState {
    */
 
   @Selector()
-  static state(state: RouterStateModel) {
+  static state<T = RouterStateSnapshot>(state: RouterStateModel<T>) {
     return state && state.state;
   }
 

--- a/packages/router-plugin/tests/router.plugin.spec.ts
+++ b/packages/router-plugin/tests/router.plugin.spec.ts
@@ -75,7 +75,7 @@ describe('NgxsRouterPlugin', () => {
     });
   }));
 
-  it('should select custom router state ', fakeAsync(async () => {
+  it('should select custom router state ', fakeAsync(() => {
     interface RouterStateParams {
       url: string;
       queryParams: Params;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: #893 

## What is the new behavior?

Now is possible to select the router state correctly typed when using the `state` selector like this:

```
store
  .select(state => RouterState.state<RouterStateParams>(state.router))
  .subscribe(routerState => {
    expect(routerState!.url).toEqual('/a-path?foo=bar');
    expect(routerState!.queryParams.foo).toEqual('bar');
  });
```


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
