### PR TITLE
fix(store): initial state should not be overwritten by defaults

### DIFF
--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -18,7 +18,11 @@ export class Store {
     private _config: NgxsConfig,
     private _internalExecutionStrategy: InternalNgxsExecutionStrategy
   ) {
-    this._stateStream.next(this._config.defaultsState);
+    const value = this._stateStream.value;
+    if (!value || Object.keys(value).length === 0) {
+      // Only set the defaults if the state stream is empty.
+      this._stateStream.next(this._config.defaultsState);
+    }
   }
 
   /**

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -9,6 +9,7 @@ import { StateStream } from './internal/state-stream';
 import { NgxsConfig } from './symbols';
 import { InternalNgxsExecutionStrategy } from './execution/internal-ngxs-execution-strategy';
 import { leaveNgxs } from './operators/leave-ngxs';
+import { ObjectKeyMap } from './internal/internals';
 
 @Injectable()
 export class Store {
@@ -18,9 +19,9 @@ export class Store {
     private _config: NgxsConfig,
     private _internalExecutionStrategy: InternalNgxsExecutionStrategy
   ) {
-    const value = this._stateStream.value;
-    if (!value || Object.keys(value).length === 0) {
-      // Only set the defaults if the state stream is empty.
+    const value: ObjectKeyMap<any> = this._stateStream.value;
+    const storeIsEmpty: boolean = !value || Object.keys(value).length === 0;
+    if (storeIsEmpty) {
       this._stateStream.next(this._config.defaultsState);
     }
   }

--- a/packages/store/tests/default-states.spec.ts
+++ b/packages/store/tests/default-states.spec.ts
@@ -5,8 +5,6 @@ import { Action, NgxsModule, State, StateContext, Store } from '../src/public_ap
 import { StateStream } from '../src/internal/state-stream';
 
 describe('Reusable States', () => {
-  let store: Store;
-
   class UpdateFoo {
     static readonly type = '[update] foo';
     constructor(public payload: number) {}
@@ -34,7 +32,7 @@ describe('Reusable States', () => {
       ]
     });
 
-    store = TestBed.get(Store);
+    const store = TestBed.get(Store);
 
     let stateValue = store.selectSnapshot(FooState);
     expect(stateValue).toEqual([4, 5, 6]);
@@ -71,10 +69,7 @@ describe('Reusable States', () => {
       ]
     });
 
-    // const stateStream: StateStream = TestBed.get(StateStream);
-    // stateStream.next({ foo: [1, 2, 3] });
-
-    store = TestBed.get(Store);
+    const store = TestBed.get(Store);
 
     let stateValue = store.selectSnapshot(FooState);
     expect(stateValue).toEqual([1, 2, 3]);
@@ -99,7 +94,7 @@ describe('Reusable States', () => {
       ]
     });
 
-    store = TestBed.get(Store);
+    const store = TestBed.get(Store);
 
     expect(store.snapshot()).toEqual({
       configState: { a: 1, b: 2 },


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #902
There was a regression caused by PR #791 in this line: 
https://github.com/ngxs/store/pull/791/files#diff-084c7b85b6562e3126b58451d5f8943aR20

This only affects Emitter plugin users. This is because of the way that Emitter inherits from Store to create an EmitStore. I found the point at which the state was being overwritten. See this stackblitz:
https://stackblitz.com/edit/ngxs-no-initial-state-debug

Ngxs does not expect a plugin to inherit from Store and essentially run this code twice. Emitter does some things with Ngxs internals that are not usual plugin behaviours.

## What is the new behavior?

This code is now protected from being run twice. The default values are only written into the store if there is no current value in the store.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

