### PR TITLE
feat: add selector options to metadata

### DIFF
--- a/packages/store/src/decorators/selector.ts
+++ b/packages/store/src/decorators/selector.ts
@@ -7,16 +7,18 @@ export function Selector(selectors?: any[]) {
   return (target: any, methodName: string, descriptor: PropertyDescriptor) => {
     if (descriptor.value !== null) {
       const originalFn = descriptor.value;
-
-      const memoizedFn = createSelector(
-        selectors,
-        originalFn.bind(target),
-        { containerClass: target, selectorName: methodName }
-      );
-
+      let memoizedFn: any = null;
       return {
         configurable: true,
         get() {
+          // Selector initialisation defered to here so that it is at runtime, not decorator parse time
+          memoizedFn =
+            memoizedFn ||
+            createSelector(
+              selectors,
+              originalFn.bind(target),
+              { containerClass: target, selectorName: methodName }
+            );
           return memoizedFn;
         }
       };

--- a/packages/store/src/internal/internals.ts
+++ b/packages/store/src/internal/internals.ts
@@ -40,7 +40,7 @@ export interface MetaDataModel {
   selectFromAppState: SelectFromState | null;
   children?: StateClass[];
   instance: any;
-  sharedSelectorOptions?: InternalSelectorOptions;
+  internalSelectorOptions?: InternalSelectorOptions;
 }
 
 export type SelectFromState = (state: any) => any;
@@ -114,7 +114,7 @@ export function ensureSelectorMetadata(target: Function): SelectorMetaDataModel 
       containerClass: null,
       selectorName: null,
       selectorOptions: {
-        injectContainerState: true // default is true in v3, will change in v4
+        injectContainerState: true // TODO: default is true in v3, will change in v4
       }
     };
 

--- a/packages/store/src/internal/internals.ts
+++ b/packages/store/src/internal/internals.ts
@@ -40,15 +40,21 @@ export interface MetaDataModel {
   selectFromAppState: SelectFromState | null;
   children?: StateClass[];
   instance: any;
+  sharedSelectorOptions?: InternalSelectorOptions;
 }
 
 export type SelectFromState = (state: any) => any;
+
+export interface InternalSelectorOptions {
+  injectContainerState?: boolean;
+}
 
 export interface SelectorMetaDataModel {
   selectFromAppState: SelectFromState | null;
   originalFn: Function | null;
   containerClass: any;
   selectorName: string | null;
+  selectorOptions: InternalSelectorOptions;
 }
 
 export interface MappedStore {
@@ -106,7 +112,10 @@ export function ensureSelectorMetadata(target: Function): SelectorMetaDataModel 
       selectFromAppState: null,
       originalFn: null,
       containerClass: null,
-      selectorName: null
+      selectorName: null,
+      selectorOptions: {
+        injectContainerState: true // default is true in v3, will change in v4
+      }
     };
 
     Object.defineProperty(target, SELECTOR_META_KEY, { value: defaultMetadata });

--- a/packages/store/src/internal/state-factory.ts
+++ b/packages/store/src/internal/state-factory.ts
@@ -235,8 +235,8 @@ export class StateFactory {
     const globalSelectorOptions: InternalSelectorOptions = (<any>this._config)
       .internalSelectorOptions;
     if (globalSelectorOptions) {
-      const sharedSelectorOptions = meta.sharedSelectorOptions || {};
-      meta.sharedSelectorOptions = { ...globalSelectorOptions, ...sharedSelectorOptions };
+      const classSelectorOptions = meta.internalSelectorOptions || {};
+      meta.internalSelectorOptions = { ...globalSelectorOptions, ...classSelectorOptions };
     }
   }
 

--- a/packages/store/src/internal/state-factory.ts
+++ b/packages/store/src/internal/state-factory.ts
@@ -24,7 +24,8 @@ import {
   StateKeyGraph,
   StatesAndDefaults,
   StatesByName,
-  topologicalSort
+  topologicalSort,
+  InternalSelectorOptions
 } from './internals';
 import { getActionTypeFromInstance, getValue, setValue } from '../utils/utils';
 import { ofActionDispatched } from '../operators/of-action';
@@ -231,6 +232,12 @@ export class StateFactory {
   private addRuntimeInfoToMeta(meta: MetaDataModel, depth: string): void {
     meta.path = depth;
     meta.selectFromAppState = propGetter(depth.split('.'), this._config);
+    const globalSelectorOptions: InternalSelectorOptions = (<any>this._config)
+      .internalSelectorOptions;
+    if (globalSelectorOptions) {
+      const sharedSelectorOptions = meta.sharedSelectorOptions || {};
+      meta.sharedSelectorOptions = { ...globalSelectorOptions, ...sharedSelectorOptions };
+    }
   }
 
   /**

--- a/packages/store/src/utils/selector-utils.ts
+++ b/packages/store/src/utils/selector-utils.ts
@@ -74,7 +74,7 @@ function getCustomSelectorOptions(
   if (containerClass) {
     const storeMetaData = getStoreMetadata(containerClass);
     const classSelectorOptions: InternalSelectorOptions =
-      (storeMetaData && storeMetaData.sharedSelectorOptions) || {};
+      (storeMetaData && storeMetaData.internalSelectorOptions) || {};
     selectorOptions = { ...selectorOptions, ...classSelectorOptions };
   }
   selectorOptions = { ...selectorOptions, ...explicitOptions };

--- a/packages/store/src/utils/selector-utils.ts
+++ b/packages/store/src/utils/selector-utils.ts
@@ -4,7 +4,9 @@ import {
   SelectFromState,
   ensureSelectorMetadata,
   getSelectorMetadata,
-  getStoreMetadata
+  getStoreMetadata,
+  SelectorMetaDataModel,
+  InternalSelectorOptions
 } from '../internal/internals';
 
 /**
@@ -27,24 +29,20 @@ export function createSelector<T extends (...args: any[]) => any>(
     return returnValue;
   } as T;
   const memoizedFn = memoize(wrappedFn);
-  const containerClass = creationMetadata && creationMetadata.containerClass;
+  const selectorMetaData = ensureSelectorMetadata(memoizedFn);
+  selectorMetaData.originalFn = originalFn;
+
+  if (creationMetadata) {
+    selectorMetaData.containerClass = creationMetadata.containerClass;
+    selectorMetaData.selectorName = creationMetadata.selectorName;
+  }
+
+  selectorMetaData.selectorOptions = getCustomSelectorOptions(selectorMetaData, {});
 
   const fn = (state: any) => {
     const results = [];
 
-    const selectorsToApply = [];
-
-    if (containerClass) {
-      // If we are on a state class, add it as the first selector parameter
-      const metadata = getStoreMetadata(containerClass);
-      if (metadata) {
-        selectorsToApply.push(containerClass);
-      }
-    }
-
-    if (selectors) {
-      selectorsToApply.push(...selectors);
-    }
+    const selectorsToApply = getSelectorsToApply(selectorMetaData, selectors);
 
     // Determine arguments from the app state using the selectors
     results.push(...selectorsToApply.map(a => getSelectorFn(a)(state)));
@@ -62,14 +60,46 @@ export function createSelector<T extends (...args: any[]) => any>(
     }
   };
 
-  const selectorMetaData = ensureSelectorMetadata(memoizedFn);
-  selectorMetaData.originalFn = originalFn;
   selectorMetaData.selectFromAppState = fn;
-  if (creationMetadata) {
-    selectorMetaData.containerClass = creationMetadata.containerClass;
-    selectorMetaData.selectorName = creationMetadata.selectorName;
-  }
+
   return memoizedFn;
+}
+
+function getCustomSelectorOptions(
+  selectorMetaData: SelectorMetaDataModel,
+  explicitOptions: InternalSelectorOptions
+) {
+  let selectorOptions = selectorMetaData.selectorOptions || {};
+  const containerClass = selectorMetaData.containerClass;
+  if (containerClass) {
+    const storeMetaData = getStoreMetadata(containerClass);
+    const classSelectorOptions: InternalSelectorOptions =
+      (storeMetaData && storeMetaData.sharedSelectorOptions) || {};
+    selectorOptions = { ...selectorOptions, ...classSelectorOptions };
+  }
+  selectorOptions = { ...selectorOptions, ...explicitOptions };
+  return selectorOptions;
+}
+
+function getSelectorsToApply(
+  selectorMetaData: SelectorMetaDataModel,
+  selectors: any[] | undefined = []
+) {
+  const selectorsToApply = [];
+  const canInjectContainerState =
+    selectors.length === 0 || selectorMetaData.selectorOptions.injectContainerState;
+  const containerClass = selectorMetaData.containerClass;
+  if (containerClass && canInjectContainerState) {
+    // If we are on a state class, add it as the first selector parameter
+    const metadata = getStoreMetadata(containerClass);
+    if (metadata) {
+      selectorsToApply.push(containerClass);
+    }
+  }
+  if (selectors) {
+    selectorsToApply.push(...selectors);
+  }
+  return selectorsToApply;
 }
 
 /**

--- a/packages/store/tests/selector.spec.ts
+++ b/packages/store/tests/selector.spec.ts
@@ -318,7 +318,7 @@ describe('Selector', () => {
           return foo + bar;
         }
       }
-      getStoreMetadata(MyStateV4).sharedSelectorOptions = { injectContainerState: false };
+      getStoreMetadata(MyStateV4).internalSelectorOptions = { injectContainerState: false };
 
       it('should select from a simple selector', async(() => {
         // Arrange

--- a/packages/store/tests/selector.spec.ts
+++ b/packages/store/tests/selector.spec.ts
@@ -231,6 +231,7 @@ describe('Selector', () => {
           bar: 'Bar1'
         }
       })
+      // tslint:disable-next-line: class-name
       class MyStateV4_1 {
         @Selector()
         static foo(state: MyStateModel) {
@@ -255,6 +256,7 @@ describe('Selector', () => {
           bar: 'Bar2'
         }
       })
+      // tslint:disable-next-line: class-name
       class MyStateV4_2 {
         @Selector()
         static foo(state: MyStateModel) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is currently an issue where the state of the container class of a selector is always injected as the first parameter. This is a problem because it makes the memoisation of every selector defined in a state class dependent on the entire state class, and therefore they are recalculated on any change within the state.
(I will populate the list of realted issues later) 
Issue Number: N/A


## What is the new behavior?
This PR introduces some internal representations of selector options, configurable at a method, class, or application level. This will be used as part of the `compat` mechanisms to ease the change of the above behaviour in NGXS v4.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

## Other information
This PR will be followed by another PR that creates a `compat` mechanism for configuring selector behaviour.