### PR TITLE
feat: expose SelectorOptions decorator

### DIFF
--- a/docs/advanced/options.md
+++ b/docs/advanced/options.md
@@ -1,12 +1,16 @@
 # Options
 
-You can provide a config when you create your root `NgxsModule`, as `forRoot` accepts 2 arguments. The second argument is a `NgxsModuleOptions` object that can have such properties as `developmentMode`, `compatibility` and `executionStrategy`.
+You can provide an `NgxsModuleOptions` object as the second argument of your `NgxsModule.forRoot`call. The following options are available:
 
-- Turning on `developmentMode` option will add additional debugging features, like freezing your state and actions to guarantee immutability. Default value is `false`.
-- `compatibility` is an object that can have `strictContentSecurityPolicy` property, if you set `strictContentSecurityPolicy` to `true`, then the support for the strict Content Security Policy will be enabled. This will cirumvent some optimisations that violate a strict CSP through the use of `new Function(...)`. Default value is `false`.
-- `executionStrategy` is an advanced option. It is used to have specific control of the way that ngxs executes code that is considered to be inside the ngxs context (ie. within `@Action` handlers) and the context under which the NGXS behaviours are observed (outside the ngxs context). These observable behaviours are: `@Select(...)`, `store.select(...)`, `actions.subscribe(...)` or `store.dispatch(...).subscribe(...)`  
-  Developers who prefer to manually control the change detection mechanism in their application may choose to use the `NoopNgxsExecutionStrategy` (or implement their own) which does not interfere with zones and therefore relies on the external context to handle change detection (for example: `OnPush` or ivy's rendering engine). The default value of `null` will result in the default strategy being used. The default strategy runs NGXS operations outside Angular's zone but all observable behaviours of NGXS are run back inside Angular's zone. The default value is `null`.
-- `selectorOptions` - setting the mechanism of the selectors. You can also enable or disable error suppression in selectors. And disable `injectContainerState` for optimize selection value from state.
+- `developmentMode` - Setting this to `true` will add additional debugging features that are useful for development time. This includes freezing your state and actions to guarantee immutability. (Default value is `false`)
+- `selectorOptions` - A nested options object for providing a global options setting to be used for selectors. This can be overridden at the class or specific selector method level using the `SelectorOptions` decorator. The following options are available:
+  - `suppressErrors` - Setting this to `true` will cause any error within a selector to result in the selector returning `undefined`. Setting this to `false` results in these errors propogating through the stack that triggered the evaluation of the selector that caused the error. **NOTE:** *The default for this setting will be changing to `false` in NGXS v4. The default value in NGXS v3.x is `true`.*
+  - `injectContainerState` - Setting this to `false` will prevent the injection of the container state model as the first parameter of a selector method (defined within a state class) that joins to other selectors for its parameters. When this setting is `true` all selectors defined within a state class will receive the container class' state model as their first parameter. As a result every selector would be re-evaluated after any change to that state. **NOTE:** *This is not ideal, therefore this setting default will be changing to `false` in NGXS v4. The default value in NGXS v3.x is `true`.*
+  - See [here](../concepts/select.md#joining-selectors) for examples of the effect this setting has on your selectors.
+- `compatibility` - A nested options object that allows for the following compatibility options:
+  - `strictContentSecurityPolicy` - Set this to `true` in order to enable support for pages where a Strict Content Security Policy has been enabled. This setting cirumvent some optimisations that violate a strict CSP through the use of `new Function(...)`. (Default value is `false`)
+- `executionStrategy` - An advanced option that is used to gain specific control over the way that ngxs executes code that is considered to be inside the ngxs context (ie. within `@Action` handlers) and the context under which the NGXS behaviours are observed (outside the ngxs context). These observable behaviours are: `@Select(...)`, `store.select(...)`, `actions.subscribe(...)` or `store.dispatch(...).subscribe(...)`  
+  Developers who prefer to manually control the change detection mechanism in their application may choose to use the `NoopNgxsExecutionStrategy` which does not interfere with zones and therefore relies on the external context to handle change detection (for example: `OnPush` or the Ivy rendering engine). Developers can also choose to implement their own strategy by providing an Angular service class that implements the `NgxsExecutionStrategy` interface. The default value of `null` will result in the default strategy being used. This default strategy runs NGXS operations outside Angular's zone but all observable behaviours of NGXS are run back inside Angular's zone. (The default value is `null`)
 
 ngxs.config.ts
 
@@ -14,15 +18,19 @@ ngxs.config.ts
 import { NgxsModuleOptions } from '@ngxs/store';
 
 export const ngxsConfig: NgxsModuleOptions = {
-  executionStrategy: NoopNgxsExecutionStrategy,
   developmentMode: !environment.production,
+  selectorOptions: {
+    // These Selector Settings are recommended in preparation for NGXS v4
+    // (See above for their effects)
+    suppressErrors: false, 
+    injectContainerState: false
+  },
   compatibility: {
     strictContentSecurityPolicy: true
   },
-  selectorOptions: {
-    suppressErrors: false,
-    injectContainerState: false
-  }
+  // Execution strategy overridden for illustrative purposes 
+  // (only do this if you know what you are doing)
+  executionStrategy: NoopNgxsExecutionStrategy
 };
 ```
 

--- a/docs/advanced/options.md
+++ b/docs/advanced/options.md
@@ -1,6 +1,6 @@
 # Options
 
-You can provide an `NgxsModuleOptions` object as the second argument of your `NgxsModule.forRoot`call. The following options are available:
+You can provide an `NgxsModuleOptions` object as the second argument of your `NgxsModule.forRoot` call. The following options are available:
 
 - `developmentMode` - Setting this to `true` will add additional debugging features that are useful for development time. This includes freezing your state and actions to guarantee immutability. (Default value is `false`)
 - `selectorOptions` - A nested options object for providing a global options setting to be used for selectors. This can be overridden at the class or specific selector method level using the `SelectorOptions` decorator. The following options are available:

--- a/docs/introduction/installation.md
+++ b/docs/introduction/installation.md
@@ -24,7 +24,7 @@ import { NgxsModule } from '@ngxs/store';
 export class AppModule {}
 ```
 
-When you include the module in the import, you can pass root stores along with options.
+When you include the module in the import, you can pass root stores along with [options](../advanced/options.md).
 If you are lazy loading, you can use the `forFeature` option with the same arguments.
 
 Options such as `developmentMode` can be passed to the module as the second argument in the `forRoot` method.

--- a/packages/store/src/decorators/selector-options.ts
+++ b/packages/store/src/decorators/selector-options.ts
@@ -13,8 +13,8 @@ export function SelectorOptions(options: SharedSelectorOptions) {
     ) {
       if (methodName) {
         // Method Decorator
-        if (descriptor.value) {
-          const originalFn = descriptor.value;
+        const originalFn = descriptor.value || (<any>descriptor).originalFn;
+        if (originalFn) {
           selectorOptionsMetaAccessor.defineOptions(originalFn, options);
         }
       } else {

--- a/packages/store/src/decorators/selector.ts
+++ b/packages/store/src/decorators/selector.ts
@@ -26,7 +26,8 @@ export function Selector(selectors?: any[]) {
               }
             );
           return memoizedFn;
-        }
+        },
+        originalFn
       };
     } else {
       throw new Error('Selectors only work on methods');

--- a/packages/store/src/decorators/selector.ts
+++ b/packages/store/src/decorators/selector.ts
@@ -8,7 +8,7 @@ export function Selector(selectors?: any[]) {
     if (descriptor.value !== null) {
       const originalFn = descriptor.value;
       let memoizedFn: any = null;
-      return {
+      const newDescriptor = {
         configurable: true,
         get() {
           // Selector initialisation defered to here so that it is at runtime, not decorator parse time
@@ -26,9 +26,11 @@ export function Selector(selectors?: any[]) {
               }
             );
           return memoizedFn;
-        },
-        originalFn
+        }
       };
+      // Add hidden property to descriptor
+      (<any>newDescriptor)['originalFn'] = originalFn;
+      return newDescriptor;
     } else {
       throw new Error('Selectors only work on methods');
     }

--- a/packages/store/src/public_api.ts
+++ b/packages/store/src/public_api.ts
@@ -3,6 +3,7 @@ export { Action } from './decorators/action';
 export { Store } from './store';
 export { State } from './decorators/state';
 export { Select } from './decorators/select';
+export { SelectorOptions } from './decorators/selector-options';
 export { Actions } from './actions-stream';
 export {
   getSelectorMetadata,

--- a/packages/store/tests/selector.spec.ts
+++ b/packages/store/tests/selector.spec.ts
@@ -4,13 +4,8 @@ import { createSelector } from '../src/utils/selector-utils';
 import { Store } from '../src/store';
 import { NgxsModule } from '../src/module';
 import { Selector } from '../src/decorators/selector';
-import { getStoreMetadata } from '../src/public_api';
-import {
-  getSelectorMetadata,
-  SharedSelectorOptions,
-  StateClass
-} from '../src/internal/internals';
-import { NgxsConfig, SELECTOR_META_KEY } from '../src/symbols';
+import { StateClass } from '../src/internal/internals';
+import { NgxsConfig } from '../src/symbols';
 import { SelectorOptions } from '../src/decorators/selector-options';
 
 describe('Selector', () => {

--- a/packages/store/tests/selector.spec.ts
+++ b/packages/store/tests/selector.spec.ts
@@ -276,12 +276,19 @@ describe('Selector', () => {
         static fooAndBar(foo: string, bar: string) {
           return foo + bar;
         }
+
+        @Selector()
+        static invalid(state: MyStateModel) {
+          throw new Error('This is a forced error');
+        }
       }
 
-      it('should configure v4 selectors globally', async(() => {
+      it('should configure injectContainerState as false globally', async(() => {
         // Arrange
         const store = setupStore([MyStateV4_1, MyStateV4_2], {
-          selectorOptions: { injectContainerState: false }
+          selectorOptions: {
+            injectContainerState: false
+          }
         });
         // Act & Assert
         expect(store.selectSnapshot(MyStateV4_1.foo)).toBe('Foo1');
@@ -290,6 +297,24 @@ describe('Selector', () => {
         expect(store.selectSnapshot(MyStateV4_2.foo)).toBe('Foo2');
         expect(store.selectSnapshot(MyStateV4_2.bar)).toBe('Bar2');
         expect(store.selectSnapshot(MyStateV4_2.fooAndBar)).toBe('Foo2Bar2');
+      }));
+
+      it('should successfully globally configure no supression of selector errors', async(() => {
+        // Arrange
+        const store = setupStore([MyStateV4_1, MyStateV4_2], {
+          selectorOptions: {
+            suppressErrors: false
+          }
+        });
+        // Act
+        let exception: Error | null = null;
+        try {
+          store.selectSnapshot(MyStateV4_2.invalid);
+        } catch (e) {
+          exception = e;
+        }
+        // Assert
+        expect(exception).not.toBeNull();
       }));
     });
 
@@ -368,7 +393,7 @@ describe('Selector', () => {
         expect(slice).toBe('FooBar');
       }));
 
-      it('should allow for no supression of errors in selectors', async(() => {
+      it('should successfully configure no supression of selector errors', async(() => {
         // Arrange
         const store = setupStore([MyStateV4]);
         // Act
@@ -442,7 +467,7 @@ describe('Selector', () => {
         expect(slice).toBe('FooBar');
       }));
 
-      it('should allow for no supression of errors in selectors', async(() => {
+      it('should successfully configure no supression of selector errors', async(() => {
         // Arrange
         const store = setupStore([MyStateV4]);
         // Act
@@ -486,6 +511,18 @@ describe('Selector', () => {
         static v4StyleSelector_FooAndBar(foo: string, bar: string) {
           return foo + bar;
         }
+
+        @SelectorOptions({ injectContainerState: false })
+        @Selector([MyStateV3.foo, MyStateV3.bar])
+        static V4StyleSelector_flipped_FooAndBar(foo: string, bar: string) {
+          return foo + bar;
+        }
+
+        @Selector([MyStateV3])
+        @SelectorOptions({ suppressErrors: false })
+        static invalid(state: MyStateModel) {
+          throw new Error('This is a forced error');
+        }
       }
 
       it('should select from a v3 selector', async(() => {
@@ -504,6 +541,29 @@ describe('Selector', () => {
         const slice = store.selectSnapshot(MyStateV3.v4StyleSelector_FooAndBar);
         // Assert
         expect(slice).toBe('FooBar');
+      }));
+
+      it('should select from a v4 selector when provided before @Selector', async(() => {
+        // Arrange
+        const store = setupStore([MyStateV3]);
+        // Act
+        const slice = store.selectSnapshot(MyStateV3.V4StyleSelector_flipped_FooAndBar);
+        // Assert
+        expect(slice).toBe('FooBar');
+      }));
+
+      it('should successfully configure no supression of selector errors', async(() => {
+        // Arrange
+        const store = setupStore([MyStateV3]);
+        // Act
+        let exception: Error | null = null;
+        try {
+          store.selectSnapshot(MyStateV3.invalid);
+        } catch (e) {
+          exception = e;
+        }
+        // Assert
+        expect(exception).not.toBeNull();
       }));
     });
   });

--- a/packages/store/types/tests/selector-options.lint.ts
+++ b/packages/store/types/tests/selector-options.lint.ts
@@ -1,18 +1,6 @@
 /* tslint:disable:max-line-length */
 /// <reference types="@types/jasmine" />
-import { TestBed } from '@angular/core/testing';
-import { Observable } from 'rxjs';
-
-import { Action } from '../../src/decorators/action';
-import { InitState, UpdateState } from '../../src/actions/actions';
-import {
-  NgxsModule,
-  Select,
-  Selector,
-  State,
-  Store,
-  SelectorOptions
-} from '../../src/public_api';
+import { Selector, State, SelectorOptions } from '../../src/public_api';
 import { assertType } from './utils/assert-type';
 
 describe('[TEST]: The SelectorOptions decorator', () => {

--- a/packages/store/types/tests/selector-options.lint.ts
+++ b/packages/store/types/tests/selector-options.lint.ts
@@ -1,0 +1,107 @@
+/* tslint:disable:max-line-length */
+/// <reference types="@types/jasmine" />
+import { TestBed } from '@angular/core/testing';
+import { Observable } from 'rxjs';
+
+import { Action } from '../../src/decorators/action';
+import { InitState, UpdateState } from '../../src/actions/actions';
+import {
+  NgxsModule,
+  Select,
+  Selector,
+  State,
+  Store,
+  SelectorOptions
+} from '../../src/public_api';
+import { assertType } from './utils/assert-type';
+
+describe('[TEST]: The SelectorOptions decorator', () => {
+  it('should be valid on on State classes', () => {
+    @State<string>({ name: 'my-state' })
+    @SelectorOptions({ injectContainerState: false })
+    class MyState {}
+  });
+
+  it('should be valid on on State class selectors', () => {
+    @State<string>({ name: 'my-state' })
+    class MyState {
+      @Selector([MyState])
+      @SelectorOptions({ injectContainerState: false })
+      static getMyState(state: string) {
+        return state;
+      }
+    }
+  });
+
+  it('should be valid on on query classes', () => {
+    @State<string>({ name: 'my-state' })
+    class MyState {}
+
+    @SelectorOptions({ suppressErrors: false })
+    class MyStateQueries {
+      @Selector([MyState])
+      static getMyState(state: string) {
+        return state;
+      }
+    }
+  });
+
+  it('should be valid on on query class selectors', () => {
+    @State<string>({ name: 'my-state' })
+    class MyState {}
+
+    class MyStateQueries {
+      @Selector([MyState])
+      @SelectorOptions({ suppressErrors: false })
+      static getMyState(state: string) {
+        return state;
+      }
+    }
+  });
+
+  it('should not be a valid parameter decorator', () => {
+    @State<string>({ name: 'my-state' })
+    class MyState {
+      @Selector([MyState])
+      getMyState(
+        @SelectorOptions({ injectContainerState: false }) // $ExpectError
+        state: string
+      ) {
+        return state;
+      }
+    }
+  });
+
+  it('should not be a valid property decorator', () => {
+    @State<string>({ name: 'my-state' })
+    class MyState {
+      @SelectorOptions({ injectContainerState: false }) // $ExpectError
+      getMyState = () => 'test';
+    }
+  });
+
+  it('should accept the following parameters', () => {
+    assertType(() => SelectorOptions({})); // $ExpectType ClassDecorator & MethodDecorator
+    assertType(() => SelectorOptions({ suppressErrors: undefined })); // $ExpectType ClassDecorator & MethodDecorator
+    assertType(() => SelectorOptions({ suppressErrors: true })); // $ExpectType ClassDecorator & MethodDecorator
+    assertType(() => SelectorOptions({ suppressErrors: false })); // $ExpectType ClassDecorator & MethodDecorator
+    assertType(() => SelectorOptions({ injectContainerState: undefined })); // $ExpectType ClassDecorator & MethodDecorator
+    assertType(() => SelectorOptions({ injectContainerState: true })); // $ExpectType ClassDecorator & MethodDecorator
+    assertType(() => SelectorOptions({ injectContainerState: false })); // $ExpectType ClassDecorator & MethodDecorator
+    assertType(() => SelectorOptions({ suppressErrors: false, injectContainerState: false })); // $ExpectType ClassDecorator & MethodDecorator
+  });
+
+  it('should not accept the following parameters', () => {
+    assertType(() => SelectorOptions()); // $ExpectError
+    assertType(() => SelectorOptions({ suppressErrors: null })); // $ExpectError
+    assertType(() => SelectorOptions({ suppressErrors: 'string' })); // $ExpectError
+    assertType(() => SelectorOptions({ suppressErrors: 123 })); // $ExpectError
+    assertType(() => SelectorOptions({ suppressErrors: {} })); // $ExpectError
+    assertType(() => SelectorOptions({ suppressErrors: [] })); // $ExpectError
+    assertType(() => SelectorOptions({ injectContainerState: null })); // $ExpectError
+    assertType(() => SelectorOptions({ injectContainerState: 'string' })); // $ExpectError
+    assertType(() => SelectorOptions({ injectContainerState: 123 })); // $ExpectError
+    assertType(() => SelectorOptions({ injectContainerState: {} })); // $ExpectError
+    assertType(() => SelectorOptions({ injectContainerState: [] })); // $ExpectError
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Selector options is only exposed as a global setting. 
The new `@SelectorOptions` decorator was left internal by PR #1029.

Issue Numbers...
See: #386 (comment)
Related: #541 #446
Related PRs: #858, #954, #1015, #1029

## What is the new behavior?

Expose the new `@SelectorOptions` decorator and add the relative docs for it.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```
