### PR TITLE
revert: "feat(store): add state names to update state"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ $ npm install @ngxs/store@dev
 ```
 * Fix: HMR Plugin - incorrect destruction of modules in hmr [#908](https://github.com/ngxs/store/pull/908)
 * Fix: Logger Plugin - print action properties [#879](https://github.com/ngxs/store/pull/879)
-* Fix: Logger Plugin - print state names when update states [#845](https://github.com/ngxs/store/pull/845)
 
 # 3.4.2 2019-03-07
 * Fix: Expose `ActionType, ActionOptions` interfaces [#873](https://github.com/ngxs/store/pull/873)

--- a/packages/store/src/actions/actions.ts
+++ b/packages/store/src/actions/actions.ts
@@ -1,5 +1,3 @@
-import { ObjectKeyMap } from '../internal/internals';
-
 /**
  * Init action
  */
@@ -18,6 +16,4 @@ export class UpdateState {
     // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138
     return '@@UPDATE_STATE';
   }
-
-  constructor(public payload?: ObjectKeyMap<any>) {}
 }

--- a/packages/store/src/module.ts
+++ b/packages/store/src/module.ts
@@ -80,9 +80,8 @@ export class NgxsFeatureModule {
 
     if (results.states.length) {
       internalStateOperations.setStateToTheCurrentWithNew(results);
-
       // dispatch the update action and invoke init and bootstrap functions after
-      lifecycleStateManager.ngxsBootstrap(new UpdateState(results.defaults), results);
+      lifecycleStateManager.ngxsBootstrap(new UpdateState(), results);
     }
   }
 }

--- a/packages/store/tests/state.spec.ts
+++ b/packages/store/tests/state.spec.ts
@@ -140,48 +140,6 @@ describe('State', () => {
       expect(TestBed.get(Store).snapshot().foo).toEqual(['initState', 'onInit']);
     });
 
-    it('should call an UpdateState action handler with multiple states', () => {
-      const expectedStates = { foo: ['test'], bar: 'baz', qux: { key: 'value' } };
-
-      @State<any>({
-        name: 'eager',
-        defaults: []
-      })
-      class EagerState {
-        @Action(UpdateState)
-        updateState(ctx: StateContext<any[]>, action: UpdateState) {
-          ctx.setState({ ...ctx.getState(), ...action.payload });
-        }
-      }
-
-      @State<string[]>({
-        name: 'foo',
-        defaults: expectedStates.foo
-      })
-      class FooState {}
-
-      @State<string>({
-        name: 'bar',
-        defaults: expectedStates.bar
-      })
-      class BarState {}
-
-      @State<any>({
-        name: 'qux',
-        defaults: expectedStates.qux
-      })
-      class QuxState {}
-
-      TestBed.configureTestingModule({
-        imports: [
-          NgxsModule.forRoot([EagerState]),
-          NgxsModule.forFeature([FooState, BarState, QuxState])
-        ]
-      });
-
-      expect(TestBed.get(Store).snapshot().eager).toEqual(expectedStates);
-    });
-
     it('should call an UpdateState action handler before the ngxsOnInit method on feature module initialisation', () => {
       @State<string[]>({
         name: 'foo',


### PR DESCRIPTION
Reverts ngxs/store#845
This should not have been merged because it is a feature and we are still doing bug fixes on master.
The api that this feature adds is also still in discussion (https://github.com/ngxs/store/pull/845#issuecomment-471702349)