### PR TITLE
docs(store): add warning about sub-state erasure

### DIFF
--- a/docs/advanced/sub-states.md
+++ b/docs/advanced/sub-states.md
@@ -129,4 +129,4 @@ export class CartState {
 }
 ```
 
-If we'd use the `setState` function - we'd overwrite the whole state value and our sub-state `CartSavedState` would erase. The `patchState` function allows us to update only needed properties and preserve our sub-state safe and sound.
+If we had used the `setState` function - we would have overwritten the whole state value and our sub-state `CartSavedState` would be erased. The `patchState` function allows us to update only needed properties and preserve our sub-state safe and sound.

--- a/docs/advanced/sub-states.md
+++ b/docs/advanced/sub-states.md
@@ -82,3 +82,51 @@ nested array objects will not work.
 Sub states can only be used once, reuse implies several restrictions that would eliminate
 some high value features. If you want to re-use them, just create a new state and inherit
 from it.
+
+## Preventing sub-state erasure
+
+Let's have a look at the state graph again:
+
+```TS
+{
+  cart: {
+    checkedout: false,
+    items: [],
+    saved: {
+      dateSaved: new Date(),
+      items: []
+    };
+  }
+}
+```
+
+This means that you have to avoid using `setState` function in the parent `CartState` state as your child state will erase. Assume you've got an action called `SetCheckedoutAndItems`:
+
+```TS
+export interface CartStateModel {
+  checkedout: boolean;
+  items: CartItem[];
+}
+
+export class SetCheckedoutAndItems {
+  static type = '[Cart] Set checkedout and items';
+  constructor(public checkedout: boolean, public items: CartItem[]) {}
+}
+
+@State<CartStateModel>({
+  name: 'cart',
+  defaults: {
+    checkedout: false,
+    items: []
+  },
+  children: [CartSavedState]
+})
+export class CartState {
+  @Action(SetCheckedoutAndItems)
+  setCheckedoutAndItems(ctx: StateContext<CartStateModel>, { checkedout, items }: SetCheckedoutAndItems) {
+    ctx.patchState({ checkedout, items });
+  }
+}
+```
+
+If we'd use the `setState` function - we'd overwrite the whole state value and our sub-state `CartSavedState` would erase. The `patchState` function allows us to update only needed properties and preserve our sub-state safe and sound.


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

https://github.com/ngxs/store/issues/566
https://github.com/ngxs/store/issues/1073