### PR TITLE
fix(logger-plugin): replace `Object.entries` as it breaks IE11

### DIFF
--- a/packages/logger-plugin/src/logger.plugin.ts
+++ b/packages/logger-plugin/src/logger.plugin.ts
@@ -97,6 +97,6 @@ export class NgxsLoggerPlugin implements NgxsPlugin {
   private _getNonEmptyProperties(event: any) {
     const keys = Object.keys(event);
     const values = keys.map(key => event[key]);
-    return values.filter(value => value !== undefined);
+    return values.filter(value => !!value);
   }
 }

--- a/packages/logger-plugin/src/logger.plugin.ts
+++ b/packages/logger-plugin/src/logger.plugin.ts
@@ -90,8 +90,13 @@ export class NgxsLoggerPlugin implements NgxsPlugin {
   }
 
   private _hasPayload(event: any) {
-    const nonEmptyProperties = Object.entries(event).filter(([, value]) => !!value);
-
+    const nonEmptyProperties = this._getNonEmptyProperties(event);
     return nonEmptyProperties.length > 0;
+  }
+
+  private _getNonEmptyProperties(event: any) {
+    const keys = Object.keys(event);
+    const values = keys.map(key => event[key]);
+    return values.filter(value => value !== undefined);
   }
 }


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Issue Number: #923


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```