### PR TITLE
fix(form-plugin): introduce conditional debounce

### DIFF
--- a/docs/plugins/form.md
+++ b/docs/plugins/form.md
@@ -1,8 +1,9 @@
 # Form Plugin - Experimental Status
+
 Often when building Reactive Forms in Angular, you need to bind values from the
 store to the form and vice versa. The values from the store are observable and
 the reactive form accepts raw objects, as a result we end up monkey patching
-this back and forth. 
+this back and forth.
 
 In addition to these issues, there are workflows where you want
 to fill out a form and leave and then come back and resume your current status.
@@ -11,6 +12,7 @@ This is an excellent use case for stores and we can conquer that case with this 
 In a nutshell, this plugin helps to keep your forms and state in sync.
 
 ## Installation
+
 ```bash
 npm install @ngxs/form-plugin --save
 
@@ -19,8 +21,9 @@ yarn add @ngxs/form-plugin
 ```
 
 ## Usage
+
 In the root module of your application, import `NgxsFormPluginModule`
-and include it in the imports. 
+and include it in the imports.
 
 ```TS
 import { NgxsFormPluginModule } from '@ngxs/form-plugin';
@@ -48,7 +51,8 @@ import { NgxsFormPluginModule } from '@ngxs/form-plugin';
 export class SomeModule {}
 ```
 
-### Form State 
+### Form State
+
 Define your default form state as part of your application state.
 
 ```TS
@@ -69,6 +73,7 @@ export class PizzaState {}
 ```
 
 ### Form Setup
+
 In your component, you would implement the reactive form and
 decorate the form with the `ngxsForm` directive with the path
 of your state object. We are passing the _string_ path to `ngxsForm`.
@@ -105,10 +110,11 @@ Now anytime your form updates, your state will also reflect the new state.
 
 The directive also has two inputs you can utilize as well:
 
-- `ngxsFormDebounce: number` - Debounce the value changes to the form. Default value: `100`.
+- `ngxsFormDebounce: number` - Debounce the value changes to the form. Default value: `100`. Ignored if updateOn is 'blur' or 'submit'
 - `ngxsFormClearOnDestroy: boolean` - Clear the state on destroy of the form.
 
 ### Actions
+
 In addition to it automatically keeping track of the form, you can also
 manually dispatch actions for things like resetting the form state. For example:
 
@@ -122,6 +128,7 @@ this.store.dispatch(
 ```
 
 The form plugin comes with the following `actions` out of the box:
+
 - `UpdateFormStatus({ status, path })` - Update the form status
 - `UpdateFormValue({ value, path })` - Update the form value
 - `UpdateFormDirty({ dirty, path })` - Update the form dirty status

--- a/docs/plugins/form.md
+++ b/docs/plugins/form.md
@@ -110,7 +110,7 @@ Now anytime your form updates, your state will also reflect the new state.
 
 The directive also has two inputs you can utilize as well:
 
-- `ngxsFormDebounce: number` - Debounce the value changes to the form. Default value: `100`. Ignored if updateOn is 'blur' or 'submit'
+- `ngxsFormDebounce: number` - Debounce the value changes to the form. Default value: `100`. Ignored if `updateOn` is `blur` or `submit`.
 - `ngxsFormClearOnDestroy: boolean` - Clear the state on destroy of the form.
 
 ### Actions

--- a/packages/form-plugin/tests/form.plugin.spec.ts
+++ b/packages/form-plugin/tests/form.plugin.spec.ts
@@ -292,5 +292,250 @@ describe('NgxsFormPlugin', () => {
         errors: {}
       });
     });
+
+    it('should update the state asynchronously when ngxsFormDebounce is greater or equal to zero', done => {
+      @State({
+        name: 'todos',
+        defaults: {
+          todosForm: {
+            model: undefined,
+            dirty: false,
+            status: '',
+            errors: {}
+          }
+        }
+      })
+      class TodosState {}
+
+      @Component({
+        template: `
+          <form [formGroup]="form" ngxsForm="todos.todosForm" [ngxsFormDebounce]="0">
+            <input formControlName="text" /> <button type="submit">Add todo</button>
+          </form>
+        `
+      })
+      class MockComponent {
+        public form = new FormGroup({
+          text: new FormControl()
+        });
+      }
+
+      TestBed.configureTestingModule({
+        imports: [
+          ReactiveFormsModule,
+          NgxsModule.forRoot([TodosState]),
+          NgxsFormPluginModule.forRoot()
+        ],
+        declarations: [MockComponent]
+      });
+
+      const store: Store = TestBed.get(Store);
+      const fixture = TestBed.createComponent(MockComponent);
+      fixture.detectChanges();
+
+      expect(store.selectSnapshot(({ todos }) => todos).todosForm).toEqual({
+        model: { text: null },
+        dirty: false,
+        status: 'VALID',
+        errors: {}
+      });
+
+      fixture.componentInstance.form.controls['text'].setValue('Buy some coffee');
+
+      expect(store.selectSnapshot(({ todos }) => todos).todosForm).toEqual({
+        model: { text: null },
+        dirty: false,
+        status: 'VALID',
+        errors: {}
+      });
+
+      setTimeout(function() {
+        expect(store.selectSnapshot(({ todos }) => todos).todosForm).toEqual({
+          model: { text: 'Buy some coffee' },
+          dirty: false,
+          status: 'VALID',
+          errors: {}
+        });
+
+        done();
+      }, 1);
+    });
+
+    it('should update the state synchronously when ngxsFormDebounce is less than zero', () => {
+      @State({
+        name: 'todos',
+        defaults: {
+          todosForm: {
+            model: undefined,
+            dirty: false,
+            status: '',
+            errors: {}
+          }
+        }
+      })
+      class TodosState {}
+
+      @Component({
+        template: `
+          <form [formGroup]="form" ngxsForm="todos.todosForm" [ngxsFormDebounce]="-1">
+            <input formControlName="text" /> <button type="submit">Add todo</button>
+          </form>
+        `
+      })
+      class MockComponent {
+        public form = new FormGroup({
+          text: new FormControl()
+        });
+      }
+
+      TestBed.configureTestingModule({
+        imports: [
+          ReactiveFormsModule,
+          NgxsModule.forRoot([TodosState]),
+          NgxsFormPluginModule.forRoot()
+        ],
+        declarations: [MockComponent]
+      });
+
+      const store: Store = TestBed.get(Store);
+      const fixture = TestBed.createComponent(MockComponent);
+      fixture.detectChanges();
+
+      expect(store.selectSnapshot(({ todos }) => todos).todosForm).toEqual({
+        model: { text: null },
+        dirty: false,
+        status: 'VALID',
+        errors: {}
+      });
+
+      fixture.componentInstance.form.controls['text'].setValue('Buy some coffee');
+
+      expect(store.selectSnapshot(({ todos }) => todos).todosForm).toEqual({
+        model: { text: 'Buy some coffee' },
+        dirty: false,
+        status: 'VALID',
+        errors: {}
+      });
+    });
+
+    it('should update the state synchronously when form\'s updateOn is "blur"', () => {
+      @State({
+        name: 'todos',
+        defaults: {
+          todosForm: {
+            model: undefined,
+            dirty: false,
+            status: '',
+            errors: {}
+          }
+        }
+      })
+      class TodosState {}
+
+      @Component({
+        template: `
+          <form [formGroup]="form" ngxsForm="todos.todosForm">
+            <input formControlName="text" /> <button type="submit">Add todo</button>
+          </form>
+        `
+      })
+      class MockComponent {
+        public form = new FormGroup(
+          {
+            text: new FormControl()
+          },
+          { updateOn: 'blur' }
+        );
+      }
+
+      TestBed.configureTestingModule({
+        imports: [
+          ReactiveFormsModule,
+          NgxsModule.forRoot([TodosState]),
+          NgxsFormPluginModule.forRoot()
+        ],
+        declarations: [MockComponent]
+      });
+
+      const store: Store = TestBed.get(Store);
+      const fixture = TestBed.createComponent(MockComponent);
+      fixture.detectChanges();
+
+      expect(store.selectSnapshot(({ todos }) => todos).todosForm).toEqual({
+        model: { text: null },
+        dirty: false,
+        status: 'VALID',
+        errors: {}
+      });
+
+      fixture.componentInstance.form.controls['text'].setValue('Buy some coffee');
+
+      expect(store.selectSnapshot(({ todos }) => todos).todosForm).toEqual({
+        model: { text: 'Buy some coffee' },
+        dirty: false,
+        status: 'VALID',
+        errors: {}
+      });
+    });
+
+    it('should update the state synchronously when form\'s updateOn is "submit"', () => {
+      @State({
+        name: 'todos',
+        defaults: {
+          todosForm: {
+            model: undefined,
+            dirty: false,
+            status: '',
+            errors: {}
+          }
+        }
+      })
+      class TodosState {}
+
+      @Component({
+        template: `
+          <form [formGroup]="form" ngxsForm="todos.todosForm">
+            <input formControlName="text" /> <button type="submit">Add todo</button>
+          </form>
+        `
+      })
+      class MockComponent {
+        public form = new FormGroup(
+          {
+            text: new FormControl()
+          },
+          { updateOn: 'submit' }
+        );
+      }
+
+      TestBed.configureTestingModule({
+        imports: [
+          ReactiveFormsModule,
+          NgxsModule.forRoot([TodosState]),
+          NgxsFormPluginModule.forRoot()
+        ],
+        declarations: [MockComponent]
+      });
+
+      const store: Store = TestBed.get(Store);
+      const fixture = TestBed.createComponent(MockComponent);
+      fixture.detectChanges();
+
+      expect(store.selectSnapshot(({ todos }) => todos).todosForm).toEqual({
+        model: { text: null },
+        dirty: false,
+        status: 'VALID',
+        errors: {}
+      });
+
+      fixture.componentInstance.form.controls['text'].setValue('Buy some coffee');
+
+      expect(store.selectSnapshot(({ todos }) => todos).todosForm).toEqual({
+        model: { text: 'Buy some coffee' },
+        dirty: false,
+        status: 'VALID',
+        errors: {}
+      });
+    });
   });
 });


### PR DESCRIPTION
make the form-plugin dispatch actions immediately when the form's updateOn is 'blur' or 'submit' or when the ngxsFormDebounce is less than zero

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
https://github.com/ngxs/store/issues/365

Issue Number: 365


## What is the new behavior?
When a ngxsFormDebounce is less than zero or when a FormGroup's updateOn property is configured with 'blur' or 'submit', the debounceTime operator will be remove from the valueChanges and statusChanges pipes.

It seems that even with a timer of zero, the state is updated asynchronously after the form has been submited.  Removing the operator in the describe situation resolve the issue.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
