### PR TITLE
feat(store): add state defaults to UpdateState

### DIFF
--- a/packages/store/src/actions/actions.ts
+++ b/packages/store/src/actions/actions.ts
@@ -1,3 +1,5 @@
+import { ObjectKeyMap } from '../internal/internals';
+
 /**
  * Init action
  */
@@ -16,4 +18,6 @@ export class UpdateState {
     // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138
     return '@@UPDATE_STATE';
   }
+
+  constructor(public addedStates?: ObjectKeyMap<any>) {}
 }

--- a/packages/store/src/modules/ngxs-feature.module.ts
+++ b/packages/store/src/modules/ngxs-feature.module.ts
@@ -32,8 +32,9 @@ export class NgxsFeatureModule {
 
     if (results.states.length) {
       internalStateOperations.setStateToTheCurrentWithNew(results);
+
       // dispatch the update action and invoke init and bootstrap functions after
-      lifecycleStateManager.ngxsBootstrap(new UpdateState(), results);
+      lifecycleStateManager.ngxsBootstrap(new UpdateState(results.defaults), results);
     }
   }
 

--- a/packages/store/tests/state.spec.ts
+++ b/packages/store/tests/state.spec.ts
@@ -140,6 +140,48 @@ describe('State', () => {
       expect(TestBed.get(Store).snapshot().foo).toEqual(['initState', 'onInit']);
     });
 
+    it('should call an UpdateState action handler with multiple states', () => {
+      const expectedStates = { foo: ['test'], bar: 'baz', qux: { key: 'value' } };
+
+      @State<any>({
+        name: 'eager',
+        defaults: []
+      })
+      class EagerState {
+        @Action(UpdateState)
+        updateState(ctx: StateContext<any[]>, action: UpdateState) {
+          ctx.setState({ ...ctx.getState(), ...action.addedStates });
+        }
+      }
+
+      @State<string[]>({
+        name: 'foo',
+        defaults: expectedStates.foo
+      })
+      class FooState {}
+
+      @State<string>({
+        name: 'bar',
+        defaults: expectedStates.bar
+      })
+      class BarState {}
+
+      @State<any>({
+        name: 'qux',
+        defaults: expectedStates.qux
+      })
+      class QuxState {}
+
+      TestBed.configureTestingModule({
+        imports: [
+          NgxsModule.forRoot([EagerState]),
+          NgxsModule.forFeature([FooState, BarState, QuxState])
+        ]
+      });
+
+      expect(TestBed.get(Store).snapshot().eager).toEqual(expectedStates);
+    });
+
     it('should call an UpdateState action handler before the ngxsOnInit method on feature module initialisation', () => {
       @State<string[]>({
         name: 'foo',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The comeback of PR #845, with one change - `payload` parameter has been changed to `addedStats`.
Issue Number: #838 

## What is the new behavior?
State defaults array is being added to the `UpdateState` action, so they will be visible using the `logger` and `devtools` plugins.
The `payload` parameter is optional in order to prevent a breaking change, in case some developer used this action directly. We might consider changing that to be required for version 4. #827 

![image](https://user-images.githubusercontent.com/9721664/53113566-8fec7080-354a-11e9-8f35-07ce9d2e79a4.png)
![image](https://user-images.githubusercontent.com/9721664/53113669-c88c4a00-354a-11e9-9e6e-ca3d2d79992d.png)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```