### PR TITLE
feat(store): add SelectorOptions decorator

### DIFF
--- a/packages/store/src/decorators/selector-options.ts
+++ b/packages/store/src/decorators/selector-options.ts
@@ -15,11 +15,11 @@ export function SelectorOptions(options: SharedSelectorOptions) {
         // Method Decorator
         if (descriptor.value) {
           const originalFn = descriptor.value;
-          selectorOptionsMetaAccessor.setFor(originalFn, options);
+          selectorOptionsMetaAccessor.defineOptions(originalFn, options);
         }
       } else {
         // Class Decorator
-        selectorOptionsMetaAccessor.setFor(target, options);
+        selectorOptionsMetaAccessor.defineOptions(target, options);
       }
     }
   );

--- a/packages/store/src/decorators/selector.ts
+++ b/packages/store/src/decorators/selector.ts
@@ -16,8 +16,14 @@ export function Selector(selectors?: any[]) {
             memoizedFn ||
             createSelector(
               selectors,
-              originalFn.bind(target),
-              { containerClass: target, selectorName: methodName }
+              originalFn,
+              {
+                containerClass: target,
+                selectorName: methodName,
+                getSelectorOptions() {
+                  return {};
+                }
+              }
             );
           return memoizedFn;
         }

--- a/packages/store/src/decorators/selectorOptions.ts
+++ b/packages/store/src/decorators/selectorOptions.ts
@@ -1,0 +1,26 @@
+import { SharedSelectorOptions } from '../internal/internals';
+import { selectorOptionsMetaAccessor } from '../utils/selector-utils';
+
+/**
+ * Decorator for setting selector options at a method or class level.
+ */
+export function SelectorOptions(options: SharedSelectorOptions) {
+  return <ClassDecorator & MethodDecorator>(
+    function decorate<T>(
+      target: any,
+      methodName: string,
+      descriptor: TypedPropertyDescriptor<T>
+    ) {
+      if (methodName) {
+        // Method Decorator
+        if (descriptor.value) {
+          const originalFn = descriptor.value;
+          selectorOptionsMetaAccessor.setFor(originalFn, options);
+        }
+      } else {
+        // Class Decorator
+        selectorOptionsMetaAccessor.setFor(target, options);
+      }
+    }
+  );
+}

--- a/packages/store/src/internal/internals.ts
+++ b/packages/store/src/internal/internals.ts
@@ -40,7 +40,6 @@ export interface MetaDataModel {
   selectFromAppState: SelectFromState | null;
   children?: StateClass[];
   instance: any;
-  selectorOptions?: SharedSelectorOptions;
 }
 
 export type SelectFromState = (state: any) => any;
@@ -55,7 +54,7 @@ export interface SelectorMetaDataModel {
   originalFn: Function | null;
   containerClass: any;
   selectorName: string | null;
-  selectorOptions: SharedSelectorOptions;
+  getSelectorOptions: () => SharedSelectorOptions;
 }
 
 export interface MappedStore {
@@ -104,6 +103,8 @@ export function getStoreMetadata(target: StateClass): MetaDataModel {
   return target[META_KEY]!;
 }
 
+export const globalSelectorOptions: SharedSelectorOptions = {};
+
 /**
  * Ensures metadata is attached to the selector and returns it.
  *
@@ -116,9 +117,7 @@ export function ensureSelectorMetadata(target: Function): SelectorMetaDataModel 
       originalFn: null,
       containerClass: null,
       selectorName: null,
-      selectorOptions: {
-        injectContainerState: true // TODO: default is true in v3, will change in v4
-      }
+      getSelectorOptions: () => ({})
     };
 
     Object.defineProperty(target, SELECTOR_META_KEY, { value: defaultMetadata });

--- a/packages/store/src/internal/internals.ts
+++ b/packages/store/src/internal/internals.ts
@@ -9,6 +9,10 @@ import {
 } from '../symbols';
 import { ActionHandlerMetaData } from '../actions/symbols';
 
+function asReadonly<T>(value: T): Readonly<T> {
+  return value;
+}
+
 export interface ObjectKeyMap<T> {
   [key: string]: T;
 }
@@ -103,7 +107,17 @@ export function getStoreMetadata(target: StateClass): MetaDataModel {
   return target[META_KEY]!;
 }
 
-export const globalSelectorOptions: SharedSelectorOptions = {};
+// closure variable used to store the global options
+let _globalSelectorOptions: SharedSelectorOptions = {};
+
+export const globalSelectorOptions = asReadonly({
+  get(): Readonly<SharedSelectorOptions> {
+    return _globalSelectorOptions;
+  },
+  set(value: Readonly<SharedSelectorOptions>) {
+    _globalSelectorOptions = { ...value };
+  }
+});
 
 /**
  * Ensures metadata is attached to the selector and returns it.

--- a/packages/store/src/internal/state-factory.ts
+++ b/packages/store/src/internal/state-factory.ts
@@ -232,11 +232,6 @@ export class StateFactory {
   private addRuntimeInfoToMeta(meta: MetaDataModel, depth: string): void {
     meta.path = depth;
     meta.selectFromAppState = propGetter(depth.split('.'), this._config);
-    const sharedSelectorOptions: SharedSelectorOptions = this._config.selectorOptions;
-    if (sharedSelectorOptions) {
-      const classSelectorOptions = meta.selectorOptions || {};
-      meta.selectorOptions = { ...sharedSelectorOptions, ...classSelectorOptions };
-    }
   }
 
   /**

--- a/packages/store/src/modules/ngxs-root.module.ts
+++ b/packages/store/src/modules/ngxs-root.module.ts
@@ -5,7 +5,12 @@ import { InternalStateOperations } from '../internal/state-operations';
 import { Store } from '../store';
 import { SelectFactory } from '../decorators/select';
 import { ROOT_STATE_TOKEN, NgxsConfig } from '../symbols';
-import { StateClass, StatesAndDefaults, globalSelectorOptions } from '../internal/internals';
+import {
+  StateClass,
+  StatesAndDefaults,
+  globalSelectorOptions,
+  SharedSelectorOptions
+} from '../internal/internals';
 import { LifecycleStateManager } from '../internal/lifecycle-state-manager';
 import { InitState } from '../actions/actions';
 
@@ -26,8 +31,7 @@ export class NgxsRootModule {
     config: NgxsConfig,
     lifecycleStateManager: LifecycleStateManager
   ) {
-    // set the global selector options from the config
-    Object.assign(globalSelectorOptions, config.selectorOptions || {});
+    globalSelectorOptions.set(config.selectorOptions || {});
 
     // add stores to the state graph and return their defaults
     const results: StatesAndDefaults = factory.addAndReturnDefaults(states);

--- a/packages/store/src/modules/ngxs-root.module.ts
+++ b/packages/store/src/modules/ngxs-root.module.ts
@@ -4,8 +4,8 @@ import { StateFactory } from '../internal/state-factory';
 import { InternalStateOperations } from '../internal/state-operations';
 import { Store } from '../store';
 import { SelectFactory } from '../decorators/select';
-import { ROOT_STATE_TOKEN } from '../symbols';
-import { StateClass, StatesAndDefaults } from '../internal/internals';
+import { ROOT_STATE_TOKEN, NgxsConfig } from '../symbols';
+import { StateClass, StatesAndDefaults, globalSelectorOptions } from '../internal/internals';
 import { LifecycleStateManager } from '../internal/lifecycle-state-manager';
 import { InitState } from '../actions/actions';
 
@@ -23,8 +23,12 @@ export class NgxsRootModule {
     @Optional()
     @Inject(ROOT_STATE_TOKEN)
     states: StateClass[] = [],
+    config: NgxsConfig,
     lifecycleStateManager: LifecycleStateManager
   ) {
+    // set the global selector options from the config
+    Object.assign(globalSelectorOptions, config.selectorOptions || {});
+
     // add stores to the state graph and return their defaults
     const results: StatesAndDefaults = factory.addAndReturnDefaults(states);
 

--- a/packages/store/src/symbols.ts
+++ b/packages/store/src/symbols.ts
@@ -58,7 +58,10 @@ export class NgxsConfig {
   /**
    * Defining shared selector options
    */
-  selectorOptions: SharedSelectorOptions = {};
+  selectorOptions: SharedSelectorOptions = {
+    injectContainerState: true, // TODO: default is true in v3, will change in v4
+    suppressErrors: true // TODO: default is true in v3, will change in v4
+  };
 
   constructor() {
     this.compatibility = {

--- a/packages/store/src/utils/selector-utils.ts
+++ b/packages/store/src/utils/selector-utils.ts
@@ -14,10 +14,10 @@ import {
 const SELECTOR_OPTIONS_META_KEY = 'NGXS_SELECTOR_OPTIONS_META';
 
 export const selectorOptionsMetaAccessor = {
-  getFrom: (target: any): SharedSelectorOptions => {
+  getOptions: (target: any): SharedSelectorOptions => {
     return (target && (<any>target)[SELECTOR_OPTIONS_META_KEY]) || {};
   },
-  setFor: (target: any, options: SharedSelectorOptions) => {
+  defineOptions: (target: any, options: SharedSelectorOptions) => {
     if (!target) return;
     (<any>target)[SELECTOR_OPTIONS_META_KEY] = options;
   }
@@ -125,9 +125,9 @@ function getCustomSelectorOptions(
   explicitOptions: SharedSelectorOptions
 ): SharedSelectorOptions {
   const selectorOptions: SharedSelectorOptions = {
-    ...globalSelectorOptions,
-    ...(selectorOptionsMetaAccessor.getFrom(selectorMetaData.containerClass) || {}),
-    ...(selectorOptionsMetaAccessor.getFrom(selectorMetaData.originalFn) || {}),
+    ...globalSelectorOptions.get(),
+    ...(selectorOptionsMetaAccessor.getOptions(selectorMetaData.containerClass) || {}),
+    ...(selectorOptionsMetaAccessor.getOptions(selectorMetaData.originalFn) || {}),
     ...(selectorMetaData.getSelectorOptions() || {}),
     ...explicitOptions
   };

--- a/packages/store/tests/selector.spec.ts
+++ b/packages/store/tests/selector.spec.ts
@@ -11,7 +11,7 @@ import {
   StateClass
 } from '../src/internal/internals';
 import { NgxsConfig, SELECTOR_META_KEY } from '../src/symbols';
-import { SelectorOptions } from '../src/decorators/selectorOptions';
+import { SelectorOptions } from '../src/decorators/selector-options';
 
 describe('Selector', () => {
   interface MyStateModel {

--- a/packages/store/tests/selector.spec.ts
+++ b/packages/store/tests/selector.spec.ts
@@ -11,6 +11,7 @@ import {
   StateClass
 } from '../src/internal/internals';
 import { NgxsConfig, SELECTOR_META_KEY } from '../src/symbols';
+import { SelectorOptions } from '../src/decorators/selectorOptions';
 
 describe('Selector', () => {
   interface MyStateModel {
@@ -214,7 +215,7 @@ describe('Selector', () => {
     });
   });
 
-  describe('(Decorator - v4 options)', () => {
+  describe('(Selector Options)', () => {
     function setupStore(
       states: StateClass<any, any>[],
       extendedOptions?: Partial<NgxsConfig>
@@ -300,6 +301,10 @@ describe('Selector', () => {
           bar: 'Bar'
         }
       })
+      @SelectorOptions({
+        injectContainerState: false,
+        suppressErrors: false
+      })
       class MyStateV4 {
         @Selector()
         static foo(state: MyStateModel) {
@@ -320,8 +325,12 @@ describe('Selector', () => {
         static fooAndBar(foo: string, bar: string) {
           return foo + bar;
         }
+
+        @Selector([MyStateV4])
+        static invalid(state: MyStateModel) {
+          throw new Error('This is a forced error');
+        }
       }
-      getStoreMetadata(MyStateV4).selectorOptions = { injectContainerState: false };
 
       it('should select from a simple selector', async(() => {
         // Arrange
@@ -358,6 +367,94 @@ describe('Selector', () => {
         // Assert
         expect(slice).toBe('FooBar');
       }));
+
+      it('should allow for no supression of errors in selectors', async(() => {
+        // Arrange
+        const store = setupStore([MyStateV4]);
+        // Act
+        let exception: Error | null = null;
+        try {
+          store.selectSnapshot(MyStateV4.invalid);
+        } catch (e) {
+          exception = e;
+        }
+        // Assert
+        expect(exception).not.toBeNull();
+      }));
+    });
+
+    describe('[at query class level]', () => {
+      @State<MyStateModel>({
+        name: 'zoo',
+        defaults: {
+          foo: 'Foo',
+          bar: 'Bar'
+        }
+      })
+      class MyStateV4 {
+        @Selector()
+        static foo(state: MyStateModel) {
+          return state.foo;
+        }
+
+        @Selector()
+        static bar(state: MyStateModel) {
+          return state.bar;
+        }
+      }
+
+      @SelectorOptions({
+        injectContainerState: false,
+        suppressErrors: false
+      })
+      class MyStateV4Queries {
+        @Selector([MyStateV4, MyStateV4.foo])
+        static selfAndFoo(state: MyStateModel, myStateFoo: string) {
+          return state.foo + myStateFoo;
+        }
+
+        @Selector([MyStateV4.foo, MyStateV4.bar])
+        static fooAndBar(foo: string, bar: string) {
+          return foo + bar;
+        }
+
+        @Selector([MyStateV4])
+        static invalid(state: MyStateModel) {
+          throw new Error('This is a forced error');
+        }
+      }
+
+      it('should select from a self joined selector', async(() => {
+        // Arrange
+        const store = setupStore([MyStateV4]);
+        // Act
+        const slice = store.selectSnapshot(MyStateV4Queries.selfAndFoo);
+        // Assert
+        expect(slice).toBe('FooFoo');
+      }));
+
+      it('should select from a joined selector', async(() => {
+        // Arrange
+        const store = setupStore([MyStateV4]);
+        // Act
+        const slice = store.selectSnapshot(MyStateV4Queries.fooAndBar);
+        // Assert
+        expect(slice).toBe('FooBar');
+      }));
+
+      it('should allow for no supression of errors in selectors', async(() => {
+        // Arrange
+        const store = setupStore([MyStateV4]);
+        // Act
+        let exception: Error | null = null;
+        try {
+          store.selectSnapshot(MyStateV4Queries.invalid);
+        } catch (e) {
+          exception = e;
+        }
+        // Assert
+        expect(exception).not.toBeNull();
+      }));
     });
 
     describe('[at method level]', () => {
@@ -385,14 +482,11 @@ describe('Selector', () => {
         }
 
         @Selector([MyStateV3.foo, MyStateV3.bar])
+        @SelectorOptions({ injectContainerState: false })
         static v4StyleSelector_FooAndBar(foo: string, bar: string) {
           return foo + bar;
         }
       }
-
-      getSelectorMetadata(MyStateV3.v4StyleSelector_FooAndBar).selectorOptions = {
-        injectContainerState: false
-      };
 
       it('should select from a v3 selector', async(() => {
         // Arrange


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is currently an issue where the state of the container class of a selector is always injected as the first parameter. This is a problem because it makes the memoisation of every selector defined in a state class dependent on the entire state class, and therefore they are recalculated on any change within the state.
(I will populate the list of realted issues later) 
Issue Numbers...
See: https://github.com/ngxs/store/issues/386#issuecomment-395780734
Related: #541 #446
Related PRs: #858, #954, #1015

## What is the new behavior?
This PR introduces a decorator for configuring selector options at a method or class level. This is needed for those wanting to take on v4 features early and when v4 drops, for users to downgrade behaviour until they fix all their old code reliant on the old v3 behaviour.

This selector can be applied at class level:
```TS
@State<MyStateModel>({
  name: 'zoo',
  defaults: {
    foo: 'Foo',
    bar: 'Bar'
  }
})
@SelectorOptions({
  injectContainerState: false,
  suppressErrors: false
})
class MyStateV4 {
  // ...
}
```
or at Method level:
```TS
@State<MyStateModel>({
  name: 'zoo',
  defaults: {
    foo: 'Foo',
    bar: 'Bar'
  }
})
class MyState {
  @Selector()
  static foo(state: MyStateModel) {
    return state.foo;
  }

  @Selector()
  static bar(state: MyStateModel) {
    return state.bar;
  }

  @Selector([MyState.foo, MyState.bar])
  @SelectorOptions({ injectContainerState: false })
  static v4StyleSelector_FooAndBar(foo: string, bar: string) {
    return foo + bar;
  }

  //...
}
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```
