### PR TITLE
fix(hmr-plugin): incorrect destruction of modules in hmr

### DIFF
--- a/docs/plugins/hmr.md
+++ b/docs/plugins/hmr.md
@@ -101,16 +101,18 @@ Update src/main.ts to use the file we just created:
 ```ts
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-import { hmr } from '@ngxs/hmr-plugin';
+import { BootstrapModuleFn as Bootstrap, hmr, WebpackModule } from '@ngxs/hmr-plugin';
 
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
+
+declare const module: WebpackModule;
 
 if (environment.production) {
   enableProdMode();
 }
 
-const bootstrap = () => platformBrowserDynamic().bootstrapModule(AppModule);
+const bootstrap: Bootstrap = () => platformBrowserDynamic().bootstrapModule(AppModule);
 
 if (environment.hmr) {
   hmr(module, bootstrap).catch(err => console.error(err));

--- a/docs/plugins/hmr.md
+++ b/docs/plugins/hmr.md
@@ -113,12 +113,7 @@ if (environment.production) {
 const bootstrap = () => platformBrowserDynamic().bootstrapModule(AppModule);
 
 if (environment.hmr) {
-  if (module['hot']) {
-    hmr(module, bootstrap).catch(err => console.error(err));
-  } else {
-    console.error('HMR is not enabled for webpack-dev-server!');
-    console.log('Are you using the --hmr flag for ng serve?');
-  }
+  hmr(module, bootstrap).catch(err => console.error(err));
 } else {
   bootstrap().catch(err => console.log(err));
 }

--- a/integrations/hello-world-ng5/src/main.ts
+++ b/integrations/hello-world-ng5/src/main.ts
@@ -1,6 +1,6 @@
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-import { BootstrapModuleFn, hmr, WebpackModule } from '@ngxs/hmr-plugin';
+import { BootstrapModuleFn as Bootstrap, hmr, WebpackModule } from '@ngxs/hmr-plugin';
 
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
@@ -11,7 +11,7 @@ if (environment.production) {
   enableProdMode();
 }
 
-const bootstrap: BootstrapModuleFn = () => platformBrowserDynamic().bootstrapModule(AppModule);
+const bootstrap: Bootstrap = () => platformBrowserDynamic().bootstrapModule(AppModule);
 
 if (environment.hmr) {
   hmr(module, bootstrap).catch(err => console.error(err));

--- a/integrations/hello-world-ng5/src/main.ts
+++ b/integrations/hello-world-ng5/src/main.ts
@@ -14,12 +14,7 @@ if (environment.production) {
 const bootstrap: BootstrapModuleFn = () => platformBrowserDynamic().bootstrapModule(AppModule);
 
 if (environment.hmr) {
-  if (module['hot']) {
-    hmr(module, bootstrap).catch(err => console.error(err));
-  } else {
-    console.error('HMR is not enabled for webpack-dev-server!');
-    console.log('Are you using the --hmr flag for ng serve?');
-  }
+  hmr(module, bootstrap).catch(err => console.error(err));
 } else {
   bootstrap().catch(err => console.log(err));
 }

--- a/packages/hmr-plugin/src/hmr-bootstrap.ts
+++ b/packages/hmr-plugin/src/hmr-bootstrap.ts
@@ -1,15 +1,18 @@
-import { NgxsHmrOptions, BootstrapModuleFn, WebpackModule } from './symbols';
-import { HmrManager } from './hmr-manager';
 import { NgModuleRef } from '@angular/core';
+import { HmrManager } from './hmr-manager';
+import { BootstrapModuleFn, NgxsHmrOptions, WebpackModule } from './symbols';
 
 export async function hmr<T>(
   module: WebpackModule,
   bootstrapFn: BootstrapModuleFn<T>,
   options: NgxsHmrOptions = {}
 ): Promise<NgModuleRef<T>> {
-  const manager = new HmrManager<T>(module, options);
+  if (!module.hot) {
+    console.error('Are you using the --hmr flag for ng serve?');
+    throw new Error('HMR is not enabled for webpack-dev-server!');
+  }
 
-  module.hot.accept();
+  const manager = new HmrManager<T>(module, options);
 
   return await manager.hmrModule(bootstrapFn, () => {
     manager.beforeModuleBootstrap();

--- a/packages/hmr-plugin/src/tests/hmr-helpers.ts
+++ b/packages/hmr-plugin/src/tests/hmr-helpers.ts
@@ -1,0 +1,34 @@
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting
+} from '@angular/platform-browser-dynamic/testing';
+import { getTestBed, TestBed } from '@angular/core/testing';
+import { Type } from '@angular/core';
+
+import { Actions, Store } from '../../../store/src/public_api';
+import { MockState, WebpackMockModule } from './hmr-mock';
+import { BootstrapModuleFn, hmr } from '../public_api';
+import { NGXS_HMR_SNAPSHOT_KEY } from '../symbols';
+
+export function setup<T>(moduleType: Type<T>, options: { storedValue?: any } = {}) {
+  TestBed.resetTestEnvironment();
+  TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
+  const bootstrap: BootstrapModuleFn<T> = () =>
+    getTestBed().platform.bootstrapModule(moduleType);
+  const storedValue = options.storedValue;
+  const storageValue = options.storedValue ? JSON.stringify(storedValue) : '';
+  sessionStorage.setItem(NGXS_HMR_SNAPSHOT_KEY, storageValue);
+  MockState.clear();
+  return { bootstrap };
+}
+
+export async function hmrTestBed<T>(moduleType: Type<T>, options: { storedValue?: any } = {}) {
+  const { bootstrap } = setup(moduleType, options);
+  const webpackModule = new WebpackMockModule();
+  const appModule = await hmr(webpackModule, bootstrap);
+  const actions$ = appModule.injector.get<Actions>(Actions);
+  const store = appModule.injector.get<Store>(Store);
+  const getStoredValue = () =>
+    JSON.parse(sessionStorage.getItem(NGXS_HMR_SNAPSHOT_KEY) || '{}');
+  return { appModule, actions$, store, getStoredValue, webpackModule };
+}

--- a/packages/hmr-plugin/src/tests/hmr-mock.ts
+++ b/packages/hmr-plugin/src/tests/hmr-mock.ts
@@ -8,7 +8,7 @@ import { Action, NgxsModule, State, StateContext } from '@ngxs/store';
 import { TestBed } from '@angular/core/testing';
 import { DOCUMENT } from '@angular/common';
 
-import { NgxsHmrLifeCycle, NgxsHmrSnapshot as Snapshot, WebpackModule } from '../symbols';
+import { NgxsHmrLifeCycle, NgxsHmrSnapshot as Snapshot } from '../symbols';
 import { HmrInitAction } from '../actions/hmr-init.action';
 import { HmrBeforeDestroyAction } from '../actions/hmr-before-destroy.action';
 
@@ -94,18 +94,19 @@ function createRootNode(selector = 'app-root'): void {
   adapter.appendChild(document.body, root);
 }
 
-export interface ModuleDispose {
-  destroyModule: () => void;
-}
-
-export const mockWebpackModule: WebpackModule & ModuleDispose = {
-  destroyModule: null,
-  hot: {
-    accept: () => {},
+export class WebpackMockModule {
+  public acceptInvoked: boolean;
+  public disposeInvoked: boolean;
+  public destroyModule: () => void;
+  public hot = {
+    accept: () => {
+      this.acceptInvoked = true;
+    },
     dispose: (callback: () => void) => {
+      this.disposeInvoked = true;
       if (!callback.name) {
-        mockWebpackModule.destroyModule = callback;
+        this.destroyModule = callback;
       }
     }
-  }
-};
+  };
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

https://github.com/ngxs/store/issues/887


## What is the new behavior?

Webpack in new versions independently destroys modules for us


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
