### PR TITLE
fix(store): trim down StateClass interface and move it to internals subpackage

### DIFF
--- a/packages/store/internals/src/index.ts
+++ b/packages/store/internals/src/index.ts
@@ -3,4 +3,4 @@ export { NgxsBootstrapper } from './ngxs-bootstrapper';
 export { memoize } from './memoize';
 export { ObjectUtils } from './object-utils';
 export { INITIAL_STATE_TOKEN, InitialState } from './initial-state';
-export { ObjectKeyMap } from './symbols';
+export { ObjectKeyMap, StateClass } from './symbols';

--- a/packages/store/internals/src/symbols.ts
+++ b/packages/store/internals/src/symbols.ts
@@ -1,3 +1,5 @@
 export interface ObjectKeyMap<T> {
   [key: string]: T;
 }
+
+export type StateClass<T = any> = new (...args: any[]) => T;

--- a/packages/store/internals/testing/src/symbol.ts
+++ b/packages/store/internals/testing/src/symbol.ts
@@ -1,6 +1,7 @@
-import { NgxsModuleOptions, StateClass, Store } from '@ngxs/store';
+import { NgxsModuleOptions, Store } from '@ngxs/store';
 import { ModuleWithProviders } from '@angular/core';
 import { TestBedStatic } from '@angular/core/testing';
+import { StateClass } from '@ngxs/store/internals';
 
 export interface NgxsOptionsTesting {
   states?: StateClass[];

--- a/packages/store/src/decorators/state.ts
+++ b/packages/store/src/decorators/state.ts
@@ -1,10 +1,11 @@
-import { ensureStoreMetadata, MetaDataModel, StateClass } from '../internal/internals';
+import { ensureStoreMetadata, MetaDataModel, StateClassInternal } from '../internal/internals';
 import { META_KEY, META_OPTIONS_KEY, StoreOptions } from '../symbols';
 import { StoreValidators } from '../utils/store-validators';
+import { StateClass } from '@ngxs/store/internals';
 
 interface MutateMetaOptions<T> {
   meta: MetaDataModel;
-  inheritedStateClass: StateClass;
+  inheritedStateClass: StateClassInternal;
   optionsWithInheritance: StoreOptions<T>;
 }
 
@@ -12,7 +13,7 @@ interface MutateMetaOptions<T> {
  * Decorates a class with ngxs state information.
  */
 export function State<T>(options: StoreOptions<T>) {
-  function getStateOptions(inheritedStateClass: StateClass): StoreOptions<T> {
+  function getStateOptions(inheritedStateClass: StateClassInternal): StoreOptions<T> {
     const inheritanceOptions: Partial<StoreOptions<T>> =
       inheritedStateClass[META_OPTIONS_KEY] || {};
     return { ...inheritanceOptions, ...options } as StoreOptions<T>;
@@ -34,10 +35,11 @@ export function State<T>(options: StoreOptions<T>) {
   }
 
   return (target: StateClass): void => {
-    const meta: MetaDataModel = ensureStoreMetadata(target);
-    const inheritedStateClass: StateClass = Object.getPrototypeOf(target);
+    const stateClass: StateClassInternal = target;
+    const meta: MetaDataModel = ensureStoreMetadata(stateClass);
+    const inheritedStateClass: StateClassInternal = Object.getPrototypeOf(stateClass);
     const optionsWithInheritance: StoreOptions<T> = getStateOptions(inheritedStateClass);
     mutateMetaData({ meta, inheritedStateClass, optionsWithInheritance });
-    target[META_OPTIONS_KEY] = optionsWithInheritance;
+    stateClass[META_OPTIONS_KEY] = optionsWithInheritance;
   };
 }

--- a/packages/store/src/internal/state-factory.ts
+++ b/packages/store/src/internal/state-factory.ts
@@ -19,7 +19,7 @@ import {
   MetaDataModel,
   nameToState,
   propGetter,
-  StateClass,
+  StateClassInternal,
   StateKeyGraph,
   StatesAndDefaults,
   StatesByName,
@@ -83,14 +83,14 @@ export class StateFactory {
     return value;
   }
 
-  private static checkStatesAreValid(stateClasses: StateClass[]): void {
+  private static checkStatesAreValid(stateClasses: StateClassInternal[]): void {
     stateClasses.forEach(StoreValidators.getValidStateMeta);
   }
 
   /**
    * Add a new state to the global defs.
    */
-  add(stateClasses: StateClass[]): MappedStore[] {
+  add(stateClasses: StateClassInternal[]): MappedStore[] {
     StateFactory.checkStatesAreValid(stateClasses);
     const { newStates } = this.addToStatesMap(stateClasses);
     if (!newStates.length) return [];
@@ -98,11 +98,11 @@ export class StateFactory {
     const stateGraph: StateKeyGraph = buildGraph(newStates);
     const sortedStates: string[] = topologicalSort(stateGraph);
     const depths: ObjectKeyMap<string> = findFullParentPath(stateGraph);
-    const nameGraph: ObjectKeyMap<StateClass> = nameToState(newStates);
+    const nameGraph: ObjectKeyMap<StateClassInternal> = nameToState(newStates);
     const bootstrappedStores: MappedStore[] = [];
 
     for (const name of sortedStates) {
-      const stateClass: StateClass = nameGraph[name];
+      const stateClass: StateClassInternal = nameGraph[name];
       const depth: string = depths[name];
       const meta: MetaDataModel = stateClass[META_KEY]!;
 
@@ -132,8 +132,8 @@ export class StateFactory {
   /**
    * Add a set of states to the store and return the defaults
    */
-  addAndReturnDefaults(stateClasses: StateClass[]): StatesAndDefaults {
-    const classes: StateClass[] = stateClasses || [];
+  addAndReturnDefaults(stateClasses: StateClassInternal[]): StatesAndDefaults {
+    const classes: StateClassInternal[] = stateClasses || [];
 
     const states: MappedStore[] = this.add(classes);
     const defaults = states.reduce(
@@ -211,8 +211,10 @@ export class StateFactory {
     return forkJoin(results);
   }
 
-  private addToStatesMap(stateClasses: StateClass[]): { newStates: StateClass[] } {
-    const newStates: StateClass[] = [];
+  private addToStatesMap(
+    stateClasses: StateClassInternal[]
+  ): { newStates: StateClassInternal[] } {
+    const newStates: StateClassInternal[] = [];
     const statesMap: StatesByName = this.statesByName;
 
     for (const stateClass of stateClasses) {

--- a/packages/store/src/module.ts
+++ b/packages/store/src/module.ts
@@ -6,7 +6,7 @@ import {
   NgModule,
   Provider
 } from '@angular/core';
-import { isAngularInTestMode, NgxsBootstrapper } from '@ngxs/store/internals';
+import { isAngularInTestMode, NgxsBootstrapper, StateClass } from '@ngxs/store/internals';
 import { INITIAL_STATE_TOKEN, InitialState } from '@ngxs/store/internals';
 
 import {
@@ -28,7 +28,6 @@ import { Store } from './store';
 import { SelectFactory } from './decorators/select';
 import { StateStream } from './internal/state-stream';
 import { PluginManager } from './plugin-manager';
-import { StateClass } from './internal/internals';
 import { NgxsRootModule } from './modules/ngxs-root.module';
 import { NgxsFeatureModule } from './modules/ngxs-feature.module';
 import { DispatchOutsideZoneNgxsExecutionStrategy } from './execution/dispatch-outside-zone-ngxs-execution-strategy';

--- a/packages/store/src/modules/ngxs-feature.module.ts
+++ b/packages/store/src/modules/ngxs-feature.module.ts
@@ -5,7 +5,7 @@ import { InternalStateOperations } from '../internal/state-operations';
 import { StateFactory } from '../internal/state-factory';
 import { FEATURE_STATE_TOKEN } from '../symbols';
 import { LifecycleStateManager } from '../internal/lifecycle-state-manager';
-import { StateClass, StatesAndDefaults } from '../internal/internals';
+import { StateClassInternal, StatesAndDefaults } from '../internal/internals';
 import { UpdateState } from '../actions/actions';
 
 /**
@@ -20,12 +20,12 @@ export class NgxsFeatureModule {
     factory: StateFactory,
     @Optional()
     @Inject(FEATURE_STATE_TOKEN)
-    states: StateClass[][] = [],
+    states: StateClassInternal[][] = [],
     lifecycleStateManager: LifecycleStateManager
   ) {
     // Since FEATURE_STATE_TOKEN is a multi token, we need to
     // flatten it [[Feature1State, Feature2State], [Feature3State]]
-    const flattenedStates: StateClass[] = NgxsFeatureModule.flattenStates(states);
+    const flattenedStates: StateClassInternal[] = NgxsFeatureModule.flattenStates(states);
 
     // add stores to the state graph and return their defaults
     const results: StatesAndDefaults = factory.addAndReturnDefaults(flattenedStates);
@@ -38,9 +38,9 @@ export class NgxsFeatureModule {
     }
   }
 
-  private static flattenStates(states: StateClass[][] = []): StateClass[] {
+  private static flattenStates(states: StateClassInternal[][] = []): StateClassInternal[] {
     return states.reduce(
-      (total: StateClass[], values: StateClass[]) => total.concat(values),
+      (total: StateClassInternal[], values: StateClassInternal[]) => total.concat(values),
       []
     );
   }

--- a/packages/store/src/modules/ngxs-root.module.ts
+++ b/packages/store/src/modules/ngxs-root.module.ts
@@ -5,7 +5,11 @@ import { InternalStateOperations } from '../internal/state-operations';
 import { Store } from '../store';
 import { SelectFactory } from '../decorators/select';
 import { NgxsConfig, ROOT_STATE_TOKEN } from '../symbols';
-import { globalSelectorOptions, StateClass, StatesAndDefaults } from '../internal/internals';
+import {
+  globalSelectorOptions,
+  StateClassInternal,
+  StatesAndDefaults
+} from '../internal/internals';
 import { LifecycleStateManager } from '../internal/lifecycle-state-manager';
 import { InitState } from '../actions/actions';
 
@@ -22,7 +26,7 @@ export class NgxsRootModule {
     _select: SelectFactory,
     @Optional()
     @Inject(ROOT_STATE_TOKEN)
-    states: StateClass[] = [],
+    states: StateClassInternal[] = [],
     config: NgxsConfig,
     lifecycleStateManager: LifecycleStateManager
   ) {

--- a/packages/store/src/plugin_api.ts
+++ b/packages/store/src/plugin_api.ts
@@ -1,6 +1,5 @@
 export { NgxsModule } from './module';
 export { NGXS_PLUGINS, NgxsPlugin, NgxsPluginFn, NgxsNextPluginFn } from './symbols';
 export { StateStream } from './internal/state-stream';
-export { StateClass } from './internal/internals';
 export { getActionTypeFromInstance, setValue, getValue } from './utils/utils';
 export { InitState, UpdateState } from './actions/actions';

--- a/packages/store/src/utils/store-validators.ts
+++ b/packages/store/src/utils/store-validators.ts
@@ -1,7 +1,7 @@
 import {
   getStoreMetadata,
   MetaDataModel,
-  StateClass,
+  StateClassInternal,
   StatesByName
 } from '../internal/internals';
 import {
@@ -26,7 +26,10 @@ export abstract class StoreValidators {
     }
   }
 
-  public static checkStateNameIsUnique(state: StateClass, statesByName: StatesByName): string {
+  public static checkStateNameIsUnique(
+    state: StateClassInternal,
+    statesByName: StatesByName
+  ): string {
     const meta: MetaDataModel = this.getValidStateMeta(state);
     const stateName: string = meta!.name as string;
     const existingState = statesByName[stateName];
@@ -36,7 +39,7 @@ export abstract class StoreValidators {
     return stateName;
   }
 
-  public static getValidStateMeta(state: StateClass): MetaDataModel {
+  public static getValidStateMeta(state: StateClassInternal): MetaDataModel {
     const meta: MetaDataModel = getStoreMetadata(state);
     if (!meta) {
       throw new Error(MESSAGES[CODE.STATE_DECORATOR]());

--- a/packages/store/tests/action-handler.spec.ts
+++ b/packages/store/tests/action-handler.spec.ts
@@ -10,7 +10,7 @@ import { NgxsModule } from '../src/module';
 import { Store } from '../src/store';
 import { Actions } from '../src/actions-stream';
 import { NoopErrorHandler } from './helpers/utils';
-import { StateClass } from '../src/internal/internals';
+import { StateClass } from '@ngxs/store/internals';
 
 describe('Action handlers', () => {
   class TestAction {

--- a/packages/store/tests/selector.spec.ts
+++ b/packages/store/tests/selector.spec.ts
@@ -1,10 +1,11 @@
 import { async, TestBed } from '@angular/core/testing';
+import { StateClass } from '@ngxs/store/internals';
+
 import { State } from '../src/decorators/state';
 import { createSelector } from '../src/utils/selector-utils';
 import { Store } from '../src/store';
 import { NgxsModule } from '../src/module';
 import { Selector } from '../src/decorators/selector';
-import { StateClass } from '../src/internal/internals';
 import { NgxsConfig } from '../src/symbols';
 import { SelectorOptions } from '../src/decorators/selector-options';
 
@@ -211,10 +212,7 @@ describe('Selector', () => {
   });
 
   describe('(Selector Options)', () => {
-    function setupStore(
-      states: StateClass<any, any>[],
-      extendedOptions?: Partial<NgxsConfig>
-    ) {
+    function setupStore(states: StateClass[], extendedOptions?: Partial<NgxsConfig>) {
       TestBed.configureTestingModule({
         imports: [NgxsModule.forRoot(states, extendedOptions)]
       });


### PR DESCRIPTION
Reverts ngxs/store#1042
This PR should never have been merged.
It exposes too much of the internal NGXS implementation details.
Hopefully the new extensibility model allows for the hooks that this was intended to expose.