### PR TITLE
refactor: improve state operator typings

### DIFF
--- a/integration/app/store/todos/todos.state.ts
+++ b/integration/app/store/todos/todos.state.ts
@@ -25,7 +25,7 @@ export class TodosState {
   @Action(SetPrefix)
   public setPrefix({ setState }: StateContext<TodoStateModel>) {
     setState(
-      patch({
+      patch<TodoStateModel>({
         pizza: patch({
           model: patch({
             toppings: (topping: any) => 'Mr. ' + topping

--- a/integration/server.ts
+++ b/integration/server.ts
@@ -40,13 +40,10 @@ app.use((req, res, next) => {
   next();
 });
 
-app.engine(
-  'html',
-  ngExpressEngine({
-    bootstrap: AppServerModuleNgFactory,
-    providers: [provideModuleMap(LAZY_MODULE_MAP)]
-  })
-);
+app.engine('html', ngExpressEngine({
+  bootstrap: AppServerModuleNgFactory,
+  providers: [provideModuleMap(LAZY_MODULE_MAP)]
+}) as any);
 
 app.set('view engine', 'html');
 app.set('views', '.');

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "codelyzer": "^4.5.0",
     "core-js": "^2.6.0",
     "cross-env": "^5.2.0",
-    "dtslint": "^0.7.6",
+    "dtslint": "^0.8.0",
     "express": "^4.17.1",
     "fs-extra": "^7.0.1",
     "husky": "^1.1.0",

--- a/packages/store/operators/src/append.ts
+++ b/packages/store/operators/src/append.ts
@@ -1,13 +1,15 @@
+import { StateOperator } from '@ngxs/store';
+
 /**
  * @param items - Specific items to append to the end of an array
  */
-export function append<T>(items: T[]) {
-  return function appendOperator(existing: Readonly<T[]>): T[] {
+export function append<T>(items: T[]): StateOperator<T[]> {
+  return function appendOperator(existing: ReadonlyArray<T>): T[] {
     // If `items` is `undefined` or `null` or `[]` but `existing` is provided
     // just return `existing`
     const itemsNotProvidedButExistingIs = (!items || !items.length) && existing;
     if (itemsNotProvidedButExistingIs) {
-      return existing;
+      return existing as T[];
     }
 
     if (Array.isArray(existing)) {

--- a/packages/store/operators/src/compose.ts
+++ b/packages/store/operators/src/compose.ts
@@ -1,7 +1,7 @@
 import { StateOperator } from '@ngxs/store';
 
-export function compose<T>(...operators: StateOperator<T>[]) {
-  return function composeOperator(existing: Readonly<T>) {
+export function compose<T>(...operators: StateOperator<T>[]): StateOperator<T> {
+  return function composeOperator(existing: Readonly<T>): T {
     return operators.reduce((accumulator, operator) => operator(accumulator), existing);
   };
 }

--- a/packages/store/operators/src/iif.ts
+++ b/packages/store/operators/src/iif.ts
@@ -29,8 +29,8 @@ function retrieveValue<T>(operatorOrValue: StateOperator<T> | T, existing?: Read
  */
 export function iif<T>(
   condition: Predicate<T> | boolean,
-  trueOperatorOrValue: StateOperator<T> | T,
-  elseOperatorOrValue?: StateOperator<T> | T
+  trueOperatorOrValue: StateOperator<T> | T | null | undefined,
+  elseOperatorOrValue?: StateOperator<T> | T | null | undefined
 ): StateOperator<T> {
   return function iifOperator(existing: Readonly<T>): T {
     // Convert the value to a boolean
@@ -41,7 +41,7 @@ export function iif<T>(
     }
 
     if (result) {
-      return retrieveValue(trueOperatorOrValue, existing);
+      return retrieveValue(trueOperatorOrValue!, existing);
     }
 
     return retrieveValue(elseOperatorOrValue!, existing);

--- a/packages/store/operators/src/iif.ts
+++ b/packages/store/operators/src/iif.ts
@@ -1,7 +1,7 @@
 import { StateOperator } from '@ngxs/store';
 
-import { isStateOperator, isUndefined, isPredicate } from './utils';
 import { Predicate } from './internals';
+import { isStateOperator, isUndefined, isPredicate } from './utils';
 
 function retrieveValue<T>(operatorOrValue: StateOperator<T> | T, existing?: Readonly<T>): T {
   // If state operator is a function
@@ -31,7 +31,7 @@ export function iif<T>(
   condition: Predicate<T> | boolean,
   trueOperatorOrValue: StateOperator<T> | T,
   elseOperatorOrValue?: StateOperator<T> | T
-) {
+): StateOperator<T> {
   return function iifOperator(existing: Readonly<T>): T {
     // Convert the value to a boolean
     let result = !!condition;

--- a/packages/store/operators/src/insert-item.ts
+++ b/packages/store/operators/src/insert-item.ts
@@ -1,15 +1,17 @@
+import { StateOperator } from '@ngxs/store';
+
 import { isNil } from './utils';
 
 /**
  * @param value - Value to insert
  * @param [beforePosition] -  Specified index to insert value before, optional
  */
-export function insertItem<T>(value: T, beforePosition?: number) {
-  return function insertItemOperator(existing: Readonly<T[]>): T[] {
+export function insertItem<T>(value: T, beforePosition?: number): StateOperator<T[]> {
+  return function insertItemOperator(existing: ReadonlyArray<T>): T[] {
     // Have to check explicitly for `null` and `undefined`
     // because `value` can be `0`, thus `!value` will return `true`
     if (isNil(value) && existing) {
-      return existing;
+      return existing as T[];
     }
 
     // Property may be dynamic and might not existed before

--- a/packages/store/operators/src/remove-item.ts
+++ b/packages/store/operators/src/remove-item.ts
@@ -1,11 +1,13 @@
+import { StateOperator } from '@ngxs/store';
+
 import { Predicate } from './internals';
 import { isPredicate, isNumber, invalidIndex } from './utils';
 
 /**
  * @param selector - index or predicate to remove an item from an array by
  */
-export function removeItem<T>(selector: number | Predicate<T>) {
-  return function removeItemOperator(existing: Readonly<T[]>): T[] {
+export function removeItem<T>(selector: number | Predicate<T>): StateOperator<T[]> {
+  return function removeItemOperator(existing: ReadonlyArray<T>): T[] {
     let index = -1;
 
     if (isPredicate(selector)) {
@@ -15,7 +17,7 @@ export function removeItem<T>(selector: number | Predicate<T>) {
     }
 
     if (invalidIndex(index)) {
-      return existing;
+      return existing as T[];
     }
 
     const clone = existing.slice();

--- a/packages/store/operators/src/update-item.ts
+++ b/packages/store/operators/src/update-item.ts
@@ -1,7 +1,7 @@
 import { StateOperator } from '@ngxs/store';
 
-import { isStateOperator, isPredicate, isNumber, invalidIndex } from './utils';
 import { Predicate } from './internals';
+import { isStateOperator, isPredicate, isNumber, invalidIndex } from './utils';
 
 /**
  * @param selector - Index of item in the array or a predicate function
@@ -13,7 +13,7 @@ export function updateItem<T>(
   selector: number | Predicate<T>,
   operatorOrValue: T | StateOperator<T>
 ): StateOperator<T[]> {
-  return function updateItemOperator(existing: Readonly<T[]>) {
+  return function updateItemOperator(existing: ReadonlyArray<T>): T[] {
     let index = -1;
 
     if (isPredicate(selector)) {
@@ -23,7 +23,7 @@ export function updateItem<T>(
     }
 
     if (invalidIndex(index)) {
-      return existing;
+      return existing as T[];
     }
 
     let value: T = null!;
@@ -38,7 +38,7 @@ export function updateItem<T>(
     // If the value hasn't been mutated
     // then we just return `existing` array
     if (value === existing[index]) {
-      return existing;
+      return existing as T[];
     }
 
     const clone = existing.slice();

--- a/packages/store/operators/tests/append.spec.ts
+++ b/packages/store/operators/tests/append.spec.ts
@@ -89,7 +89,7 @@ describe('append', () => {
         const original: Original = { a: [1, 2, 3], b: [1, 2, 3], c: [1, 2, 3] };
 
         // Act
-        const newValue = patch({
+        const newValue = patch<Original>({
           a: append([4, 5]),
           b: append([4, 5]),
           c: append([4, 5]),
@@ -112,13 +112,15 @@ describe('append', () => {
   describe('when object with nested patch operators provided', () => {
     describe('with different calculated values', () => {
       it('treats the nested object as a patch', () => {
+        interface B {
+          hello?: string[];
+          goodbye?: string[];
+        }
+
         // Arrange
         interface Original {
           a: number[];
-          b: {
-            hello?: string[];
-            goodbye?: string[];
-          };
+          b: B;
         }
         const original: Original = {
           a: [1, 2, 3],
@@ -130,7 +132,7 @@ describe('append', () => {
         // Act
         const newValue = patch({
           a: append([4, 5]),
-          b: patch({
+          b: patch<B>({
             goodbye: ['there']
           })
         })(original);
@@ -148,16 +150,18 @@ describe('append', () => {
 
     describe('with nesting multiple levels deep', () => {
       it('returns the deeply patched object', () => {
+        interface NestedStock {
+          wine: Wine[];
+          nestedStock?: {
+            whiskey: Whiskey[];
+          };
+        }
+
         // Arrange
         interface Stock {
           beer: Beer[];
           controller: string[];
-          nestedStock?: {
-            wine: Wine[];
-            nestedStock?: {
-              whiskey: Whiskey[];
-            };
-          };
+          nestedStock?: NestedStock;
         }
 
         interface Beer {
@@ -201,7 +205,7 @@ describe('append', () => {
         })(original);
 
         const newValue2 = patch<Stock>({
-          nestedStock: patch({
+          nestedStock: patch<NestedStock>({
             wine: append([{ name: 'Chablis', quantity: 20 }]),
             nestedStock: patch({
               whiskey: append([{ name: 'Chivas' }])

--- a/packages/store/operators/tests/compose.spec.ts
+++ b/packages/store/operators/tests/compose.spec.ts
@@ -28,17 +28,23 @@ describe('compose', () => {
     });
 
     it('returns the same root', () => {
+      interface Original {
+        a: {
+          hello: string;
+        };
+      }
+
       // Arrange
-      const original = {
+      const original: Original = {
         a: {
           hello: 'world'
         }
       };
 
       // Act
-      const newValue = patch({
+      const newValue = patch<Original>({
         a: compose(
-          iif(
+          iif<Original['a']>(
             a => a!.hello === 'world',
             patch({
               hello: 'world'
@@ -52,18 +58,24 @@ describe('compose', () => {
     });
 
     it('returns a new root', () => {
+      interface Original {
+        a: number;
+        b: number;
+        c: number;
+      }
+
       // Arrange
-      const original = {
+      const original: Original = {
         a: 1,
         b: 2,
         c: 3
       };
 
       // Act
-      const newValue = compose(
+      const newValue = compose<Original>(
         patch({ a: 10 }),
-        iif(object => object!.b === 2, patch({ b: 20 })),
-        iif(object => object!.c === 3, patch({ c: 30 }))
+        iif<Original>(object => object!.b === 2, patch({ b: 20 })),
+        iif<Original>(object => object!.c === 3, patch({ c: 30 }))
       )(original);
 
       // Assert
@@ -329,7 +341,7 @@ describe('compose', () => {
         }
       })(original);
 
-      const newValue2 = patch({
+      const newValue2 = patch<Stock>({
         nestedStock: patch({
           wine: compose(
             iif(wines => wines!.length === 0, append([{ name: 'Geneve', quantity: 10 }])),

--- a/packages/store/operators/tests/compose.spec.ts
+++ b/packages/store/operators/tests/compose.spec.ts
@@ -73,9 +73,9 @@ describe('compose', () => {
 
       // Act
       const newValue = compose<Original>(
-        patch({ a: 10 }),
-        iif<Original>(object => object!.b === 2, patch({ b: 20 })),
-        iif<Original>(object => object!.c === 3, patch({ c: 30 }))
+        patch<Original>({ a: 10 }),
+        iif<Original>(object => object!.b === 2, patch<Original>({ b: 20 })),
+        iif<Original>(object => object!.c === 3, patch<Original>({ c: 30 }))
       )(original);
 
       // Assert
@@ -282,16 +282,18 @@ describe('compose', () => {
 
   describe('compose with with nesting multiple levels deep', () => {
     it('returns the deeply patched object', () => {
+      interface NestedStock {
+        wine: Wine[];
+        nestedStock?: {
+          whiskey: Whiskey[];
+        };
+      }
+
       // Arrange
       interface Stock {
         beer: Beer[];
         controller: string[];
-        nestedStock?: {
-          wine: Wine[];
-          nestedStock?: {
-            whiskey: Whiskey[];
-          };
-        };
+        nestedStock?: NestedStock;
       }
 
       interface Beer {
@@ -342,7 +344,7 @@ describe('compose', () => {
       })(original);
 
       const newValue2 = patch<Stock>({
-        nestedStock: patch({
+        nestedStock: patch<NestedStock>({
           wine: compose(
             iif(wines => wines!.length === 0, append([{ name: 'Geneve', quantity: 10 }])),
             insertItem({ name: 'Geneve 2', quantity: 20 })

--- a/packages/store/operators/tests/iif.spec.ts
+++ b/packages/store/operators/tests/iif.spec.ts
@@ -340,7 +340,7 @@ describe('iif', () => {
         const newValue2 = patch<Model>({
           b: patch<Model['b']>({
             hello: patch<Greeting>({
-              motivated: iif(motivated => motivated !== true, true),
+              motivated: iif<boolean>(motivated => motivated !== true, true),
               person: patch({
                 name: iif(name => name !== 'Mark', 'Artur'),
                 lastName: iif(lastName => lastName !== 'Whitfield', 'Androsovych')

--- a/packages/store/operators/tests/iif.spec.ts
+++ b/packages/store/operators/tests/iif.spec.ts
@@ -187,7 +187,9 @@ describe('iif', () => {
       const original = { a: 1, b: 2, c: 3 };
 
       // Act
-      const newValue = iif<Original>(() => false, patch({ b: 20 }), patch({ a: 1 }))(original);
+      const newValue = iif(() => false, patch<Original>({ b: 20 }), patch<Original>({ a: 1 }))(
+        original
+      );
 
       // Assert
       expect(newValue).toBe(original);
@@ -268,7 +270,10 @@ describe('iif', () => {
         const original: Combined = { a: 1, b: { hello: 'world' } };
         // Act
         const newValue = patch({
-          b: iif<Combined['b']>(b => b!.hello === 'world', patch({ goodbye: 'there' }))
+          b: iif<Combined['b']>(
+            b => b!.hello === 'world',
+            patch<{ hello?: string; goodbye?: string }>({ goodbye: 'there' })
+          )
         })(original);
 
         // Assert
@@ -323,8 +328,8 @@ describe('iif', () => {
         const newValue = patch<Model>({
           b: iif<Model['b']>(
             b => typeof b!.hello === 'object',
-            patch({
-              hello: patch({
+            patch<Model['b']>({
+              hello: patch<Greeting>({
                 motivated: iif(motivated => motivated !== true, true),
                 person: patch({
                   name: 'Artur',

--- a/packages/store/operators/tests/insert-item.spec.ts
+++ b/packages/store/operators/tests/insert-item.spec.ts
@@ -57,11 +57,15 @@ describe('insert item', () => {
 
   describe('when property is added dynamically', () => {
     it('returns a new root', () => {
+      interface Original {
+        a?: number[];
+      }
+
       // Arrange
-      const original: { a?: number[] } = {};
+      const original: Original = {};
 
       // Act
-      const newValue = patch({
+      const newValue = patch<Original>({
         a: insertItem(10)
       })(original);
 
@@ -114,14 +118,17 @@ describe('insert item', () => {
   describe('when object with nested patch operators provided', () => {
     describe('with different calculated values', () => {
       it('treats the nested object as a patch', () => {
+        interface B {
+          hello?: string[];
+          goodbye?: string[];
+        }
+
         // Arrange
         interface Original {
           a: number[];
-          b: {
-            hello?: string[];
-            goodbye?: string[];
-          };
+          b: B;
         }
+
         const original: Original = {
           a: [1, 2, 3],
           b: {
@@ -132,7 +139,7 @@ describe('insert item', () => {
         // Act
         const newValue = patch({
           a: insertItem(20),
-          b: patch({
+          b: patch<B>({
             goodbye: insertItem('there')
           })
         })(original);
@@ -151,16 +158,18 @@ describe('insert item', () => {
 
   describe('with nesting multiple levels deep', () => {
     it('returns the deeply patched object', () => {
+      interface NestedStock {
+        wine: Wine[];
+        nestedStock?: {
+          whiskey: Whiskey[];
+        };
+      }
+
       // Arrange
       interface Stock {
         beer: Beer[];
         controller: string[];
-        nestedStock?: {
-          wine: Wine[];
-          nestedStock?: {
-            whiskey: Whiskey[];
-          };
-        };
+        nestedStock?: NestedStock;
       }
 
       interface Beer {
@@ -204,7 +213,7 @@ describe('insert item', () => {
       })(original);
 
       const newValue2 = patch<Stock>({
-        nestedStock: patch({
+        nestedStock: patch<NestedStock>({
           wine: insertItem({ name: 'Chablis', quantity: 20 }),
           nestedStock: patch({
             whiskey: insertItem({ name: 'Chivas' })

--- a/packages/store/operators/tests/patch.spec.ts
+++ b/packages/store/operators/tests/patch.spec.ts
@@ -303,8 +303,8 @@ describe('patch', () => {
 
           // Act
           const newValue = patch<Model>({
-            b: patch({
-              hello: patch({
+            b: patch<Model['b']>({
+              hello: patch<Model['b']['hello']>({
                 enthusiastic: true,
                 person: patch({
                   name: 'Mark',

--- a/packages/store/operators/tests/remove-item.spec.ts
+++ b/packages/store/operators/tests/remove-item.spec.ts
@@ -102,13 +102,15 @@ describe('remove item', () => {
           person: Person;
         }
 
+        interface B {
+          hello?: Greeting[];
+          goodbye?: Greeting[];
+          greeting?: string[];
+        }
+
         interface Model {
           a: number[];
-          b: {
-            hello?: Greeting[];
-            goodbye?: Greeting[];
-            greeting?: string[];
-          };
+          b: B;
         }
 
         const original: Model = {
@@ -144,7 +146,7 @@ describe('remove item', () => {
         // Act
         const newValue = patch({
           a: removeItem(number => number === 5),
-          b: patch({
+          b: patch<B>({
             hello: removeItem<Greeting>(greeting => greeting!.person.name === 'YOU'),
             goodbye: removeItem<Greeting>(greeting => greeting!.person.name === 'Artur')
           })

--- a/packages/store/operators/tests/update-item.spec.ts
+++ b/packages/store/operators/tests/update-item.spec.ts
@@ -49,14 +49,21 @@ describe('update item', () => {
     });
 
     it('returns the same root', () => {
+      interface Original {
+        a: { name: string }[];
+      }
+
       // Arrange
-      const original = {
+      const original: Original = {
         a: [{ name: 'Mark' }, { name: 'Artur' }]
       };
 
       // Act
-      const newValue = patch({
-        a: updateItem(item => item!.name === 'Mark', patch({ name: 'Mark' }))
+      const newValue = patch<Original>({
+        a: updateItem<Original['a'][number]>(
+          item => item!.name === 'Mark',
+          patch({ name: 'Mark' })
+        )
       })(original);
 
       // Assert

--- a/packages/store/operators/tests/update-item.spec.ts
+++ b/packages/store/operators/tests/update-item.spec.ts
@@ -253,13 +253,15 @@ describe('update item', () => {
           person: Person;
         }
 
+        interface B {
+          hello?: Greeting[];
+          goodbye?: Greeting[];
+          greeting?: string[];
+        }
+
         interface Model {
           a: number;
-          b: {
-            hello?: Greeting[];
-            goodbye?: Greeting[];
-            greeting?: string[];
-          };
+          b: B;
           c?: number;
         }
 
@@ -285,7 +287,7 @@ describe('update item', () => {
 
         // Act
         const newValue = patch({
-          b: patch({
+          b: patch<B>({
             hello: updateItem<Greeting>(item => item!.person.name === 'you', {
               enthusiastic: true,
               person: {
@@ -366,7 +368,7 @@ describe('update item', () => {
         const newValue = patch({
           games: updateItem<Game>(
             item => item!.name === 'CS:GO',
-            patch({
+            patch<Game>({
               categories: updateItem(
                 item => item!.name === 'shooter',
                 patch({ name: 'shooter' })

--- a/packages/store/types/tests/state-operators.iif.lint.ts
+++ b/packages/store/types/tests/state-operators.iif.lint.ts
@@ -28,14 +28,14 @@ describe('[TEST]: the iif State Operator', () => {
     iif<number | null>(() => true, null)(100); // $ExpectType number | null
     iif<number | null>(() => false, 1)(100); // $ExpectType number | null
     iif<number | null>(() => false, 1, null)(100); // $ExpectType number | null
-    // patch<MyType>({ _num: iif(() => true, null) })(original); // $ExpectType MyType
-    // patch<MyType>({ _num: iif(() => false, 123, null) })(original); // $ExpectType MyType
+    patch<MyType>({ _num: iif<number>(() => true, null) })(original); // $ExpectType MyType
+    patch<MyType>({ _num: iif<number>(() => false, 123, null) })(original); // $ExpectType MyType
 
     iif<number | undefined>(() => true, undefined)(100); // $ExpectType number | undefined
     iif<number | undefined>(() => true, 1)(100); // $ExpectType number | undefined
     iif<number | undefined>(() => true, 1, undefined)(100); // $ExpectType number | undefined
-    // patch<MyType>({ __num: iif(() => true, undefined) })(original); // $ExpectType MyType
-    // patch<MyType>({ __num: iif(() => false, 123, undefined) })(original); // $ExpectType MyType
+    patch<MyType>({ __num: iif<number>(() => true, undefined) })(original); // $ExpectType MyType
+    patch<MyType>({ __num: iif<number>(() => false, 123, undefined) })(original); // $ExpectType MyType
 
     iif<MyType>(() => true, patch<MyType>({ num: 1 }))(original); // $ExpectType MyType
     iif<MyType>(
@@ -75,14 +75,14 @@ describe('[TEST]: the iif State Operator', () => {
     iif<string | null>(() => true, null)('100'); // $ExpectType string | null
     iif<string | null>(() => false, '1')('100'); // $ExpectType string | null
     iif<string | null>(() => false, '1', null)('100'); // $ExpectType string | null
-    // patch<MyType>({ _str: iif(() => true, null) })(original); // $ExpectType MyType
-    // patch<MyType>({ _str: iif(() => false, '123', null) })(original); // $ExpectType MyType
+    patch<MyType>({ _str: iif<string>(() => true, null) })(original); // $ExpectType MyType
+    patch<MyType>({ _str: iif<string>(() => false, '123', null) })(original); // $ExpectType MyType
 
     iif<string | undefined>(() => true, undefined)('100'); // $ExpectType string | undefined
     iif<string | undefined>(() => true, '1')('100'); // $ExpectType string | undefined
     iif<string | undefined>(() => true, '1', undefined)('100'); // $ExpectType string | undefined
-    // patch<MyType>({ __str: iif(() => true, undefined) })(original); // $ExpectType MyType
-    // patch<MyType>({ __str: iif(() => false, '123', undefined) })(original); // $ExpectType MyType
+    patch<MyType>({ __str: iif<string>(() => true, undefined) })(original); // $ExpectType MyType
+    patch<MyType>({ __str: iif<string>(() => false, '123', undefined) })(original); // $ExpectType MyType
 
     iif<MyType>(() => true, patch<MyType>({ str: '1' }))(original); // $ExpectType MyType
     iif<MyType>(
@@ -107,14 +107,14 @@ describe('[TEST]: the iif State Operator', () => {
 
     const original: MyType = { bool: true, _bool: null };
 
-    // patch<MyType>({ bool: iif(null!, true) })(original); // $ExpectType MyType
-    patch<MyType>({ bool: iif(null!, false, true) })(original); // $ExpectType MyType
-    // patch<MyType>({ bool: iif(undefined!, true) })(original); // $ExpectType MyType
-    patch<MyType>({ bool: iif(undefined!, false, true) })(original); // $ExpectType MyType
+    patch<MyType>({ bool: iif<boolean>(null!, true) })(original); // $ExpectType MyType
+    patch<MyType>({ bool: iif<boolean>(null!, false, true) })(original); // $ExpectType MyType
+    patch<MyType>({ bool: iif<boolean>(undefined!, true) })(original); // $ExpectType MyType
+    patch<MyType>({ bool: iif<boolean>(undefined!, false, true) })(original); // $ExpectType MyType
 
-    // patch<MyType>({ bool: iif(() => true, true) })(original); // $ExpectType MyType
-    // patch<MyType>({ bool: iif(true, true) })(original); // $ExpectType MyType
-    // patch<MyType>({ bool: iif(val => val === true, true) })(original); // $ExpectType MyType
+    patch<MyType>({ bool: iif<boolean>(() => true, true) })(original); // $ExpectType MyType
+    patch<MyType>({ bool: iif<boolean>(true, true) })(original); // $ExpectType MyType
+    patch<MyType>({ bool: iif<boolean>(val => val === true, true) })(original); // $ExpectType MyType
     patch<MyType>({ bool: iif(() => false, true, false) })(original); // $ExpectType MyType
     patch<MyType>({ bool: iif(false, true, false) })(original); // $ExpectType MyType
     patch<MyType>({ bool: iif(val => val === false, true, false) })(original); // $ExpectType MyType
@@ -122,14 +122,14 @@ describe('[TEST]: the iif State Operator', () => {
     iif<boolean | null>(() => true, null)(true); // $ExpectType boolean | null
     iif<boolean | null>(() => false, true)(true); // $ExpectType boolean | null
     iif<boolean | null>(() => false, true, null)(true); // $ExpectType boolean | null
-    // patch<MyType>({ _bool: iif(() => true, null) })(original); // $ExpectType MyType
-    // patch<MyType>({ _bool: iif(() => false, true, null) })(original); // $ExpectType MyType
+    patch<MyType>({ _bool: iif<boolean>(() => true, null) })(original); // $ExpectType MyType
+    patch<MyType>({ _bool: iif<boolean>(() => false, true, null) })(original); // $ExpectType MyType
 
     iif<boolean | undefined>(() => true, undefined)(true); // $ExpectType boolean | undefined
     iif<boolean | undefined>(() => true, true)(true); // $ExpectType boolean | undefined
     iif<boolean | undefined>(() => true, true, undefined)(true); // $ExpectType boolean | undefined
-    // patch<MyType>({ __bool: iif(() => true, undefined) })(original); // $ExpectType MyType
-    // patch<MyType>({ __bool: iif(() => false, true, undefined) })(original); // $ExpectType MyType
+    patch<MyType>({ __bool: iif<boolean>(() => true, undefined) })(original); // $ExpectType MyType
+    patch<MyType>({ __bool: iif<boolean>(() => false, true, undefined) })(original); // $ExpectType MyType
 
     iif<MyType>(() => true, patch<MyType>({ bool: true }))(original); // $ExpectType MyType
     iif<MyType>(
@@ -174,14 +174,14 @@ describe('[TEST]: the iif State Operator', () => {
     iif<MyObj | null>(() => true, null)({ val: '100' }); // $ExpectType MyObj | null
     iif<MyObj | null>(() => false, { val: '1' })({ val: '100' }); // $ExpectType MyObj | null
     iif<MyObj | null>(() => false, { val: '1' }, null)({ val: '100' }); // $ExpectType MyObj | null
-    // patch<MyType>({ _obj: iif(() => true, null) })(original); // $ExpectType MyType
-    // patch<MyType>({ _obj: iif(() => false, { val: '123' }, null) })(original); // $ExpectType MyType
+    patch<MyType>({ _obj: iif<MyObj>(() => true, null) })(original); // $ExpectType MyType
+    patch<MyType>({ _obj: iif<MyObj>(() => false, { val: '123' }, null) })(original); // $ExpectType MyType
 
     iif<MyObj | undefined>(() => true, undefined)({ val: '100' }); // $ExpectType MyObj | undefined
     iif<MyObj | undefined>(() => true, { val: '1' })({ val: '100' }); // $ExpectType MyObj | undefined
     iif<MyObj | undefined>(() => true, { val: '1' }, undefined)({ val: '100' }); // $ExpectType MyObj | undefined
-    // patch<MyType>({ __obj: iif(() => true, undefined) })(original); // $ExpectType MyType
-    // patch<MyType>({ __obj: iif(() => false, { val: '123' }, undefined) })(original); // $ExpectType MyType
+    patch<MyType>({ __obj: iif<MyObj>(() => true, undefined) })(original); // $ExpectType MyType
+    patch<MyType>({ __obj: iif<MyObj>(() => false, { val: '123' }, undefined) })(original); // $ExpectType MyType
 
     iif<MyType>(() => true, patch<MyType>({ obj: { val: '1' } }))(original); // $ExpectType MyType
     iif<MyType>(
@@ -235,13 +235,12 @@ describe('[TEST]: the iif State Operator', () => {
       }
     };
 
-    /*
     patch<Model>({
       b: iif<Model['b']>(
         b => typeof b!.hello === 'object',
         patch<Model['b']>({
-          hello: patch({
-            motivated: iif(motivated => motivated !== true, true),
+          hello: patch<Greeting>({
+            motivated: iif<boolean>(motivated => motivated !== true, true),
             person: patch({
               name: 'Artur',
               lastName: 'Androsovych'
@@ -251,14 +250,12 @@ describe('[TEST]: the iif State Operator', () => {
         })
       ),
       c: iif(c => c !== 100, () => 0 + 100, 10)
-    })(original); // $//ExpectType Model
-    */
+    })(original); // $ExpectType Model
 
-    /*
     patch<Model>({
       b: patch<Model['b']>({
         hello: patch<Greeting>({
-          motivated: iif(motivated => motivated !== true, true),
+          motivated: iif<boolean>(motivated => motivated !== true, true),
           person: patch({
             name: iif(name => name !== 'Mark', 'Artur'),
             lastName: iif(lastName => lastName !== 'Whitfeld', 'Androsovych')
@@ -267,8 +264,7 @@ describe('[TEST]: the iif State Operator', () => {
         greeting: iif(greeting => !greeting, 'How are you?')
       }),
       c: iif(c => !c, 100, 10)
-    })(original); // $//ExpectType Model
-    */
+    })(original); // $ExpectType Model
   });
 
   it('should not accept the following usages', () => {

--- a/packages/store/types/tests/state-operators.iif.lint.ts
+++ b/packages/store/types/tests/state-operators.iif.lint.ts
@@ -1,0 +1,315 @@
+/* tslint:disable:max-line-length */
+
+/// <reference types="@types/jest" />
+import { iif, patch } from '../../operators/src';
+
+describe('[TEST]: the iif State Operator', () => {
+  it('should have the following valid number usages', () => {
+    interface MyType {
+      num: number;
+      _num: number | null;
+      __num?: number;
+    }
+
+    const original: MyType = { num: 1, _num: null };
+
+    patch<MyType>({ num: iif(null!, 1) })(original); // $ExpectType MyType
+    patch<MyType>({ num: iif(null!, 2, 3) })(original); // $ExpectType MyType
+    patch<MyType>({ num: iif(undefined!, 1) })(original); // $ExpectType MyType
+    patch<MyType>({ num: iif(undefined!, 2, 3) })(original); // $ExpectType MyType
+
+    patch<MyType>({ num: iif(() => true, 10) })(original); // $ExpectType MyType
+    patch<MyType>({ num: iif(true, 10) })(original); // $ExpectType MyType
+    patch<MyType>({ num: iif(val => val === 1, 10) })(original); // $ExpectType MyType
+    patch<MyType>({ num: iif(() => false, 10, 20) })(original); // $ExpectType MyType
+    patch<MyType>({ num: iif(false, 10, 20) })(original); // $ExpectType MyType
+    patch<MyType>({ num: iif(val => val === 2, 10, 20) })(original); // $ExpectType MyType
+
+    iif<number | null>(() => true, null)(100); // $ExpectType number | null
+    iif<number | null>(() => false, 1)(100); // $ExpectType number | null
+    iif<number | null>(() => false, 1, null)(100); // $ExpectType number | null
+    // patch<MyType>({ _num: iif(() => true, null) })(original); // $ExpectType MyType
+    // patch<MyType>({ _num: iif(() => false, 123, null) })(original); // $ExpectType MyType
+
+    iif<number | undefined>(() => true, undefined)(100); // $ExpectType number | undefined
+    iif<number | undefined>(() => true, 1)(100); // $ExpectType number | undefined
+    iif<number | undefined>(() => true, 1, undefined)(100); // $ExpectType number | undefined
+    // patch<MyType>({ __num: iif(() => true, undefined) })(original); // $ExpectType MyType
+    // patch<MyType>({ __num: iif(() => false, 123, undefined) })(original); // $ExpectType MyType
+
+    iif<MyType>(() => true, patch<MyType>({ num: 1 }))(original); // $ExpectType MyType
+    iif<MyType>(
+      () => true,
+      patch<MyType>({ num: 3, _num: 4 }),
+      patch<MyType>({ num: 5, __num: 6 })
+    )(original); // $ExpectType MyType
+
+    patch<MyType>({
+      num: iif(() => false, 10, 30),
+      _num: iif(() => true, 50, 100),
+      __num: iif(() => true, 5, 10)
+    })(original); // $ExpectType MyType
+  });
+
+  it('should have the following valid string usages', () => {
+    interface MyType {
+      str: string;
+      _str: string | null;
+      __str?: string;
+    }
+
+    const original: MyType = { str: '1', _str: null };
+
+    patch<MyType>({ str: iif(null!, '1') })(original); // $ExpectType MyType
+    patch<MyType>({ str: iif(null!, '2', '3') })(original); // $ExpectType MyType
+    patch<MyType>({ str: iif(undefined!, '1') })(original); // $ExpectType MyType
+    patch<MyType>({ str: iif(undefined!, '2', '3') })(original); // $ExpectType MyType
+
+    patch<MyType>({ str: iif(() => true, '10') })(original); // $ExpectType MyType
+    patch<MyType>({ str: iif(true, '10') })(original); // $ExpectType MyType
+    patch<MyType>({ str: iif(val => val === '1', '10') })(original); // $ExpectType MyType
+    patch<MyType>({ str: iif(() => false, '10', '20') })(original); // $ExpectType MyType
+    patch<MyType>({ str: iif(false, '10', '20') })(original); // $ExpectType MyType
+    patch<MyType>({ str: iif(val => val === '2', '10', '20') })(original); // $ExpectType MyType
+
+    iif<string | null>(() => true, null)('100'); // $ExpectType string | null
+    iif<string | null>(() => false, '1')('100'); // $ExpectType string | null
+    iif<string | null>(() => false, '1', null)('100'); // $ExpectType string | null
+    // patch<MyType>({ _str: iif(() => true, null) })(original); // $ExpectType MyType
+    // patch<MyType>({ _str: iif(() => false, '123', null) })(original); // $ExpectType MyType
+
+    iif<string | undefined>(() => true, undefined)('100'); // $ExpectType string | undefined
+    iif<string | undefined>(() => true, '1')('100'); // $ExpectType string | undefined
+    iif<string | undefined>(() => true, '1', undefined)('100'); // $ExpectType string | undefined
+    // patch<MyType>({ __str: iif(() => true, undefined) })(original); // $ExpectType MyType
+    // patch<MyType>({ __str: iif(() => false, '123', undefined) })(original); // $ExpectType MyType
+
+    iif<MyType>(() => true, patch<MyType>({ str: '1' }))(original); // $ExpectType MyType
+    iif<MyType>(
+      () => true,
+      patch<MyType>({ str: '3', _str: '4' }),
+      patch<MyType>({ str: '5', __str: '6' })
+    )(original); // $ExpectType MyType
+
+    patch<MyType>({
+      str: iif(() => false, '10', '30'),
+      _str: iif(() => true, '50', '100'),
+      __str: iif(() => true, '5', '10')
+    })(original); // $ExpectType MyType
+  });
+
+  it('should have the following valid boolean usages', () => {
+    interface MyType {
+      bool: boolean;
+      _bool: boolean | null;
+      __bool?: boolean;
+    }
+
+    const original: MyType = { bool: true, _bool: null };
+
+    // patch<MyType>({ bool: iif(null!, true) })(original); // $ExpectType MyType
+    patch<MyType>({ bool: iif(null!, false, true) })(original); // $ExpectType MyType
+    // patch<MyType>({ bool: iif(undefined!, true) })(original); // $ExpectType MyType
+    patch<MyType>({ bool: iif(undefined!, false, true) })(original); // $ExpectType MyType
+
+    // patch<MyType>({ bool: iif(() => true, true) })(original); // $ExpectType MyType
+    // patch<MyType>({ bool: iif(true, true) })(original); // $ExpectType MyType
+    // patch<MyType>({ bool: iif(val => val === true, true) })(original); // $ExpectType MyType
+    patch<MyType>({ bool: iif(() => false, true, false) })(original); // $ExpectType MyType
+    patch<MyType>({ bool: iif(false, true, false) })(original); // $ExpectType MyType
+    patch<MyType>({ bool: iif(val => val === false, true, false) })(original); // $ExpectType MyType
+
+    iif<boolean | null>(() => true, null)(true); // $ExpectType boolean | null
+    iif<boolean | null>(() => false, true)(true); // $ExpectType boolean | null
+    iif<boolean | null>(() => false, true, null)(true); // $ExpectType boolean | null
+    // patch<MyType>({ _bool: iif(() => true, null) })(original); // $ExpectType MyType
+    // patch<MyType>({ _bool: iif(() => false, true, null) })(original); // $ExpectType MyType
+
+    iif<boolean | undefined>(() => true, undefined)(true); // $ExpectType boolean | undefined
+    iif<boolean | undefined>(() => true, true)(true); // $ExpectType boolean | undefined
+    iif<boolean | undefined>(() => true, true, undefined)(true); // $ExpectType boolean | undefined
+    // patch<MyType>({ __bool: iif(() => true, undefined) })(original); // $ExpectType MyType
+    // patch<MyType>({ __bool: iif(() => false, true, undefined) })(original); // $ExpectType MyType
+
+    iif<MyType>(() => true, patch<MyType>({ bool: true }))(original); // $ExpectType MyType
+    iif<MyType>(
+      () => true,
+      patch<MyType>({ bool: true, _bool: false }),
+      patch<MyType>({ bool: false, __bool: true })
+    )(original); // $ExpectType MyType
+
+    patch<MyType>({
+      bool: iif(() => false, true, false),
+      _bool: iif(() => true, false, true),
+      __bool: iif(() => true, false, true)
+    })(original); // $ExpectType MyType
+  });
+
+  it('should have the following valid object usages', () => {
+    interface MyObj {
+      val: string;
+    }
+    interface MyType {
+      obj: MyObj;
+      _obj: MyObj | null;
+      __obj?: MyObj;
+    }
+
+    const original: MyType = { obj: { val: '1' }, _obj: null };
+
+    patch<MyType>({ obj: iif(null!, { val: '1' }) })(original); // $ExpectType MyType
+    patch<MyType>({ obj: iif(null!, { val: '2' }, { val: '3' }) })(original); // $ExpectType MyType
+    patch<MyType>({ obj: iif(undefined!, { val: '1' }) })(original); // $ExpectType MyType
+    patch<MyType>({ obj: iif(undefined!, { val: '2' }, { val: '3' }) })(original); // $ExpectType MyType
+
+    patch<MyType>({ obj: iif(() => true, { val: '10' }) })(original); // $ExpectType MyType
+    patch<MyType>({ obj: iif(true, { val: '10' }) })(original); // $ExpectType MyType
+    patch<MyType>({ obj: iif(obj => obj!.val === '1', { val: '10' }) })(original); // $ExpectType MyType
+    patch<MyType>({ obj: iif(() => false, { val: '10' }, { val: '20' }) })(original); // $ExpectType MyType
+    patch<MyType>({ obj: iif(false, { val: '10' }, { val: '20' }) })(original); // $ExpectType MyType
+    patch<MyType>({
+      obj: iif(obj => obj!.val === '2', { val: '10' }, { val: '20' })
+    })(original); // $ExpectType MyType
+
+    iif<MyObj | null>(() => true, null)({ val: '100' }); // $ExpectType MyObj | null
+    iif<MyObj | null>(() => false, { val: '1' })({ val: '100' }); // $ExpectType MyObj | null
+    iif<MyObj | null>(() => false, { val: '1' }, null)({ val: '100' }); // $ExpectType MyObj | null
+    // patch<MyType>({ _obj: iif(() => true, null) })(original); // $ExpectType MyType
+    // patch<MyType>({ _obj: iif(() => false, { val: '123' }, null) })(original); // $ExpectType MyType
+
+    iif<MyObj | undefined>(() => true, undefined)({ val: '100' }); // $ExpectType MyObj | undefined
+    iif<MyObj | undefined>(() => true, { val: '1' })({ val: '100' }); // $ExpectType MyObj | undefined
+    iif<MyObj | undefined>(() => true, { val: '1' }, undefined)({ val: '100' }); // $ExpectType MyObj | undefined
+    // patch<MyType>({ __obj: iif(() => true, undefined) })(original); // $ExpectType MyType
+    // patch<MyType>({ __obj: iif(() => false, { val: '123' }, undefined) })(original); // $ExpectType MyType
+
+    iif<MyType>(() => true, patch<MyType>({ obj: { val: '1' } }))(original); // $ExpectType MyType
+    iif<MyType>(
+      () => true,
+      patch<MyType>({ obj: { val: '3' }, _obj: { val: '4' } }),
+      patch<MyType>({ obj: { val: '5' }, __obj: { val: '6' } })
+    )(original); // $ExpectType MyType
+
+    patch<MyType>({
+      obj: iif(() => false, { val: '10' }, { val: '30' }),
+      _obj: iif(() => true, { val: '50' }, { val: '100' }),
+      __obj: iif(() => true, { val: '5' }, { val: '10' })
+    })(original); // $ExpectType MyType
+  });
+
+  it('should have the following valid complex usage', () => {
+    interface Person {
+      name: string;
+      lastName?: string;
+      nickname?: string;
+    }
+
+    interface Greeting {
+      motivated?: boolean;
+      person: Person;
+    }
+
+    interface Model {
+      a: number;
+      b: {
+        hello?: Greeting;
+        goodbye?: Greeting;
+        greeting?: string;
+      };
+      c?: number;
+    }
+
+    const original: Model = {
+      a: 1,
+      b: {
+        hello: {
+          person: {
+            name: 'you'
+          }
+        },
+        goodbye: {
+          person: {
+            name: 'Artur'
+          }
+        }
+      }
+    };
+
+    /*
+    patch<Model>({
+      b: iif<Model['b']>(
+        b => typeof b!.hello === 'object',
+        patch<Model['b']>({
+          hello: patch({
+            motivated: iif(motivated => motivated !== true, true),
+            person: patch({
+              name: 'Artur',
+              lastName: 'Androsovych'
+            })
+          }),
+          greeting: 'How are you?'
+        })
+      ),
+      c: iif(c => c !== 100, () => 0 + 100, 10)
+    })(original); // $//ExpectType Model
+    */
+
+    /*
+    patch<Model>({
+      b: patch<Model['b']>({
+        hello: patch<Greeting>({
+          motivated: iif(motivated => motivated !== true, true),
+          person: patch({
+            name: iif(name => name !== 'Mark', 'Artur'),
+            lastName: iif(lastName => lastName !== 'Whitfeld', 'Androsovych')
+          })
+        }),
+        greeting: iif(greeting => !greeting, 'How are you?')
+      }),
+      c: iif(c => !c, 100, 10)
+    })(original); // $//ExpectType Model
+    */
+  });
+
+  it('should not accept the following usages', () => {
+    interface MyType {
+      num: number;
+      _num: number | null;
+      __num?: number;
+      str: string;
+      _str: string | null;
+      __str?: string;
+      bool: boolean;
+      _bool: boolean | null;
+      __bool?: boolean;
+    }
+
+    const original: MyType = {
+      num: 1,
+      _num: null,
+      str: '2',
+      _str: null,
+      bool: true,
+      _bool: null
+    };
+
+    patch<MyType>({ num: iif(true, '1') })(original); // $ExpectError
+    patch<MyType>({ num: iif(true, {}) })(original); // $ExpectError
+    patch<MyType>({ _num: iif(true, '1') })(original); // $ExpectError
+    patch<MyType>({ _num: iif(true, undefined) })(original); // $ExpectError
+    patch<MyType>({ __num: iif(true, '1') })(original); // $ExpectError
+    patch<MyType>({ __num: iif(true, null) })(original); // $ExpectError
+    patch<MyType>({ str: iif(true, 1) })(original); // $ExpectError
+    patch<MyType>({ str: iif(true, {}) })(original); // $ExpectError
+    patch<MyType>({ _str: iif(true, 1) })(original); // $ExpectError
+    patch<MyType>({ _str: iif(true, undefined) })(original); // $ExpectError
+    patch<MyType>({ __str: iif(true, 1) })(original); // $ExpectError
+    patch<MyType>({ __str: iif(true, null) })(original); // $ExpectError
+    patch<MyType>({ bool: iif(true, '1') })(original); // $ExpectError
+    patch<MyType>({ bool: iif(true, {}) })(original); // $ExpectError
+    patch<MyType>({ _bool: iif(true, '1') })(original); // $ExpectError
+    patch<MyType>({ _bool: iif(true, undefined) })(original); // $ExpectError
+    patch<MyType>({ __bool: iif(true, '1') })(original); // $ExpectError
+    patch<MyType>({ __bool: iif(true, null) })(original); // $ExpectError
+  });
+});

--- a/packages/store/types/tslint.json
+++ b/packages/store/types/tslint.json
@@ -28,6 +28,11 @@
     "interface-name": false,
     "prefer-switch": false,
     "no-misused-new": false,
-    "prefer-const": false
+    "prefer-const": false,
+    "one-variable-per-declaration": false,
+    "object-literal-key-quotes": false,
+    "no-arg": false,
+    "no-var-keyword": false,
+    "no-redundant-undefined": false
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,9 +3,9 @@
 
 
 "@angular-builders/jest@^7.4.2":
-  version "7.4.2"
-  resolved "https://registry.npmjs.org/@angular-builders/jest/-/jest-7.4.2.tgz#69bffcc0ab7c0879f0ca6db6f12bd36f4017b404"
-  integrity sha512-gbg7SKkAT7LB0WBl70tKLF7YGYta8wdShc3VBF0qClL45PPuTnHT/zBAScQNblfsaavLH3B5J1GPYqQODML0WA==
+  version "7.4.4"
+  resolved "https://registry.npmjs.org/@angular-builders/jest/-/jest-7.4.4.tgz#c514e32c31b88e39c7b96b5850f183e84bd79913"
+  integrity sha512-NebKV6zr3Osm6MjAK2Igqv0ZKaPU1X192zytT++ZVnLuYbfieOY7SLKaeynzIF+/NfGPw6tiQlA/NbMbwHuYFw==
   dependencies:
     jest-preset-angular "^7.0.1"
     lodash "^4.17.10"
@@ -234,16 +234,16 @@
     "@babel/highlight" "^7.0.0"
 
 "@babel/core@^7.1.0":
-  version "7.4.4"
-  resolved "https://registry.npmjs.org/@babel/core/-/core-7.4.4.tgz#84055750b05fcd50f9915a826b44fa347a825250"
-  integrity sha512-lQgGX3FPRgbz2SKmhMtYgJvVzGZrmjaF4apZ2bLwofAKiSjxU0drPh4S/VasyYXwaTs+A1gvQ45BN8SQJzHsQQ==
+  version "7.4.5"
+  resolved "https://registry.npmjs.org/@babel/core/-/core-7.4.5.tgz#081f97e8ffca65a9b4b0fdc7e274e703f000c06a"
+  integrity sha512-OvjIh6aqXtlsA8ujtGKfC7LYWksYSX8yQcM8Ay3LuvVeQ63lcOKgoZWVqcpFwkd29aYU9rVx7jxhfhiEDV9MZA==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/generator" "^7.4.4"
     "@babel/helpers" "^7.4.4"
-    "@babel/parser" "^7.4.4"
+    "@babel/parser" "^7.4.5"
     "@babel/template" "^7.4.4"
-    "@babel/traverse" "^7.4.4"
+    "@babel/traverse" "^7.4.5"
     "@babel/types" "^7.4.4"
     convert-source-map "^1.1.0"
     debug "^4.1.0"
@@ -310,10 +310,10 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.4.3", "@babel/parser@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.4.4.tgz#5977129431b8fe33471730d255ce8654ae1250b6"
-  integrity sha512-5pCS4mOsL+ANsFZGdvNLybx4wtqAZJ0MJjMHxvzI3bvIsz6sQvzW8XX92EYIkiPtIvcfG3Aj+Ir5VNyjnZhP7w==
+"@babel/parser@^7.1.0", "@babel/parser@^7.4.3", "@babel/parser@^7.4.4", "@babel/parser@^7.4.5":
+  version "7.4.5"
+  resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.4.5.tgz#04af8d5d5a2b044a2a1bffacc1e5e6673544e872"
+  integrity sha512-9mUqkL1FF5T7f0WDFfAoDdiMVPWsdD1gZYzSnaXsxUCUqzuch/8of9G3VUSNiZmMBoRxT3neyVsqeiL/ZPcjew==
 
 "@babel/plugin-syntax-object-rest-spread@^7.0.0":
   version "7.2.0"
@@ -323,9 +323,9 @@
     "@babel/helper-plugin-utils" "^7.0.0"
 
 "@babel/runtime@^7.0.0":
-  version "7.4.4"
-  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz#dc2e34982eb236803aa27a07fea6857af1b9171d"
-  integrity sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==
+  version "7.4.5"
+  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz#582bb531f5f9dc67d2fcb682979894f75e253f12"
+  integrity sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==
   dependencies:
     regenerator-runtime "^0.13.2"
 
@@ -338,16 +338,16 @@
     "@babel/parser" "^7.4.4"
     "@babel/types" "^7.4.4"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.4.3", "@babel/traverse@^7.4.4":
-  version "7.4.4"
-  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.4.tgz#0776f038f6d78361860b6823887d4f3937133fe8"
-  integrity sha512-Gw6qqkw/e6AGzlyj9KnkabJX7VcubqPtkUQVAwkc0wUMldr3A/hezNB3Rc5eIvId95iSGkGIOe5hh1kMKf951A==
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.4.3", "@babel/traverse@^7.4.4", "@babel/traverse@^7.4.5":
+  version "7.4.5"
+  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz#4e92d1728fd2f1897dafdd321efbff92156c3216"
+  integrity sha512-Vc+qjynwkjRmIFGxy0KYoPj4FdVDxLej89kMHFsWScq999uX+pwcX4v9mWRjW0KcAYTPAuVQl2LKP1wEVLsp+A==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/generator" "^7.4.4"
     "@babel/helper-function-name" "^7.1.0"
     "@babel/helper-split-export-declaration" "^7.4.4"
-    "@babel/parser" "^7.4.4"
+    "@babel/parser" "^7.4.5"
     "@babel/types" "^7.4.4"
     debug "^4.1.0"
     globals "^11.1.0"
@@ -751,9 +751,9 @@
     "@babel/types" "^7.0.0"
 
 "@types/babel__traverse@*", "@types/babel__traverse@^7.0.6":
-  version "7.0.6"
-  resolved "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.6.tgz#328dd1a8fc4cfe3c8458be9477b219ea158fd7b2"
-  integrity sha512-XYVgHF2sQ0YblLRMLNPB3CkFMewzFmlDsH/TneZFHUXDlABQgh88uOxuez7ZcXxayLFrqLwtDH1t+FmlFwNZxw==
+  version "7.0.7"
+  resolved "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.7.tgz#2496e9ff56196cc1429c72034e07eab6121b6f3f"
+  integrity sha512-CeBpmX1J8kWLcDEnI3Cl2Eo6RfbGvzUctA+CjZUhOKDFbLfcr7fc4usEqLNWetrlJd7RhAkyYe2czXop4fICpw==
   dependencies:
     "@babel/types" "^7.3.0"
 
@@ -793,17 +793,17 @@
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
 "@types/express-serve-static-core@*":
-  version "4.16.4"
-  resolved "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.4.tgz#56bb8be4559401d68af4a3624ae9dd3166103e60"
-  integrity sha512-x/8h6FHm14rPWnW2HP5likD/rsqJ3t/77OWx2PLxym0hXbeBWQmcPyHmwX+CtCQpjIfgrUdEoDFcLPwPZWiqzQ==
+  version "4.16.7"
+  resolved "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.7.tgz#50ba6f8a691c08a3dd9fa7fba25ef3133d298049"
+  integrity sha512-847KvL8Q1y3TtFLRTXcVakErLJQgdpFSaq+k043xefz9raEf0C7HalpSY7OW5PyjCnY8P7bPW5t/Co9qqp+USg==
   dependencies:
     "@types/node" "*"
     "@types/range-parser" "*"
 
 "@types/express@^4.16.1":
-  version "4.16.1"
-  resolved "https://registry.npmjs.org/@types/express/-/express-4.16.1.tgz#d756bd1a85c34d87eaf44c888bad27ba8a4b7cf0"
-  integrity sha512-V0clmJow23WeyblmACoxbHBu2JKlE5TiIme6Lem14FnPW9gsttyHtk6wq7njcdIWH1njAaFgR8gW09lgY98gQg==
+  version "4.17.0"
+  resolved "https://registry.npmjs.org/@types/express/-/express-4.17.0.tgz#49eaedb209582a86f12ed9b725160f12d04ef287"
+  integrity sha512-CjaMu57cjgjuZbh9DpkloeGxV45CnMGlVd+XpG7Gm9QgVrd7KFq+X4HY0vM+2v0bczS48Wg7bvnMY5TN+Xmcfw==
   dependencies:
     "@types/body-parser" "*"
     "@types/express-serve-static-core" "*"
@@ -863,9 +863,9 @@
   integrity sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==
 
 "@types/jest@^24.0.13":
-  version "24.0.13"
-  resolved "https://registry.npmjs.org/@types/jest/-/jest-24.0.13.tgz#10f50b64cb05fb02411fbba49e9042a3a11da3f9"
-  integrity sha512-3m6RPnO35r7Dg+uMLj1+xfZaOgIHHHut61djNjzwExXN4/Pm9has9C6I1KMYSfz7mahDhWUOVg4HW/nZdv5Pww==
+  version "24.0.15"
+  resolved "https://registry.npmjs.org/@types/jest/-/jest-24.0.15.tgz#6c42d5af7fe3b44ffff7cc65de7bf741e8fa427f"
+  integrity sha512-MU1HIvWUme74stAoc3mgAi+aMlgKOudgEvQDIm1v4RkrDudBh1T+NFp5sftpBAdXdx1J0PbdpJ+M2EsSOi1djA==
   dependencies:
     "@types/jest-diff" "*"
 
@@ -875,9 +875,9 @@
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
 "@types/lodash@^4.14.110":
-  version "4.14.129"
-  resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.129.tgz#9aaca391db126802482655c48dd79a814488202f"
-  integrity sha512-oYaV0eSlnOacOr7i4X1FFdH8ttSlb57gu3I9MuStIv2CYkISEY84dNHYsC3bF6sNH7qYcu1BtVrCtQ8Q4KPTfQ==
+  version "4.14.134"
+  resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.134.tgz#9032b440122db3a2a56200e91191996161dde5b9"
+  integrity sha512-2/O0khFUCFeDlbi7sZ7ZFRCcT812fAeOLm7Ev4KbwASkZ575TDrDcY7YyaoHdTOzKcNbfiwLYZqPmoC4wadrsw==
 
 "@types/marked@^0.4.0":
   version "0.4.2"
@@ -895,19 +895,19 @@
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/mocha@^5.2.6":
-  version "5.2.6"
-  resolved "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.6.tgz#b8622d50557dd155e9f2f634b7d68fd38de5e94b"
-  integrity sha512-1axi39YdtBI7z957vdqXI4Ac25e7YihYQtJa+Clnxg1zTJEaIRbndt71O3sP4GAMgiAm0pY26/b9BrY4MR/PMw==
+  version "5.2.7"
+  resolved "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz#315d570ccb56c53452ff8638738df60726d5b6ea"
+  integrity sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==
 
-"@types/node@*", "@types/node@^12.0.2":
-  version "12.0.2"
-  resolved "https://registry.npmjs.org/@types/node/-/node-12.0.2.tgz#3452a24edf9fea138b48fad4a0a028a683da1e40"
-  integrity sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA==
+"@types/node@*", "@types/node@^12.0.8":
+  version "12.0.8"
+  resolved "https://registry.npmjs.org/@types/node/-/node-12.0.8.tgz#551466be11b2adc3f3d47156758f610bd9f6b1d8"
+  integrity sha512-b8bbUOTwzIY3V5vDTY1fIJ+ePKDUBqt2hC2woVGotdQQhG/2Sh62HOKHrT7ab+VerXAcPyAiTEipPu/FsreUtg==
 
 "@types/node@^11.9.0":
-  version "11.13.11"
-  resolved "https://registry.npmjs.org/@types/node/-/node-11.13.11.tgz#65766752cbbe198ff353ea861a23b6484cf33df4"
-  integrity sha512-blLeR+KIy26km1OU8yTLUlSyVCOvT6+wPq/77tIA+uSHHa4yYQosn+bbaJqPtWId0wjVClUtD7aXzDbZeKWqig==
+  version "11.13.14"
+  resolved "https://registry.npmjs.org/@types/node/-/node-11.13.14.tgz#03e9416f7d699d71742e5a1e455def7bd55f8fb9"
+  integrity sha512-9NjFOB6UUGjJLNANmyIouuaN8YPsPgC4DCOd5lU+DL7HSX/RCfzz0JOtHlspEJq1Ll/JUu/8Cm4wzxpZ8w5sjQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -1188,7 +1188,14 @@ acorn@^6.0.1, acorn@^6.0.4, acorn@^6.0.5, acorn@^6.1.1:
   resolved "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
   integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
 
-agent-base@4, agent-base@^4.1.0, agent-base@~4.2.1:
+agent-base@4, agent-base@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"
+  integrity sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==
+  dependencies:
+    es6-promisify "^5.0.0"
+
+agent-base@~4.2.1:
   version "4.2.1"
   resolved "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
   integrity sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==
@@ -1527,16 +1534,17 @@ autoprefixer@9.4.6:
     postcss "^7.0.13"
     postcss-value-parser "^3.3.1"
 
-autoprefixer@^9.0.0:
-  version "9.5.1"
-  resolved "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.5.1.tgz#243b1267b67e7e947f28919d786b50d3bb0fb357"
-  integrity sha512-KJSzkStUl3wP0D5sdMlP82Q52JLy5+atf2MHAre48+ckWkXgixmfHyWmA77wFDy6jTHU6mIgXv6hAQ2mf1PjJQ==
+autoprefixer@^9.6.0:
+  version "9.6.0"
+  resolved "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.6.0.tgz#0111c6bde2ad20c6f17995a33fad7cf6854b4c87"
+  integrity sha512-kuip9YilBqhirhHEGHaBTZKXL//xxGnzvsD0FtBQa6z+A69qZD6s/BAX9VzDF1i9VKDquTJDQaPLSEhOnL6FvQ==
   dependencies:
-    browserslist "^4.5.4"
-    caniuse-lite "^1.0.30000957"
+    browserslist "^4.6.1"
+    caniuse-lite "^1.0.30000971"
+    chalk "^2.4.2"
     normalize-range "^0.1.2"
     num2fraction "^1.2.2"
-    postcss "^7.0.14"
+    postcss "^7.0.16"
     postcss-value-parser "^3.3.1"
 
 aws-sign2@~0.7.0:
@@ -1732,9 +1740,9 @@ block-stream@*:
     inherits "~2.0.0"
 
 bluebird@^3.5.1, bluebird@^3.5.3:
-  version "3.5.4"
-  resolved "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz#d6cc661595de30d5b3af5fcedd3c0b3ef6ec5714"
-  integrity sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==
+  version "3.5.5"
+  resolved "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
+  integrity sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
@@ -1895,14 +1903,14 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
-browserslist@^4.0.0, browserslist@^4.4.1, browserslist@^4.5.4:
-  version "4.6.0"
-  resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.6.0.tgz#5274028c26f4d933d5b1323307c1d1da5084c9ff"
-  integrity sha512-Jk0YFwXBuMOOol8n6FhgkDzn3mY9PYLYGk29zybF05SbRTsMgPqmTNeQQhOghCxq5oFqAXE3u4sYddr4C0uRhg==
+browserslist@^4.0.0, browserslist@^4.4.1, browserslist@^4.6.1:
+  version "4.6.2"
+  resolved "https://registry.npmjs.org/browserslist/-/browserslist-4.6.2.tgz#574c665950915c2ac73a4594b8537a9eba26203f"
+  integrity sha512-2neU/V0giQy9h3XMPwLhEY3+Ao0uHSwHvU8Q1Ea6AgLVL1sXbX3dzPrJ8NWe5Hi4PoTkCYXOtVR9rfRLI0J/8Q==
   dependencies:
-    caniuse-lite "^1.0.30000967"
-    electron-to-chromium "^1.3.133"
-    node-releases "^1.1.19"
+    caniuse-lite "^1.0.30000974"
+    electron-to-chromium "^1.3.150"
+    node-releases "^1.1.23"
 
 bs-logger@0.x:
   version "0.2.6"
@@ -2027,16 +2035,16 @@ cache-base@^1.0.1:
     unset-value "^1.0.0"
 
 cacheable-request@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.0.0.tgz#4a1727414e02ac4af82560c4da1b61daa3fa2b63"
-  integrity sha512-2N7AmszH/WPPpl5Z3XMw1HAP+8d+xugnKQAeKvxFZ/04dbT/CAznqwbl+7eSr3HkwdepNwtb2yx3CAMQWvG01Q==
+  version "6.1.0"
+  resolved "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz#20ffb8bd162ba4be11e9567d823db651052ca912"
+  integrity sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==
   dependencies:
     clone-response "^1.0.2"
-    get-stream "^4.0.0"
+    get-stream "^5.1.0"
     http-cache-semantics "^4.0.0"
     keyv "^3.0.0"
-    lowercase-keys "^1.0.1"
-    normalize-url "^3.1.0"
+    lowercase-keys "^2.0.0"
+    normalize-url "^4.1.0"
     responselike "^1.0.2"
 
 caller-callsite@^2.0.0:
@@ -2100,10 +2108,10 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-caniuse-lite@^1.0.30000929, caniuse-lite@^1.0.30000957, caniuse-lite@^1.0.30000967:
-  version "1.0.30000969"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000969.tgz#7664f571f2072657bde70b00a1fc1ba41f1942a9"
-  integrity sha512-Kus0yxkoAJgVc0bax7S4gLSlFifCa7MnSZL9p9VuS/HIKEL4seaqh28KIQAAO50cD/rJ5CiJkJFapkdDAlhFxQ==
+caniuse-lite@^1.0.30000929, caniuse-lite@^1.0.30000971, caniuse-lite@^1.0.30000974:
+  version "1.0.30000974"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000974.tgz#b7afe14ee004e97ce6dc73e3f878290a12928ad8"
+  integrity sha512-xc3rkNS/Zc3CmpMKuczWEdY2sZgx09BkAxfvkxlAEBTqcMHeL8QnPqhKse+5sRTi3nrw2pJwToD2WvKn1Uhvww==
 
 canonical-path@1.0.0:
   version "1.0.0"
@@ -2213,9 +2221,9 @@ chokidar@^2.0.0, chokidar@^2.0.2, chokidar@^2.1.1:
     fsevents "^1.2.7"
 
 chokidar@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/chokidar/-/chokidar-3.0.0.tgz#6b538f0fd6d5d31d5dd2b59e05426bec0f49aa40"
-  integrity sha512-ebzWopcacB2J19Jsb5RPtMrzmjUZ5VAQnsL0Ztrix3lswozHbiDp+1Lg3AWSKHdwsps/W2vtshA/x3I827F78g==
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/chokidar/-/chokidar-3.0.1.tgz#98fe9aa476c55d9aea7841d6325ffdb30e95b40c"
+  integrity sha512-2ww34sJWehnbpV0Q4k4V5Hh7juo7po6z7LUWkcIQnSGN1lHOL8GGtLtfwabKvLFQw/hbSUQ0u6V7OgGYgBzlkQ==
   dependencies:
     anymatch "^3.0.1"
     async-each "^1.0.3"
@@ -2224,7 +2232,7 @@ chokidar@^3.0.0:
     is-binary-path "^2.1.0"
     is-glob "^4.0.1"
     normalize-path "^3.0.0"
-    readdirp "^3.0.1"
+    readdirp "^3.0.2"
   optionalDependencies:
     fsevents "^2.0.6"
 
@@ -2234,9 +2242,9 @@ chownr@^1.0.1, chownr@^1.1.1:
   integrity sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==
 
 chrome-trace-event@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz#45a91bd2c20c9411f0963b5aaeb9a1b95e09cc48"
-  integrity sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz#234090ee97c7d4ad1a2c4beae27505deffc608a4"
+  integrity sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==
   dependencies:
     tslib "^1.9.0"
 
@@ -2563,26 +2571,16 @@ copy-webpack-plugin@4.6.0:
     serialize-javascript "^1.4.0"
 
 core-js@^2.4.0, core-js@^2.5.0, core-js@^2.6.0:
-  version "2.6.6"
-  resolved "https://registry.npmjs.org/core-js/-/core-js-2.6.6.tgz#00eb6d6bf815471cc16d8563edd7d38786dec50b"
-  integrity sha512-Mt/LaAym54NXnrjEMdo918cT2h70tqb/Yl7T3uPHQHRm5SxVoqlKmerUy4mL11k8saSBDWQ7ULIHxmeFyT3pfg==
+  version "2.6.9"
+  resolved "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
+  integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
-cosmiconfig@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz#760391549580bbd2df1e562bc177b13c290972dc"
-  integrity sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==
-  dependencies:
-    is-directory "^0.3.1"
-    js-yaml "^3.9.0"
-    parse-json "^4.0.0"
-    require-from-string "^2.0.1"
-
-cosmiconfig@^5.0.7, cosmiconfig@^5.2.0:
+cosmiconfig@^5.0.0, cosmiconfig@^5.0.7, cosmiconfig@^5.2.0:
   version "5.2.1"
   resolved "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz#040f726809c591e77a17c0a3626ca45b4f168b1a"
   integrity sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==
@@ -2903,10 +2901,10 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
-definitelytyped-header-parser@1.1.0, definitelytyped-header-parser@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/definitelytyped-header-parser/-/definitelytyped-header-parser-1.1.0.tgz#7047dd9af5589c57f96b4d7b7f97299cfc720bf5"
-  integrity sha512-goGRhRUJVQhXc28OjwSCoAoutl/dcFUJXwEv3DYdtxGFCXWK+YFS/MrFfsAnHG0ZYPKBcniXWRUlr3UHGKaTHw==
+definitelytyped-header-parser@1.2.0, definitelytyped-header-parser@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/definitelytyped-header-parser/-/definitelytyped-header-parser-1.2.0.tgz#f21374b8a18fabcd3ba4b008a0bcbc9db2b7b4c4"
+  integrity sha512-xpg8uu/2YD/reaVsZV4oJ4g7UDYFqQGWvT1W9Tsj6q4VtWBSaig38Qgah0ZMnQGF9kAsAim08EXDO1nSi0+Nog==
   dependencies:
     "@types/parsimmon" "^1.3.0"
     parsimmon "^1.2.0"
@@ -3065,22 +3063,22 @@ download-file-sync@^1.0.4:
   resolved "https://registry.npmjs.org/download-file-sync/-/download-file-sync-1.0.4.tgz#d3e3c543f836f41039455b9034c72e355b036019"
   integrity sha1-0+PFQ/g29BA5RVuQNMcuNVsDYBk=
 
-dts-critic@^1.0.9:
-  version "1.0.9"
-  resolved "https://registry.npmjs.org/dts-critic/-/dts-critic-1.0.9.tgz#af666a43bb1b22b031b9437fd3dfb11a509b42b9"
-  integrity sha512-fUh7YSqC+usC0r4pnslxPr02XB9txKEvk/4drxAbSNx1CZDHSkpIAXlTSp6zAz1dBM09/qakRsAsr3r6zKNl2Q==
+dts-critic@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/dts-critic/-/dts-critic-1.2.0.tgz#fc358cad7461180ad426438ab88b249fedebd5c0"
+  integrity sha512-z6VI1Sz7xxy0BgN6YsWuG9hbRIfph3U9hwrfNHLnLzsq865VYyjo5xKKUgXPuqMgJ04BUF1LGYQJ+kWyWwvUvQ==
   dependencies:
-    definitelytyped-header-parser "^1.0.1"
+    definitelytyped-header-parser "^1.2.0"
     download-file-sync "^1.0.4"
     yargs "^12.0.5"
 
-dtslint@^0.7.6:
-  version "0.7.6"
-  resolved "https://registry.npmjs.org/dtslint/-/dtslint-0.7.6.tgz#191d0283386a7d277aa059bcb44a932b4b154da4"
-  integrity sha512-QmD66NTHMQ1qf/nRp06gl1DBhY19PXGNVi+FTsaFhDtUTNOma1LSqbldKot+MBB+eEfw9YoUelNxZGJt+SU45Q==
+dtslint@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.npmjs.org/dtslint/-/dtslint-0.8.0.tgz#250c1ae384faca36d9136c46b41f848436d1980b"
+  integrity sha512-uDIPC2UPgVM1QXceRBZiTwX3uCb1jzo3Z8rU9ycTSl0p/dkFi7GGNR/MDO4SxSeHw9HaubetafqFZK1l3oKNrw==
   dependencies:
-    definitelytyped-header-parser "1.1.0"
-    dts-critic "^1.0.9"
+    definitelytyped-header-parser "1.2.0"
+    dts-critic "^1.2.0"
     fs-extra "^6.0.1"
     request "^2.88.0"
     strip-json-comments "^2.0.1"
@@ -3115,10 +3113,10 @@ ee-first@1.1.1:
   resolved "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-electron-to-chromium@^1.3.133:
-  version "1.3.135"
-  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.135.tgz#f5799b95f2bcd8de17cde47d63392d83a4477041"
-  integrity sha512-xXLNstRdVsisPF3pL3H9TVZo2XkMILfqtD6RiWIUmDK2sFX1Bjwqmd8LBp0Kuo2FgKO63JXPoEVGm8WyYdwP0Q==
+electron-to-chromium@^1.3.150:
+  version "1.3.162"
+  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.162.tgz#e006e3a2aeebaf942064a16b24c6dfc864510de1"
+  integrity sha512-/cCwFlLV0lImvAfNsJpEVIZFhJBoutb7L0AHd56K4h8McUqpdkbBvAbMnY/mfNKnCqkX6GZVvQc+BVod4t2EMw==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -3217,9 +3215,9 @@ es-to-primitive@^1.2.0:
     is-symbol "^1.0.2"
 
 es6-promise@^4.0.3:
-  version "4.2.6"
-  resolved "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz#b685edd8258886365ea62b57d30de28fadcd974f"
-  integrity sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==
+  version "4.2.8"
+  resolved "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
+  integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
 
 es6-promisify@^5.0.0:
   version "5.0.0"
@@ -3280,10 +3278,10 @@ estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   resolved "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
   integrity sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=
 
-estree-walker@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.0.tgz#5d865327c44a618dde5699f763891ae31f257dae"
-  integrity sha512-peq1RfVAVzr3PU/jL31RaOjUKLoZJpObQWJJ+LgfcxDUifyLZ1RjPQZTl0pzj2uJ45b7A7XpyppXvxdEqzo4rw==
+estree-walker@^0.6.0, estree-walker@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
+  integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
 
 esutils@^2.0.2:
   version "2.0.2"
@@ -3394,43 +3392,7 @@ expect@^24.8.0:
     jest-message-util "^24.8.0"
     jest-regex-util "^24.3.0"
 
-express@^4.16.2:
-  version "4.17.0"
-  resolved "https://registry.npmjs.org/express/-/express-4.17.0.tgz#288af62228a73f4c8ea2990ba3b791bb87cd4438"
-  integrity sha512-1Z7/t3Z5ZnBG252gKUPyItc4xdeaA0X934ca2ewckAsVsw9EG71i++ZHZPYnus8g/s5Bty8IMpSVEuRkmwwPRQ==
-  dependencies:
-    accepts "~1.3.7"
-    array-flatten "1.1.1"
-    body-parser "1.19.0"
-    content-disposition "0.5.3"
-    content-type "~1.0.4"
-    cookie "0.4.0"
-    cookie-signature "1.0.6"
-    debug "2.6.9"
-    depd "~1.1.2"
-    encodeurl "~1.0.2"
-    escape-html "~1.0.3"
-    etag "~1.8.1"
-    finalhandler "~1.1.2"
-    fresh "0.5.2"
-    merge-descriptors "1.0.1"
-    methods "~1.1.2"
-    on-finished "~2.3.0"
-    parseurl "~1.3.3"
-    path-to-regexp "0.1.7"
-    proxy-addr "~2.0.5"
-    qs "6.7.0"
-    range-parser "~1.2.1"
-    safe-buffer "5.1.2"
-    send "0.17.1"
-    serve-static "1.14.1"
-    setprototypeof "1.1.1"
-    statuses "~1.5.0"
-    type-is "~1.6.18"
-    utils-merge "1.0.1"
-    vary "~1.1.2"
-
-express@^4.17.1:
+express@^4.16.2, express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.npmjs.org/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
   integrity sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==
@@ -3562,9 +3524,9 @@ faye-websocket@^0.10.0:
     websocket-driver ">=0.5.1"
 
 faye-websocket@~0.11.1:
-  version "0.11.1"
-  resolved "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz#f0efe18c4f56e4f40afc7e06c719fd5ee6188f38"
-  integrity sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=
+  version "0.11.3"
+  resolved "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz#5c0e9a8968e8912c286639fde977a8b209f2508e"
+  integrity sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==
   dependencies:
     websocket-driver ">=0.5.1"
 
@@ -3927,6 +3889,13 @@ get-stream@^4.0.0, get-stream@^4.1.0:
   dependencies:
     pump "^3.0.0"
 
+get-stream@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz#01203cdc92597f9b909067c3e656cc1f4d3c4dc9"
+  integrity sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==
+  dependencies:
+    pump "^3.0.0"
+
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
@@ -4198,9 +4167,9 @@ he@1.2.0:
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 highlight.js@^9.13.1:
-  version "9.15.6"
-  resolved "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.6.tgz#72d4d8d779ec066af9a17cb14360c3def0aa57c4"
-  integrity sha512-zozTAWM1D6sozHo8kqhfYgsac+B+q0PmsjXeyDrYIHHcBN0zTVT66+s2GW1GZv7DbyaROdLXKdabwS/WqPyIdQ==
+  version "9.15.8"
+  resolved "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.8.tgz#f344fda123f36f1a65490e932cf90569e4999971"
+  integrity sha512-RrapkKQWwE+wKdF73VsOa2RQdIoO3mxwJ4P8mhbI6KYJUraUHRKM5w5zQQKXNk0xNL4UVRdulV9SBJcmzJNzVA==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -4274,10 +4243,10 @@ http-errors@~1.6.2:
     setprototypeof "1.1.0"
     statuses ">= 1.4.0 < 2"
 
-http-parser-js@>=0.4.0:
-  version "0.5.0"
-  resolved "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.0.tgz#d65edbede84349d0dc30320815a15d39cc3cbbd8"
-  integrity sha512-cZdEF7r4gfRIq7ezX9J0T+kQmJNOub71dWbgAXVHDct80TKP4MCETtZQ31xyv38UwgzkWPYF/Xc0ge55dW9Z9w==
+"http-parser-js@>=0.4.0 <0.4.11":
+  version "0.4.10"
+  resolved "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz#92c9c1374c35085f75db359ec56cc257cbb93fa4"
+  integrity sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=
 
 http-proxy-agent@^2.1.0:
   version "2.1.0"
@@ -4449,11 +4418,6 @@ indent-string@^3.0.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
   integrity sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=
-
-indexof@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
-  integrity sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -5057,9 +5021,9 @@ jest-get-type@^24.8.0:
   integrity sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ==
 
 jest-haste-map@^24.8.0:
-  version "24.8.0"
-  resolved "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.8.0.tgz#51794182d877b3ddfd6e6d23920e3fe72f305800"
-  integrity sha512-ZBPRGHdPt1rHajWelXdqygIDpJx8u3xOoLyUBWRW28r3tagrgoepPrzAozW7kW9HrQfhvmiv1tncsxqHJO1onQ==
+  version "24.8.1"
+  resolved "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.8.1.tgz#f39cc1d2b1d907e014165b4bd5a957afcb992982"
+  integrity sha512-SwaxMGVdAZk3ernAx2Uv2sorA7jm3Kx+lR0grp6rMmnY06Kn/urtKx1LPN2mGTea4fCT38impYT28FfcLUhX0g==
   dependencies:
     "@jest/types" "^24.8.0"
     anymatch "^2.0.0"
@@ -5140,15 +5104,7 @@ jest-pnp-resolver@^1.2.1:
   resolved "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz#ecdae604c077a7fbc70defb6d517c3c1c898923a"
   integrity sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==
 
-jest-preset-angular@^7.0.1:
-  version "7.1.0"
-  resolved "https://registry.npmjs.org/jest-preset-angular/-/jest-preset-angular-7.1.0.tgz#df023f8bd9bf4f20497701bcd813906fa26e04ce"
-  integrity sha512-MSenqcEbmkNYXh77zpsFbIJvMBsVD2kPTy5+2GLm/07e7cQe29GEQLNN4F52VZMGW70RCvGFAiAE4ljsK9hYSg==
-  dependencies:
-    jest-environment-jsdom-thirteen "^1.0.0"
-    ts-jest "^24.0.0"
-
-jest-preset-angular@^7.1.1:
+jest-preset-angular@^7.0.1, jest-preset-angular@^7.1.1:
   version "7.1.1"
   resolved "https://registry.npmjs.org/jest-preset-angular/-/jest-preset-angular-7.1.1.tgz#b51fc910e5abea91701fcd89532823ae5990450b"
   integrity sha512-/uJUi9IHoCxtB6aH6I+llpHjyfGfP2q32lcBCUKKk16v1uYKXvj1Nfdlvfvu/eqjZVoKEDLP+Ejup4bbsc0gAA==
@@ -5333,7 +5289,7 @@ js-tokens@^3.0.2:
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@3.13.1, js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.7.0, js-yaml@^3.9.0:
+js-yaml@3.13.1, js-yaml@^3.13.1, js-yaml@^3.7.0:
   version "3.13.1"
   resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -5456,9 +5412,9 @@ json-stringify-safe@~5.0.1:
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
 json3@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
-  integrity sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=
+  version "3.3.3"
+  resolved "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz#7fc10e375fc5ae42c4705a5cc0aa6f62be305b81"
+  integrity sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==
 
 json5@2.x, json5@^2.1.0:
   version "2.1.0"
@@ -5630,9 +5586,9 @@ license-webpack-plugin@2.1.0:
     webpack-sources "^1.2.0"
 
 lint-staged@^8.1.7:
-  version "8.1.7"
-  resolved "https://registry.npmjs.org/lint-staged/-/lint-staged-8.1.7.tgz#a8988bc83bdffa97d04adb09dbc0b1f3a58fa6fc"
-  integrity sha512-egT0goFhIFoOGk6rasPngTFh2qDqxZddM0PwI58oi66RxCDcn5uDwxmiasWIF0qGnchHSYVJ8HPRD5LrFo7TKA==
+  version "8.2.1"
+  resolved "https://registry.npmjs.org/lint-staged/-/lint-staged-8.2.1.tgz#752fcf222d9d28f323a3b80f1e668f3654ff221f"
+  integrity sha512-n0tDGR/rTCgQNwXnUf/eWIpPNddGWxC32ANTNYsj2k02iZb7Cz5ox2tytwBu+2r0zDXMEMKw7Y9OD/qsav561A==
   dependencies:
     chalk "^2.3.1"
     commander "^2.14.1"
@@ -5641,7 +5597,6 @@ lint-staged@^8.1.7:
     dedent "^0.7.0"
     del "^3.0.0"
     execa "^1.0.0"
-    find-parent-dir "^0.3.0"
     g-status "^2.0.2"
     is-glob "^4.0.0"
     is-windows "^1.0.2"
@@ -5740,7 +5695,7 @@ loader-runner@^2.3.0:
   resolved "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
-loader-utils@1.2.3, loader-utils@^1.0.1, loader-utils@^1.0.2, loader-utils@^1.1.0:
+loader-utils@1.2.3, loader-utils@^1.0.1, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3:
   version "1.2.3"
   resolved "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7"
   integrity sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==
@@ -5834,9 +5789,9 @@ log-update@^2.3.0:
     wrap-ansi "^3.0.1"
 
 loglevel@^1.4.1:
-  version "1.6.1"
-  resolved "https://registry.npmjs.org/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
-  integrity sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=
+  version "1.6.3"
+  resolved "https://registry.npmjs.org/loglevel/-/loglevel-1.6.3.tgz#77f2eb64be55a404c9fd04ad16d57c1d6d6b1280"
+  integrity sha512-LoEDv5pgpvWgPF4kNYuIp0qqSJVWak/dML0RY74xlzMZiT9w77teNAwKYKWBTYjlokMirg+o3jBwp+vlLrcfAA==
 
 loose-envify@^1.0.0:
   version "1.4.0"
@@ -5857,6 +5812,11 @@ lowercase-keys@^1.0.0, lowercase-keys@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
   integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
+
+lowercase-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
+  integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
 lru-cache@^4.0.1, lru-cache@^4.1.1, lru-cache@^4.1.2, lru-cache@^4.1.3:
   version "4.1.5"
@@ -6116,9 +6076,9 @@ mime@1.6.0, mime@^1.4.1:
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
 mime@^2.0.3, mime@^2.3.1:
-  version "2.4.3"
-  resolved "https://registry.npmjs.org/mime/-/mime-2.4.3.tgz#229687331e86f68924e6cb59e1cdd937f18275fe"
-  integrity sha512-QgrPRJfE+riq5TPZMcHZOtm8c6K/yYrMbKIoRfapfiGLxS8OTeIfRhUGW5LU7MlRa52KOAGCfUNruqLrIBvWZw==
+  version "2.4.4"
+  resolved "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz#bd7b91135fc6b01cde3e9bae33d659b63d8857e5"
+  integrity sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -6184,7 +6144,7 @@ minimist@~0.0.1:
   resolved "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
   integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
-minipass@^2.2.1, minipass@^2.3.4, minipass@^2.3.5:
+minipass@^2.2.1, minipass@^2.3.5:
   version "2.3.5"
   resolved "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz#cacebe492022497f656b0f0f51e2682a9ed2d848"
   integrity sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==
@@ -6192,7 +6152,7 @@ minipass@^2.2.1, minipass@^2.3.4, minipass@^2.3.5:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
-minizlib@^1.1.1:
+minizlib@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
   integrity sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==
@@ -6307,10 +6267,15 @@ ms@2.0.0:
   resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
-ms@2.1.1, ms@^2.0.0, ms@^2.1.1:
+ms@2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
+
+ms@^2.0.0, ms@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
 multicast-dns-service-types@^1.1.0:
   version "1.1.0"
@@ -6377,12 +6342,12 @@ neo-async@^2.5.0, neo-async@^2.6.0:
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
 ng-packagr@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.npmjs.org/ng-packagr/-/ng-packagr-5.2.0.tgz#a27af1aa3861eea5905223174b3a73848ab33bf7"
-  integrity sha512-OZLBm9NUai8v5uKn7K1h9RyC2g1RG4G905j7VS3p9zphqkF+LYs7u7xDz+Shmtnk39YsyvDsL0xxMD9WRoATKg==
+  version "5.3.0"
+  resolved "https://registry.npmjs.org/ng-packagr/-/ng-packagr-5.3.0.tgz#92434ca05ecbd1e01fe961a66c8a9a66b095f6fa"
+  integrity sha512-i+964lzZC7VVzatDCLDZndiXTog1XGozY7K1Bs78+uBF8O1YHNQP9wB9C5fR4uEaSKVhCWEBYekoS69flCugMA==
   dependencies:
     "@ngtools/json-schema" "^1.1.0"
-    autoprefixer "^9.0.0"
+    autoprefixer "^9.6.0"
     browserslist "^4.0.0"
     chalk "^2.3.1"
     chokidar "^3.0.0"
@@ -6394,7 +6359,6 @@ ng-packagr@^5.2.0:
     less "^3.8.0"
     less-plugin-npm-import "^2.1.0"
     node-sass-tilde-importer "^1.0.0"
-    opencollective-postinstall "^2.0.1"
     postcss "^7.0.0"
     postcss-url "^8.0.0"
     read-pkg-up "^5.0.0"
@@ -6407,7 +6371,7 @@ ng-packagr@^5.2.0:
     rxjs "^6.0.0"
     sass "^1.17.3"
     stylus "^0.54.5"
-    terser "^3.16.1"
+    terser "^4.0.0"
     update-notifier "^3.0.0"
 
 nice-try@^1.0.4:
@@ -6461,9 +6425,9 @@ node-int64@^0.4.0:
   integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
 
 node-libs-browser@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.0.tgz#c72f60d9d46de08a940dedbb25f3ffa2f9bbaa77"
-  integrity sha512-5MQunG/oyOaBdttrL40dA7bUfPORLRWMUJLQtMg7nluxUvk5XwnLdL9twQHFAjRx/y7mIMkLKT9++qPbbk6BZA==
+  version "2.2.1"
+  resolved "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz#b64f513d18338625f90346d27b0d235e631f6425"
+  integrity sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==
   dependencies:
     assert "^1.1.1"
     browserify-zlib "^0.2.0"
@@ -6475,7 +6439,7 @@ node-libs-browser@^2.0.0:
     events "^3.0.0"
     https-browserify "^1.0.0"
     os-browserify "^0.3.0"
-    path-browserify "0.0.0"
+    path-browserify "0.0.1"
     process "^0.11.10"
     punycode "^1.2.4"
     querystring-es3 "^0.2.0"
@@ -6487,7 +6451,7 @@ node-libs-browser@^2.0.0:
     tty-browserify "0.0.0"
     url "^0.11.0"
     util "^0.11.0"
-    vm-browserify "0.0.4"
+    vm-browserify "^1.0.1"
 
 node-modules-regexp@^1.0.0:
   version "1.0.0"
@@ -6521,10 +6485,10 @@ node-pre-gyp@^0.12.0:
     semver "^5.3.0"
     tar "^4"
 
-node-releases@^1.1.19:
-  version "1.1.19"
-  resolved "https://registry.npmjs.org/node-releases/-/node-releases-1.1.19.tgz#c492d1e381fea0350b338b646c27867e88e91b3d"
-  integrity sha512-SH/B4WwovHbulIALsQllAVwqZZD1kPmKCqrhGfR29dXjLAVZMHvBjD3S6nL9D/J9QkmZ1R92/0wCMDKXUUvyyA==
+node-releases@^1.1.23:
+  version "1.1.23"
+  resolved "https://registry.npmjs.org/node-releases/-/node-releases-1.1.23.tgz#de7409f72de044a2fa59c097f436ba89c39997f0"
+  integrity sha512-uq1iL79YjfYC0WXoHbC/z28q/9pOl8kSHaXdWmAAc8No+bDwqkZbzIJz55g/MUsPgSGm9LZ7QSUbzTcH5tz47w==
   dependencies:
     semver "^5.3.0"
 
@@ -6600,10 +6564,10 @@ normalize-range@^0.1.2:
   resolved "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
   integrity sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=
 
-normalize-url@^3.1.0:
-  version "3.3.0"
-  resolved "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
-  integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
+normalize-url@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz#9c49e10fc1876aeb76dba88bf1b2b5d9fa57b2ee"
+  integrity sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ==
 
 npm-bundled@^1.0.1:
   version "1.0.6"
@@ -6811,11 +6775,6 @@ open@6.0.0:
   dependencies:
     is-wsl "^1.1.0"
 
-opencollective-postinstall@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
-  integrity sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==
-
 opn@^5.1.0:
   version "5.5.0"
   resolved "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz#fc7164fab56d235904c51c3b27da6758ca3b9bfc"
@@ -6979,14 +6938,14 @@ p-try@^2.0.0:
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
 package-json@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.npmjs.org/package-json/-/package-json-6.3.0.tgz#5ed793418b8322af7abfb985a19a20c2f40c2fb0"
-  integrity sha512-XO7WS3EEXd48vmW633Y97Mh9xuENFiOevI9G+ExfTG/k6xuY9cBd3fxkAoDMSEsNZXasaVJIJ1rD/n7GMf18bA==
+  version "6.4.0"
+  resolved "https://registry.npmjs.org/package-json/-/package-json-6.4.0.tgz#4f626976604f4a9a41723ce1792b204a60b1b61e"
+  integrity sha512-bd1T8OBG7hcvMd9c/udgv6u5v9wISP3Oyl9Cm7Weop8EFwrtcQDnS2sb6zhwqus2WslSr5wSTIPiTTpxxmPm7Q==
   dependencies:
     got "^9.6.0"
     registry-auth-token "^3.4.0"
     registry-url "^5.0.0"
-    semver "^5.6.0"
+    semver "^6.1.1"
 
 pacote@9.4.0:
   version "9.4.0"
@@ -7094,10 +7053,10 @@ pascalcase@^0.1.1:
   resolved "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
-path-browserify@0.0.0:
-  version "0.0.0"
-  resolved "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
-  integrity sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=
+path-browserify@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
+  integrity sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==
 
 path-dirname@^1.0.0:
   version "1.0.2"
@@ -7285,11 +7244,11 @@ postcss-import@12.0.1:
     resolve "^1.1.7"
 
 postcss-load-config@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.0.0.tgz#f1312ddbf5912cd747177083c5ef7a19d62ee484"
-  integrity sha512-V5JBLzw406BB8UIfsAWSK2KSwIJ5yoEIVFb4gVkXci0QdKgA24jLmHZ/ghe/GgX0lJ0/D1uUK1ejhzEY94MChQ==
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.0.tgz#c84d692b7bb7b41ddced94ee62e8ab31b417b003"
+  integrity sha512-4pV3JJVPLd5+RueiVVB+gFOAa7GWc25XQcMp86Zexzke69mKf6Nx9LRcQywdz7yZI9n1udOxmLuAwTBypypF8Q==
   dependencies:
-    cosmiconfig "^4.0.0"
+    cosmiconfig "^5.0.0"
     import-cwd "^2.0.0"
 
 postcss-loader@3.0.0:
@@ -7327,10 +7286,10 @@ postcss@7.0.14:
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.13, postcss@^7.0.14, postcss@^7.0.2:
-  version "7.0.16"
-  resolved "https://registry.npmjs.org/postcss/-/postcss-7.0.16.tgz#48f64f1b4b558cb8b52c88987724359acb010da2"
-  integrity sha512-MOo8zNSlIqh22Uaa3drkdIAgUGEL+AD1ESiSdmElLUmE2uVDo1QloiT/IfW9qRw8Gw+Y/w69UVMGwbufMSftxA==
+postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.13, postcss@^7.0.16, postcss@^7.0.2:
+  version "7.0.17"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-7.0.17.tgz#4da1bdff5322d4a0acaab4d87f3e782436bad31f"
+  integrity sha512-546ZowA+KZ3OasvQZHsbuEpysvwTZNGJv9EfyCQdsIDltPSWHAeTQ5fQy/Npi2ZDtLI3zs7Ps/p6wThErhm9fQ==
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"
@@ -7404,9 +7363,9 @@ promise@~7.0.1:
     asap "~2.0.3"
 
 prompts@^2.0.1:
-  version "2.0.4"
-  resolved "https://registry.npmjs.org/prompts/-/prompts-2.0.4.tgz#179f9d4db3128b9933aa35f93a800d8fce76a682"
-  integrity sha512-HTzM3UWp/99A0gk51gAegwo1QRYA7xjcZufMNe33rCclFszUYAuHe1fIN/3ZmiHeGPkUsNaRyQm1hHOfM0PKxA==
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/prompts/-/prompts-2.1.0.tgz#bf90bc71f6065d255ea2bdc0fe6520485c1b45db"
+  integrity sha512-+x5TozgqYdOwWsQFZizE/Tra3fKvAoy037kOyU6cgz84n8f6zxngLOV4O32kTwt9FcLCxAqw0P/c8rOr9y+Gfg==
   dependencies:
     kleur "^3.0.2"
     sisteransi "^1.0.0"
@@ -7447,9 +7406,9 @@ pseudomap@^1.0.2:
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
 psl@^1.1.24, psl@^1.1.28:
-  version "1.1.31"
-  resolved "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz#e9aa86d0101b5b105cbe93ac6b784cd547276184"
-  integrity sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==
+  version "1.1.32"
+  resolved "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz#3f132717cf2f9c169724b2b6caf373cf694198db"
+  integrity sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g==
 
 public-encrypt@^4.0.0:
   version "4.0.3"
@@ -7712,9 +7671,9 @@ read-pkg@^5.0.0:
     util-deprecate "~1.0.1"
 
 readable-stream@^3.0.6:
-  version "3.3.0"
-  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz#cb8011aad002eb717bf040291feba8569c986fb9"
-  integrity sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==
+  version "3.4.0"
+  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz#a51c26754658e0a3c21dbf59163bd45ba6f447fc"
+  integrity sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==
   dependencies:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
@@ -7729,10 +7688,10 @@ readdirp@^2.0.0, readdirp@^2.2.1:
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
 
-readdirp@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/readdirp/-/readdirp-3.0.1.tgz#14a8875883c5575c235579624a1e177cb0b1ec58"
-  integrity sha512-emMp13NEwWQQX1yeDgrzDNCSY7NHV6k9HTW0OhyQqOAzYacbqQhnmWiCYjxNPcqMTQ9k77oXQJp28jkytm3+jg==
+readdirp@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/readdirp/-/readdirp-3.0.2.tgz#cba63348e9e42fc1bd334b1d2ef895b6a043cbd6"
+  integrity sha512-LbyJYv48eywrhOlScq16H/VkCiGKGPC2TpOdZCJ7QXnYEjn3NN/Oblh8QEU3vqfSRBB7OGvh5x45NKiVeNujIQ==
   dependencies:
     picomatch "^2.0.4"
 
@@ -7904,11 +7863,6 @@ require-directory@^2.1.1:
   resolved "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
-require-from-string@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
-  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
-
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
@@ -7963,7 +7917,7 @@ resolve@1.1.7, resolve@~1.1.6:
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@1.x, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.3.2:
+resolve@1.x, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.3.2:
   version "1.11.0"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz#4014870ba296176b86343d50b60f3b50609ce232"
   integrity sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==
@@ -8029,15 +7983,15 @@ rollup-plugin-json@^4.0.0:
     rollup-pluginutils "^2.5.0"
 
 rollup-plugin-node-resolve@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.0.0.tgz#754abf4841ed4bab2241551cba0a11d04c57f290"
-  integrity sha512-JUFr7DkFps3div9DYwpSg0O+s8zuSSRASUZUVNx6h6zhw2m8vcpToeS68JDPsFbmisMVSMYK0IxftngCRv7M9Q==
+  version "5.0.3"
+  resolved "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.0.3.tgz#5e90fbd04a33fa1e4e1ed6d9b54afbe45af944f1"
+  integrity sha512-Mhhmf0x493xgUPEsRELnU1VM+4+WO82knWkAbZ0d2DvZQZJMbhzyQK/hqtpVscoRru1EqlK3TM1kK9ro469wPw==
   dependencies:
     "@types/resolve" "0.0.8"
     builtin-modules "^3.1.0"
     is-module "^1.0.0"
-    resolve "^1.10.1"
-    rollup-pluginutils "^2.7.0"
+    resolve "^1.11.0"
+    rollup-pluginutils "^2.8.0"
 
 rollup-plugin-sourcemaps@^0.4.2:
   version "0.4.2"
@@ -8047,27 +8001,26 @@ rollup-plugin-sourcemaps@^0.4.2:
     rollup-pluginutils "^2.0.1"
     source-map-resolve "^0.5.0"
 
-rollup-pluginutils@^2.0.1, rollup-pluginutils@^2.5.0, rollup-pluginutils@^2.7.0:
-  version "2.7.1"
-  resolved "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.7.1.tgz#a7915ce8b12c177364784bf38a1590cc6c2c8250"
-  integrity sha512-3nRf3buQGR9qz/IsSzhZAJyoK663kzseps8itkYHr+Z7ESuaffEPfgRinxbCRA0pf0gzLqkNKkSb8aNVTq75NA==
+rollup-pluginutils@^2.0.1, rollup-pluginutils@^2.5.0, rollup-pluginutils@^2.7.0, rollup-pluginutils@^2.8.0:
+  version "2.8.1"
+  resolved "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.1.tgz#8fa6dd0697344938ef26c2c09d2488ce9e33ce97"
+  integrity sha512-J5oAoysWar6GuZo0s+3bZ6sVZAC0pfqKz68De7ZgDi5z63jOVZn1uJL/+z1jeKHNbGII8kAyHF5q8LnxSX5lQg==
   dependencies:
-    estree-walker "^0.6.0"
-    micromatch "^3.1.10"
+    estree-walker "^0.6.1"
 
 rollup@^1.12.1:
-  version "1.12.3"
-  resolved "https://registry.npmjs.org/rollup/-/rollup-1.12.3.tgz#068b1957d5bebf6c0a758cfe42609b512add35a9"
-  integrity sha512-ueWhPijWN+GaPgD3l77hXih/gcDXmYph6sWeQegwBYtaqAE834e8u+MC2wT6FKIUsz1DBOyOXAQXUZB+rjWDoQ==
+  version "1.15.6"
+  resolved "https://registry.npmjs.org/rollup/-/rollup-1.15.6.tgz#caf0ed28d2d78e3a59c1398e5a3695fb600a0ef0"
+  integrity sha512-s3Vn3QJQ5YVFfIG4nXoG9VdL1I37IZsft+4ZyeBhxE0df1kCFz9e+4bEAbR4mKH3pvBO9e9xjdxWPhhIp0r9ow==
   dependencies:
     "@types/estree" "0.0.39"
-    "@types/node" "^12.0.2"
+    "@types/node" "^12.0.8"
     acorn "^6.1.1"
 
 rsvp@^4.8.4:
-  version "4.8.4"
-  resolved "https://registry.npmjs.org/rsvp/-/rsvp-4.8.4.tgz#b50e6b34583f3dd89329a2f23a8a2be072845911"
-  integrity sha512-6FomvYPfs+Jy9TfXmBpBuMWNH94SgCsZmJKcanySzgNNP6LjWxBvyLTa9KaMfDDM5oxRfrKDB0r/qeRsLwnBfA==
+  version "4.8.5"
+  resolved "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
+  integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
 run-async@^2.2.0:
   version "2.3.0"
@@ -8102,7 +8055,7 @@ rxjs@^6.0.0, rxjs@^6.1.0, rxjs@^6.3.3, rxjs@^6.5.2:
   dependencies:
     tslib "^1.9.0"
 
-safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@5.1.2, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -8157,9 +8110,9 @@ sass-loader@7.1.0:
     semver "^5.5.0"
 
 sass@^1.17.3:
-  version "1.20.1"
-  resolved "https://registry.npmjs.org/sass/-/sass-1.20.1.tgz#737b901fe072336da540b6d00ec155e2267420da"
-  integrity sha512-BnCawee/L5kVG3B/5Jg6BFwASqUwFVE6fj2lnkVuSXDgQ7gMAhY9a2yPeqsKhJMCN+Wgx0r2mAW7XF/aTF5qtA==
+  version "1.21.0"
+  resolved "https://registry.npmjs.org/sass/-/sass-1.21.0.tgz#cc565444e27c2336746b09c45d6e8c46caaf6b04"
+  integrity sha512-67hIIOZZtarbhI2aSgKBPDUgn+VqetduKoD+ZSYeIWg+ksNioTzeX+R2gUdebDoolvKNsQ/GY9NDxctbXluTNA==
   dependencies:
     chokidar "^2.0.0"
 
@@ -8174,9 +8127,9 @@ sax@^1.2.4:
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
 saxes@^3.1.5:
-  version "3.1.9"
-  resolved "https://registry.npmjs.org/saxes/-/saxes-3.1.9.tgz#c1c197cd54956d88c09f960254b999e192d7058b"
-  integrity sha512-FZeKhJglhJHk7eWG5YM0z46VHmI3KJpMBAQm3xa9meDvd+wevB5GuBB0wc0exPInZiBBHqi00DbS8AcvCGCFMw==
+  version "3.1.10"
+  resolved "https://registry.npmjs.org/saxes/-/saxes-3.1.10.tgz#6028a4d6d65f0b5f5b5d250c0500be6a7950fe13"
+  integrity sha512-G/mVZCCGhJqgS+I7wT5gBHyTNXLe2SQcu2qmhwl1OKcSHyJEXKQY2CLT+qWIxV+m6uiGMLfSOJGLQQHhklIeEQ==
   dependencies:
     xmlchars "^1.3.1"
 
@@ -8260,10 +8213,15 @@ semver@5.6.0:
   resolved "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
 
-semver@6.0.0, semver@^6.0.0:
+semver@6.0.0:
   version "6.0.0"
   resolved "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz#05e359ee571e5ad7ed641a6eec1e547ba52dea65"
   integrity sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==
+
+semver@^6.0.0, semver@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz#53f53da9b30b2103cd4f15eab3a18ecbcb210c9b"
+  integrity sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==
 
 semver@~5.3.0:
   version "5.3.0"
@@ -8416,9 +8374,9 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
 simple-git@^1.85.0:
-  version "1.113.0"
-  resolved "https://registry.npmjs.org/simple-git/-/simple-git-1.113.0.tgz#668989728a1e9cf4ec6c72b69ea2eecc93489bea"
-  integrity sha512-i9WVsrK2u0G/cASI9nh7voxOk9mhanWY9eGtWBDSYql6m49Yk5/Fan6uZsDr/xmzv8n+eQ8ahKCoEr8cvU3h+g==
+  version "1.115.0"
+  resolved "https://registry.npmjs.org/simple-git/-/simple-git-1.115.0.tgz#159a49cf95c5126d5903e36df67504a8c634e817"
+  integrity sha512-PXcDVDgXifUE7/M2xUfQQ8uG3r73+kYRyPmsbc/iWwUrPbOASHt8p+HEbu85k546qmXixbcSPDg83kegw1vqcA==
   dependencies:
     debug "^4.0.1"
 
@@ -8972,14 +8930,14 @@ symbol-observable@1.2.0, symbol-observable@^1.1.0:
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 symbol-tree@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
-  integrity sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=
+  version "3.2.4"
+  resolved "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
+  integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
 synchronous-promise@^2.0.6:
-  version "2.0.7"
-  resolved "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.7.tgz#3574b3d2fae86b145356a4b89103e1577f646fe3"
-  integrity sha512-16GbgwTmFMYFyQMLvtQjvNWh30dsFe1cAW5Fg1wm5+dg84L9Pe36mftsIRU95/W2YsISxsz/xq4VB23sqpgb/A==
+  version "2.0.9"
+  resolved "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.9.tgz#b83db98e9e7ae826bf9c8261fd8ac859126c780a"
+  integrity sha512-LO95GIW16x69LuND1nuuwM4pjgFGupg7pZ/4lU86AmchPKrhk0o2tpMU2unXRrqo81iAFe1YJ0nAGEVwsrZAgg==
 
 tapable@^1.0.0, tapable@^1.1.0:
   version "1.1.3"
@@ -8996,17 +8954,17 @@ tar@^2.0.0:
     inherits "2"
 
 tar@^4, tar@^4.4.8:
-  version "4.4.8"
-  resolved "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz#b19eec3fde2a96e64666df9fdb40c5ca1bc3747d"
-  integrity sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==
+  version "4.4.10"
+  resolved "https://registry.npmjs.org/tar/-/tar-4.4.10.tgz#946b2810b9a5e0b26140cf78bea6b0b0d689eba1"
+  integrity sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==
   dependencies:
     chownr "^1.1.1"
     fs-minipass "^1.2.5"
-    minipass "^2.3.4"
-    minizlib "^1.1.1"
+    minipass "^2.3.5"
+    minizlib "^1.2.1"
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
-    yallist "^3.0.2"
+    yallist "^3.0.3"
 
 term-size@^1.2.0:
   version "1.2.0"
@@ -9030,24 +8988,34 @@ terser-webpack-plugin@1.2.2:
     worker-farm "^1.5.2"
 
 terser-webpack-plugin@^1.1.0:
-  version "1.2.4"
-  resolved "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.4.tgz#56f87540c28dd5265753431009388f473b5abba3"
-  integrity sha512-64IiILNQlACWZLzFlpzNaG0bpQ4ytaB7fwOsbpsdIV70AfLUmIGGeuKL0YV2WmtcrURjE2aOvHD4/lrFV3Rg+Q==
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.3.0.tgz#69aa22426299f4b5b3775cbed8cb2c5d419aa1d4"
+  integrity sha512-W2YWmxPjjkUcOWa4pBEv4OP4er1aeQJlSo2UhtCFQCuRXEHjOFscO8VyWHj9JLlA0RzQb8Y2/Ta78XZvT54uGg==
   dependencies:
     cacache "^11.3.2"
     find-cache-dir "^2.0.0"
     is-wsl "^1.1.0"
+    loader-utils "^1.2.3"
     schema-utils "^1.0.0"
     serialize-javascript "^1.7.0"
     source-map "^0.6.1"
-    terser "^3.17.0"
+    terser "^4.0.0"
     webpack-sources "^1.3.0"
     worker-farm "^1.7.0"
 
-terser@^3.16.1, terser@^3.17.0:
+terser@^3.16.1:
   version "3.17.0"
   resolved "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz#f88ffbeda0deb5637f9d24b0da66f4e15ab10cb2"
   integrity sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==
+  dependencies:
+    commander "^2.19.0"
+    source-map "~0.6.1"
+    source-map-support "~0.5.10"
+
+terser@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/terser/-/terser-4.0.0.tgz#ef356f6f359a963e2cc675517f21c1c382877374"
+  integrity sha512-dOapGTU0hETFl1tCo4t56FN+2jffoKyER9qBGoUFyZ6y7WLoKT0bF+lAYi6B6YsILcGF3q1C2FBh8QcKSCgkgA==
   dependencies:
     commander "^2.19.0"
     source-map "~0.6.1"
@@ -9266,9 +9234,9 @@ ts-node@7.0.1:
     yn "^2.0.0"
 
 ts-node@^8.2.0:
-  version "8.2.0"
-  resolved "https://registry.npmjs.org/ts-node/-/ts-node-8.2.0.tgz#4a89754b00560bb24cd54526e1685fa38c45f240"
-  integrity sha512-m8XQwUurkbYqXrKqr3WHCW310utRNvV5OnRVeISeea7LoCWVcdfeB/Ntl8JYWFh+WRoUAdBgESrzKochQt7sMw==
+  version "8.3.0"
+  resolved "https://registry.npmjs.org/ts-node/-/ts-node-8.3.0.tgz#e4059618411371924a1fb5f3b125915f324efb57"
+  integrity sha512-dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==
   dependencies:
     arg "^4.1.0"
     diff "^4.0.1"
@@ -9297,9 +9265,9 @@ tsickle@0.35.0:
     source-map "^0.7.3"
 
 tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
-  version "1.9.3"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
-  integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+  version "1.10.0"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
+  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
 tslint@5.14.0:
   version "5.14.0"
@@ -9321,9 +9289,9 @@ tslint@5.14.0:
     tsutils "^2.29.0"
 
 tslint@^5.16.0:
-  version "5.16.0"
-  resolved "https://registry.npmjs.org/tslint/-/tslint-5.16.0.tgz#ae61f9c5a98d295b9a4f4553b1b1e831c1984d67"
-  integrity sha512-UxG2yNxJ5pgGwmMzPMYh/CCnCnh0HfPgtlVRDs1ykZklufFBL1ZoTlWFRz2NQjcoEiDoRp+JyT0lhBbbH/obyA==
+  version "5.17.0"
+  resolved "https://registry.npmjs.org/tslint/-/tslint-5.17.0.tgz#f9f0ce2011d8e90debaa6e9b4975f24cd16852b8"
+  integrity sha512-pflx87WfVoYepTet3xLfDOLDm9Jqi61UXIKePOuca0qoAZyrGWonDG9VTbji58Fy+8gciUn8Bt7y69+KEVjc/w==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     builtin-modules "^1.1.1"
@@ -9331,7 +9299,7 @@ tslint@^5.16.0:
     commander "^2.12.1"
     diff "^3.2.0"
     glob "^7.1.1"
-    js-yaml "^3.13.0"
+    js-yaml "^3.13.1"
     minimatch "^3.0.4"
     mkdirp "^0.5.1"
     resolve "^1.3.2"
@@ -9446,9 +9414,9 @@ typescript@3.2.4, typescript@3.2.x:
   integrity sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==
 
 typescript@next:
-  version "3.5.0-dev.20190518"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-3.5.0-dev.20190518.tgz#06ed70f95a6eb88c73844701411935f543a1f949"
-  integrity sha512-s5JWFkb5VFSsXuwn65qGhXNLNSi6yqIKJSftX6ig4UnO52PoUVTg5h9MEEpnh5dNMLYgx+l5oMmgn7vvQ5cMvA==
+  version "3.6.0-dev.20190615"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-3.6.0-dev.20190615.tgz#02a1a61526318901fc99c274c839cde05d4a4d8c"
+  integrity sha512-DKxiKVjcd2Tw5LGCAjO9qw4xr4/bVUyeg0PRf/90xqlnVP+nP6xG17gd0Ujn5rkBd5BDDM6NnXD0GS3rPXmDFA==
 
 typescript@~3.1.6:
   version "3.1.6"
@@ -9456,9 +9424,9 @@ typescript@~3.1.6:
   integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
 
 uglify-js@^3.1.4:
-  version "3.5.13"
-  resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.13.tgz#d2d8857b598d77f8764ae3bfcf90bb1df134d2bd"
-  integrity sha512-Lho+IJlquX6sdJgyKSJx/M9y4XbDd3ekPjD8S6HYmT5yVSwDtlSuca2w5hV4g2dIsp0Y/4orbfWxKexodmFv7w==
+  version "3.6.0"
+  resolved "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz#704681345c53a8b2079fb6cec294b05ead242ff5"
+  integrity sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==
   dependencies:
     commander "~2.20.0"
     source-map "~0.6.1"
@@ -9481,9 +9449,9 @@ unique-filename@^1.1.0, unique-filename@^1.1.1:
     unique-slug "^2.0.0"
 
 unique-slug@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz#5e9edc6d1ce8fb264db18a507ef9bd8544451ca6"
-  integrity sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz#baabce91083fc64e945b0f3ad613e264f7cd4e6c"
+  integrity sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==
   dependencies:
     imurmurhash "^0.1.4"
 
@@ -9641,12 +9609,10 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vm-browserify@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz#5d7ea45bbef9e4a6ff65f95438e0a87c357d5a73"
-  integrity sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=
-  dependencies:
-    indexof "0.0.1"
+vm-browserify@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz#bd76d6a23323e2ca8ffa12028dc04559c75f9019"
+  integrity sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==
 
 w3c-hr-time@^1.0.1:
   version "1.0.1"
@@ -9817,11 +9783,12 @@ webpack@4.29.0:
     webpack-sources "^1.3.0"
 
 websocket-driver@>=0.5.1:
-  version "0.7.0"
-  resolved "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz#0caf9d2d755d93aee049d4bdd0d3fe2cca2a24eb"
-  integrity sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=
+  version "0.7.3"
+  resolved "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.3.tgz#a2d4e0d4f4f116f1e6297eba58b05d430100e9f9"
+  integrity sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==
   dependencies:
-    http-parser-js ">=0.4.0"
+    http-parser-js ">=0.4.0 <0.4.11"
+    safe-buffer ">=5.1.0"
     websocket-extensions ">=0.1.1"
 
 websocket-extensions@>=0.1.1:
@@ -9943,9 +9910,9 @@ write-file-atomic@2.4.1:
     signal-exit "^3.0.2"
 
 write-file-atomic@^2.0.0:
-  version "2.4.2"
-  resolved "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz#a7181706dfba17855d221140a9c06e15fcdd87b9"
-  integrity sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==
+  version "2.4.3"
+  resolved "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz#1fd2e9ae1df3e75b8d8c367443c692d4ca81f481"
+  integrity sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==
   dependencies:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
@@ -10017,7 +9984,7 @@ yallist@^2.1.2:
   resolved "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
-yallist@^3.0.0, yallist@^3.0.2:
+yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.0.3"
   resolved "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==
@@ -10046,9 +10013,9 @@ yargs-parser@^11.1.1:
     decamelize "^1.2.0"
 
 yargs-parser@^13.0.0:
-  version "13.1.0"
-  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.0.tgz#7016b6dd03e28e1418a510e258be4bff5a31138f"
-  integrity sha512-Yq+32PrijHRri0vVKQEm+ys8mbqWjLiwQkMFNXEENutzLPP0bE4Lcd4iA3OQY5HF+GD3xXxf0MEHb8E4/SA3AA==
+  version "13.1.1"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz#d26058532aa06d365fe091f6a1fc06b2f7e5eca0"
+  integrity sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The current typings are not explicit


## What is the new behavior?
To add explicit return type typings for the state operators.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```