### PR TITLE
fix: remove `NonNullable` type

### DIFF
--- a/packages/store/operators/src/patch.ts
+++ b/packages/store/operators/src/patch.ts
@@ -1,7 +1,7 @@
 import { StateOperator } from '@ngxs/store';
 import { isStateOperator } from './utils';
 
-export type PatchSpec<T> = { [P in keyof T]?: T[P] | StateOperator<NonNullable<T[P]>> };
+export type PatchSpec<T> = { [P in keyof T]?: T[P] | StateOperator<T[P]> };
 
 type PatchValues<T> = {
   readonly [P in keyof T]?: T[P] extends (...args: any[]) => infer R ? R : T[P]


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
```TS
interface MyObject {
  num: number | null;
}

const original: MyObject = {
  num: 10
};

patch<MyObject>({
  num: iif(() => true, null)
})(original);
```

I want to assign `null` to the `num` property (as it CAN BE `null`, as defined in the `MyObject` interface). It throws with:
`Type 'StateOperator<null>' is not assignable to type StateOperator<number>.'`, just because of `NonNullable` which excludes `null` and `undefined`.

## What is the new behavior?
The new behavior is much evident, it compiles without errors:
```TS
interface MyObject {
  num: number | null;
}

const original: MyObject = {
  num: 10
};

const newOriginal = patch<MyObject>({
  num: iif<MyObject['num']>(() => true, null)
})(original);

console.log(newOriginal.num); // null
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
