### PR TITLE
perf(store): replace `spread` with `slice` in the operator functions

### DIFF
--- a/packages/store/operators/src/insert-item.ts
+++ b/packages/store/operators/src/insert-item.ts
@@ -17,7 +17,7 @@ export function insertItem<T>(value: T, beforePosition?: number) {
       return [value];
     }
 
-    const clone = [...existing];
+    const clone = existing.slice();
 
     let index = 0;
 

--- a/packages/store/operators/src/remove-item.ts
+++ b/packages/store/operators/src/remove-item.ts
@@ -18,7 +18,7 @@ export function removeItem<T>(selector: number | Predicate<T>) {
       return existing;
     }
 
-    const clone = [...existing];
+    const clone = existing.slice();
     clone.splice(index, 1);
     return clone;
   };

--- a/packages/store/operators/src/update-item.ts
+++ b/packages/store/operators/src/update-item.ts
@@ -41,7 +41,7 @@ export function updateItem<T>(
       return existing;
     }
 
-    const clone = [...existing];
+    const clone = existing.slice();
     clone[index] = value;
     return clone;
   };


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Issue Number: #1055 


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```