### PR TITLE
fix(router-plugin): serialize after `ResolveEnd`

### DIFF
--- a/integration/app/list/list.component.html
+++ b/integration/app/list/list.component.html
@@ -2,3 +2,7 @@
   {{ list$ | async }},
   {{ foo | async }}
 </div>
+
+<div *ngIf="router$ | async as router">
+  animals were resolved {{ router.state.root.data.list }}
+</div>

--- a/integration/app/list/list.component.html
+++ b/integration/app/list/list.component.html
@@ -4,5 +4,5 @@
 </div>
 
 <div *ngIf="router$ | async as router">
-  animals were resolved {{ router.root.firstChild.data.list }}
+  animals were resolved {{ router.root.firstChild.firstChild.data.list }}
 </div>

--- a/integration/app/list/list.component.html
+++ b/integration/app/list/list.component.html
@@ -4,5 +4,5 @@
 </div>
 
 <div *ngIf="router$ | async as router">
-  animals were resolved {{ router.state.root.data.list }}
+  animals were resolved {{ router.root.firstChild.data.list }}
 </div>

--- a/integration/app/list/list.component.ts
+++ b/integration/app/list/list.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { Select } from '@ngxs/store';
+import { RouterState } from '@ngxs/router-plugin';
 import { Observable } from 'rxjs';
 
 import { ListState } from '@integration/list/list.state';
@@ -11,4 +12,5 @@ import { ListState } from '@integration/list/list.state';
 export class ListComponent {
   @Select(ListState) public list$: Observable<string[]>;
   @Select(ListState.hello) public foo: Observable<string>;
+  @Select(RouterState) public router$: Observable<RouterState>;
 }

--- a/integration/app/list/list.component.ts
+++ b/integration/app/list/list.component.ts
@@ -12,5 +12,5 @@ import { ListState } from '@integration/list/list.state';
 export class ListComponent {
   @Select(ListState) public list$: Observable<string[]>;
   @Select(ListState.hello) public foo: Observable<string>;
-  @Select(RouterState) public router$: Observable<RouterState>;
+  @Select(RouterState.state) public router$: Observable<RouterState>;
 }

--- a/integration/app/list/list.module.ts
+++ b/integration/app/list/list.module.ts
@@ -6,9 +6,11 @@ import { NgxsModule } from '@ngxs/store';
 import { ListState } from '@integration/list/list.state';
 import { ListComponent } from '@integration/list/list.component';
 import { routes } from '@integration/list/list.routes';
+import { ListResolver } from '@integration/list/list.resolver';
 
 @NgModule({
   imports: [CommonModule, RouterModule.forChild(routes), NgxsModule.forFeature([ListState])],
-  declarations: [ListComponent]
+  declarations: [ListComponent],
+  providers: [ListResolver]
 })
 export class ListModule {}

--- a/integration/app/list/list.resolver.ts
+++ b/integration/app/list/list.resolver.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@angular/core';
+import { Resolve } from '@angular/router';
+
+@Injectable()
+export class ListResolver implements Resolve<string[]> {
+  public async resolve(): Promise<string[]> {
+    return ['zebras', 'pandas', 'lions', 'giraffes'];
+  }
+}

--- a/integration/app/list/list.routes.ts
+++ b/integration/app/list/list.routes.ts
@@ -1,9 +1,13 @@
 import { Routes } from '@angular/router';
 import { ListComponent } from '@integration/list/list.component';
+import { ListResolver } from '@integration/list/list.resolver';
 
 export const routes: Routes = [
   {
     path: '',
-    component: ListComponent
+    component: ListComponent,
+    resolve: {
+      list: ListResolver
+    }
   }
 ];

--- a/integration/app/store/store.module.ts
+++ b/integration/app/store/store.module.ts
@@ -4,6 +4,7 @@ import { CommonModule } from '@angular/common';
 import { NgxsFormPluginModule } from '@ngxs/form-plugin';
 import { NgxsLoggerPluginModule } from '@ngxs/logger-plugin';
 import { NgxsReduxDevtoolsPluginModule } from '@ngxs/devtools-plugin';
+import { NgxsRouterPluginModule } from '@ngxs/router-plugin';
 
 import { environment as env } from '@integration/env/environment';
 import { TodosState } from '@integration/store/todos/todos.state';
@@ -15,6 +16,7 @@ import { TodoState } from '@integration/store/todos/todo/todo.state';
     NgxsFormPluginModule.forRoot(),
     NgxsLoggerPluginModule.forRoot({ logger: console, collapsed: false }),
     NgxsReduxDevtoolsPluginModule.forRoot({ disabled: env.production }),
+    NgxsRouterPluginModule.forRoot(),
     NgxsModule.forRoot([TodosState, TodoState], { developmentMode: !env.production })
   ],
   exports: [

--- a/integration/tests-ssr/todo.mocha.ts
+++ b/integration/tests-ssr/todo.mocha.ts
@@ -35,7 +35,6 @@ describe('NGXS + SSR', () => {
 
   it('should successfully resolve list of animals', async () => {
     body = await request('http://localhost:4000/list');
-    console.log('body here bro: ', body);
     const animalsWereResolvedIndex = body.indexOf('animals were resolved');
     const resolvedAnimalsIndex = body.indexOf('zebras,pandas,lions,giraffes');
     expect(animalsWereResolvedIndex).to.be.greaterThan(-1);

--- a/integration/tests-ssr/todo.mocha.ts
+++ b/integration/tests-ssr/todo.mocha.ts
@@ -33,7 +33,7 @@ describe('NGXS + SSR', () => {
     });
   });
 
-  it('should resolve list of numbers', async () => {
+  it('should successfully resolve list of animals', async () => {
     body = await request('http://localhost:4000/list');
     console.log('body here bro: ', body);
     const animalsWereResolvedIndex = body.indexOf('animals were resolved');

--- a/integration/tests-ssr/todo.mocha.ts
+++ b/integration/tests-ssr/todo.mocha.ts
@@ -32,4 +32,13 @@ describe('NGXS + SSR', () => {
       }
     });
   });
+
+  it('should resolve list of numbers', async () => {
+    body = await request('http://localhost:4000/list');
+    console.log('body here bro: ', body);
+    const animalsWereResolvedIndex = body.indexOf('animals were resolved');
+    const resolvedAnimalsIndex = body.indexOf('zebras,pandas,lions,giraffes');
+    expect(animalsWereResolvedIndex).to.be.greaterThan(-1);
+    expect(resolvedAnimalsIndex).to.be.greaterThan(-1);
+  });
 });

--- a/packages/router-plugin/src/router.module.ts
+++ b/packages/router-plugin/src/router.module.ts
@@ -15,8 +15,7 @@ import { RouterState } from './router.state';
 export class NgxsRouterPluginModule {
   static forRoot(): ModuleWithProviders {
     return {
-      ngModule: NgxsRouterPluginModule,
-      providers: []
+      ngModule: NgxsRouterPluginModule
     };
   }
 }

--- a/packages/router-plugin/src/router.state.ts
+++ b/packages/router-plugin/src/router.state.ts
@@ -116,7 +116,9 @@ export class RouterState {
     }
 
     this.routerStateSnapshot = this._serializer.serialize(snapshot);
-    if (this.shouldDispatchRouterNavigation()) this.dispatchRouterNavigation();
+    if (this.shouldDispatchRouterNavigation()) {
+      this.dispatchRouterNavigation();
+    }
   }
 
   private shouldDispatchRouterNavigation(): boolean {

--- a/packages/router-plugin/src/router.state.ts
+++ b/packages/router-plugin/src/router.state.ts
@@ -5,8 +5,7 @@ import {
   Router,
   RouterStateSnapshot,
   RoutesRecognized,
-  ActivationEnd,
-  ActivatedRouteSnapshot
+  ResolveEnd
 } from '@angular/router';
 import { Action, Selector, State, StateContext, Store } from '@ngxs/store';
 
@@ -98,8 +97,8 @@ export class RouterState {
     this._router.events.subscribe(e => {
       if (e instanceof RoutesRecognized) {
         this.lastRoutesRecognized = e;
-      } else if (e instanceof ActivationEnd) {
-        this.activationEnd(e.snapshot);
+      } else if (e instanceof ResolveEnd) {
+        this.resolveEnd(e.state);
       } else if (e instanceof NavigationCancel) {
         this.dispatchRouterCancel(e);
       } else if (e instanceof NavigationError) {
@@ -108,14 +107,12 @@ export class RouterState {
     });
   }
 
-  private activationEnd(snapshot: ActivatedRouteSnapshot): void {
-    // `component` property equals `null` if this snapshot is empty
-    // and was created for the root component
-    if (snapshot.component === null) {
-      return;
-    }
-
-    this.routerStateSnapshot = this._serializer.serialize(snapshot);
+  /**
+   * The `ResolveEnd` event is always triggered after running all resolvers
+   * that are linked to some route and child routes
+   */
+  private resolveEnd(routerStateSnapshot: RouterStateSnapshot): void {
+    this.routerStateSnapshot = this._serializer.serialize(routerStateSnapshot);
     if (this.shouldDispatchRouterNavigation()) {
       this.dispatchRouterNavigation();
     }

--- a/packages/router-plugin/src/router.state.ts
+++ b/packages/router-plugin/src/router.state.ts
@@ -111,7 +111,7 @@ export class RouterState {
   private activationEnd(snapshot: ActivatedRouteSnapshot): void {
     // `component` property equals `null` if this snapshot is empty
     // and was created for the root component
-    if (!snapshot.component) {
+    if (snapshot.component === null) {
       return;
     }
 

--- a/packages/router-plugin/src/serializer.ts
+++ b/packages/router-plugin/src/serializer.ts
@@ -1,7 +1,7 @@
 import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 
 export abstract class RouterStateSerializer<T> {
-  abstract serialize(routerState: RouterStateSnapshot): T;
+  abstract serialize(snapshot: ActivatedRouteSnapshot): T;
 }
 
 export interface SerializedRouterStateSnapshot {
@@ -11,10 +11,10 @@ export interface SerializedRouterStateSnapshot {
 
 export class DefaultRouterStateSerializer
   implements RouterStateSerializer<SerializedRouterStateSnapshot> {
-  serialize(routerState: RouterStateSnapshot): SerializedRouterStateSnapshot {
+  serialize(snapshot: ActivatedRouteSnapshot): SerializedRouterStateSnapshot {
     return {
-      root: this.serializeRoute(routerState.root),
-      url: routerState.url
+      root: this.serializeRoute(snapshot),
+      url: this.getRouterStateSnapshot(snapshot).url
     };
   }
 
@@ -38,5 +38,12 @@ export class DefaultRouterStateSerializer
       queryParamMap: route.queryParamMap,
       toString: route.toString
     };
+  }
+
+  /**
+   * `_routerState` is a private property but always exists
+   */
+  private getRouterStateSnapshot(snapshot: any): RouterStateSnapshot {
+    return snapshot._routerState;
   }
 }

--- a/packages/router-plugin/src/serializer.ts
+++ b/packages/router-plugin/src/serializer.ts
@@ -1,7 +1,7 @@
 import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 
 export abstract class RouterStateSerializer<T> {
-  abstract serialize(snapshot: ActivatedRouteSnapshot): T;
+  abstract serialize(routerState: RouterStateSnapshot): T;
 }
 
 export interface SerializedRouterStateSnapshot {
@@ -11,10 +11,10 @@ export interface SerializedRouterStateSnapshot {
 
 export class DefaultRouterStateSerializer
   implements RouterStateSerializer<SerializedRouterStateSnapshot> {
-  serialize(snapshot: ActivatedRouteSnapshot): SerializedRouterStateSnapshot {
+  serialize(routerState: RouterStateSnapshot): SerializedRouterStateSnapshot {
     return {
-      root: this.serializeRoute(snapshot),
-      url: this.getRouterStateSnapshot(snapshot).url
+      root: this.serializeRoute(routerState.root),
+      url: routerState.url
     };
   }
 
@@ -38,12 +38,5 @@ export class DefaultRouterStateSerializer
       queryParamMap: route.queryParamMap,
       toString: route.toString
     };
-  }
-
-  /**
-   * `_routerState` is a private property but always exists
-   */
-  private getRouterStateSnapshot(snapshot: any): RouterStateSnapshot {
-    return snapshot._routerState;
   }
 }

--- a/packages/router-plugin/tests/router.plugin.spec.ts
+++ b/packages/router-plugin/tests/router.plugin.spec.ts
@@ -90,9 +90,7 @@ function createTestModule(
     selector: 'pagea-cmp',
     template: 'pagea-cmp'
   })
-  class SimpleCmp {
-    constructor(public route: ActivatedRoute) {}
-  }
+  class SimpleCmp {}
 
   TestBed.configureTestingModule({
     declarations: [AppCmp, SimpleCmp],

--- a/packages/router-plugin/tests/router.plugin.spec.ts
+++ b/packages/router-plugin/tests/router.plugin.spec.ts
@@ -1,6 +1,6 @@
 import { Component, Provider } from '@angular/core';
 import { async, fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { Router, ActivatedRoute } from '@angular/router';
+import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { NgxsModule, Store } from '@ngxs/store';

--- a/packages/router-plugin/tests/router.plugin.spec.ts
+++ b/packages/router-plugin/tests/router.plugin.spec.ts
@@ -1,11 +1,10 @@
 import { Component, Provider } from '@angular/core';
 import { async, fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { Router } from '@angular/router';
+import { Router, ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { NgxsModule, Store } from '@ngxs/store';
-import { NgxsRouterPluginModule, RouterState } from '../';
-import { Navigate } from '@ngxs/router-plugin/src/router.actions';
+import { NgxsRouterPluginModule, RouterState, Navigate } from '../';
 
 describe('NgxsRouterPlugin', () => {
   it('should dispatch router state events', async(async () => {
@@ -21,27 +20,25 @@ describe('NgxsRouterPlugin', () => {
       { type: 'url', state: undefined }, // init event. has nothing to do with the router
       { type: 'router', event: 'NavigationStart', url: '/' },
       { type: 'router', event: 'RoutesRecognized', url: '/' },
-      { type: 'url', state: '/' }, // RouterNavigation event in the store
       { type: 'router', event: 'GuardsCheckStart', url: '/' },
       { type: 'router', event: 'GuardsCheckEnd', url: '/' },
       { type: 'router', event: 'ResolveStart', url: '/' },
       { type: 'router', event: 'ResolveEnd', url: '/' },
-
+      { type: 'url', state: '/' }, // RouterNavigation event in the store
       { type: 'router', event: 'NavigationEnd', url: '/' }
     ]);
 
     log.splice(0);
-    await router.navigateByUrl('next');
+    await router.navigateByUrl('/next');
 
     expect(log).toEqual([
       { type: 'router', event: 'NavigationStart', url: '/next' },
       { type: 'router', event: 'RoutesRecognized', url: '/next' },
-      { type: 'url', state: '/next' },
       { type: 'router', event: 'GuardsCheckStart', url: '/next' },
       { type: 'router', event: 'GuardsCheckEnd', url: '/next' },
       { type: 'router', event: 'ResolveStart', url: '/next' },
       { type: 'router', event: 'ResolveEnd', url: '/next' },
-
+      { type: 'url', state: '/next' },
       { type: 'router', event: 'NavigationEnd', url: '/next' }
     ]);
   }));
@@ -93,7 +90,9 @@ function createTestModule(
     selector: 'pagea-cmp',
     template: 'pagea-cmp'
   })
-  class SimpleCmp {}
+  class SimpleCmp {
+    constructor(public route: ActivatedRoute) {}
+  }
 
   TestBed.configureTestingModule({
     declarations: [AppCmp, SimpleCmp],

--- a/packages/router-plugin/tests/router.plugin.spec.ts
+++ b/packages/router-plugin/tests/router.plugin.spec.ts
@@ -23,8 +23,8 @@ describe('NgxsRouterPlugin', () => {
       { type: 'router', event: 'GuardsCheckStart', url: '/' },
       { type: 'router', event: 'GuardsCheckEnd', url: '/' },
       { type: 'router', event: 'ResolveStart', url: '/' },
-      { type: 'router', event: 'ResolveEnd', url: '/' },
       { type: 'url', state: '/' }, // RouterNavigation event in the store
+      { type: 'router', event: 'ResolveEnd', url: '/' },
       { type: 'router', event: 'NavigationEnd', url: '/' }
     ]);
 
@@ -37,8 +37,8 @@ describe('NgxsRouterPlugin', () => {
       { type: 'router', event: 'GuardsCheckStart', url: '/next' },
       { type: 'router', event: 'GuardsCheckEnd', url: '/next' },
       { type: 'router', event: 'ResolveStart', url: '/next' },
-      { type: 'router', event: 'ResolveEnd', url: '/next' },
       { type: 'url', state: '/next' },
+      { type: 'router', event: 'ResolveEnd', url: '/next' },
       { type: 'router', event: 'NavigationEnd', url: '/next' }
     ]);
   }));


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Issue Number: #481 


## What is the new behavior?
Right now `serialize` is triggered in the `beforePreactivation` hook. Before preactivation is handled before running guards and resolvers. I've moved it to the `ResolveEnd` hook

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```