### PR TITLE
fix: typescript 3.4 has issues seeing true / false as boolean

### DIFF
--- a/packages/store/operators/src/append.ts
+++ b/packages/store/operators/src/append.ts
@@ -1,13 +1,15 @@
+import { RepairType } from './utils';
+
 /**
  * @param items - Specific items to append to the end of an array
  */
 export function append<T>(items: T[]) {
-  return function appendOperator(existing: Readonly<T[]>): T[] {
+  return function appendOperator(existing: Readonly<RepairType<T>[]>): RepairType<T>[] {
     // If `items` is `undefined` or `null` or `[]` but `existing` is provided
     // just return `existing`
     const itemsNotProvidedButExistingIs = (!items || !items.length) && existing;
     if (itemsNotProvidedButExistingIs) {
-      return existing as T[];
+      return existing as RepairType<T>[];
     }
 
     if (Array.isArray(existing)) {
@@ -16,6 +18,6 @@ export function append<T>(items: T[]) {
 
     // For example if some property is added dynamically
     // and didn't exist before thus it's not `ArrayLike`
-    return items;
+    return items as RepairType<T>[];
   };
 }

--- a/packages/store/operators/src/append.ts
+++ b/packages/store/operators/src/append.ts
@@ -13,7 +13,7 @@ export function append<T>(items: T[]) {
     }
 
     if (Array.isArray(existing)) {
-      return existing.concat(items);
+      return existing.concat(items as RepairType<T>[]);
     }
 
     // For example if some property is added dynamically

--- a/packages/store/operators/src/iif.ts
+++ b/packages/store/operators/src/iif.ts
@@ -1,23 +1,27 @@
 import { StateOperator } from '@ngxs/store';
 
-import { isStateOperator, isUndefined, isPredicate } from './utils';
+import { isStateOperator, isUndefined, isPredicate, RepairType } from './utils';
 import { Predicate } from './internals';
 
-function retrieveValue<T>(operatorOrValue: StateOperator<T> | T, existing?: Readonly<T>): T {
+function retrieveValue<T>(
+  operatorOrValue: StateOperator<T> | T,
+  existing?: Readonly<RepairType<T>>
+): RepairType<T> {
   // If state operator is a function
   // then call it with an original value
   if (isStateOperator(operatorOrValue)) {
-    return operatorOrValue(existing!);
+    const value = operatorOrValue(existing! as Readonly<T>);
+    return value as RepairType<T>;
   }
 
   // If operator or value was not provided
   // e.g. `elseOperatorOrValue` is `undefined`
   // then we just return an original value
   if (isUndefined(operatorOrValue)) {
-    return existing!;
+    return existing! as RepairType<T>;
   }
 
-  return operatorOrValue;
+  return operatorOrValue as RepairType<T>;
 }
 
 /**
@@ -32,7 +36,7 @@ export function iif<T>(
   trueOperatorOrValue: StateOperator<T> | T,
   elseOperatorOrValue?: StateOperator<T> | T
 ) {
-  return function iifOperator(existing: Readonly<T>): T {
+  return function iifOperator(existing: RepairType<Readonly<T>>): RepairType<T> {
     // Convert the value to a boolean
     let result = !!condition;
     // but if it is a function then run it to get the result
@@ -41,9 +45,9 @@ export function iif<T>(
     }
 
     if (result) {
-      return retrieveValue(trueOperatorOrValue, existing);
+      return retrieveValue<T>(trueOperatorOrValue, existing);
     }
 
-    return retrieveValue(elseOperatorOrValue!, existing);
+    return retrieveValue<T>(elseOperatorOrValue!, existing);
   };
 }

--- a/packages/store/operators/src/iif.ts
+++ b/packages/store/operators/src/iif.ts
@@ -18,7 +18,7 @@ function retrieveValue<T>(
   // e.g. `elseOperatorOrValue` is `undefined`
   // then we just return an original value
   if (isUndefined(operatorOrValue)) {
-    return existing! as RepairType<T>;
+    return (<any>existing)! as RepairType<T>;
   }
 
   return operatorOrValue as RepairType<T>;
@@ -45,9 +45,9 @@ export function iif<T>(
     }
 
     if (result) {
-      return retrieveValue<T>(trueOperatorOrValue, existing);
+      return retrieveValue<T>(trueOperatorOrValue, existing as RepairType<T>);
     }
 
-    return retrieveValue<T>(elseOperatorOrValue!, existing);
+    return retrieveValue<T>(elseOperatorOrValue!, existing as RepairType<T>);
   };
 }

--- a/packages/store/operators/src/insert-item.ts
+++ b/packages/store/operators/src/insert-item.ts
@@ -28,7 +28,7 @@ export function insertItem<T>(value: T, beforePosition?: number) {
       index = beforePosition!;
     }
 
-    clone.splice(index, 0, value);
+    clone.splice(index, 0, value as RepairType<T>);
     return clone;
   };
 }

--- a/packages/store/operators/src/insert-item.ts
+++ b/packages/store/operators/src/insert-item.ts
@@ -1,20 +1,20 @@
-import { isNil } from './utils';
+import { isNil, RepairType } from './utils';
 
 /**
  * @param value - Value to insert
  * @param [beforePosition] -  Specified index to insert value before, optional
  */
 export function insertItem<T>(value: T, beforePosition?: number) {
-  return function insertItemOperator(existing: Readonly<T[]>): T[] {
+  return function insertItemOperator(existing: Readonly<RepairType<T>[]>): RepairType<T>[] {
     // Have to check explicitly for `null` and `undefined`
     // because `value` can be `0`, thus `!value` will return `true`
     if (isNil(value) && existing) {
-      return existing as T[];
+      return existing as RepairType<T>[];
     }
 
     // Property may be dynamic and might not existed before
     if (!Array.isArray(existing)) {
-      return [value];
+      return [value as RepairType<T>];
     }
 
     const clone = existing.slice();

--- a/packages/store/operators/src/internals.ts
+++ b/packages/store/operators/src/internals.ts
@@ -1,1 +1,3 @@
-export type Predicate<T = any> = (value?: T) => boolean;
+import { RepairType } from './utils';
+
+export type Predicate<T = any> = (value?: RepairType<T>) => boolean;

--- a/packages/store/operators/src/remove-item.ts
+++ b/packages/store/operators/src/remove-item.ts
@@ -1,11 +1,11 @@
 import { Predicate } from './internals';
-import { isPredicate, isNumber, invalidIndex } from './utils';
+import { isPredicate, isNumber, invalidIndex, RepairType } from './utils';
 
 /**
  * @param selector - index or predicate to remove an item from an array by
  */
 export function removeItem<T>(selector: number | Predicate<T>) {
-  return function removeItemOperator(existing: Readonly<T[]>): T[] {
+  return function removeItemOperator(existing: Readonly<RepairType<T>[]>): RepairType<T>[] {
     let index = -1;
 
     if (isPredicate(selector)) {
@@ -15,7 +15,7 @@ export function removeItem<T>(selector: number | Predicate<T>) {
     }
 
     if (invalidIndex(index)) {
-      return existing as T[];
+      return existing as RepairType<T>[];
     }
 
     const clone = existing.slice();

--- a/packages/store/operators/src/update-item.ts
+++ b/packages/store/operators/src/update-item.ts
@@ -1,6 +1,6 @@
 import { StateOperator } from '@ngxs/store';
 
-import { isStateOperator, isPredicate, isNumber, invalidIndex } from './utils';
+import { isStateOperator, isPredicate, isNumber, invalidIndex, RepairType } from './utils';
 import { Predicate } from './internals';
 
 /**
@@ -12,8 +12,8 @@ import { Predicate } from './internals';
 export function updateItem<T>(
   selector: number | Predicate<T>,
   operatorOrValue: T | StateOperator<T>
-): StateOperator<T[]> {
-  return function updateItemOperator(existing: Readonly<T[]>) {
+): StateOperator<RepairType<T>[]> {
+  return function updateItemOperator(existing: Readonly<RepairType<T>[]>): RepairType<T>[] {
     let index = -1;
 
     if (isPredicate(selector)) {
@@ -23,14 +23,14 @@ export function updateItem<T>(
     }
 
     if (invalidIndex(index)) {
-      return existing as T[];
+      return existing as RepairType<T>[];
     }
 
     let value: T = null!;
     // Need to check if the new item value will change the existing item value
     // then, only if it will change it then clone the array and set the item
     if (isStateOperator(operatorOrValue)) {
-      value = operatorOrValue(existing[index]);
+      value = operatorOrValue(existing[index] as Readonly<T>);
     } else {
       value = operatorOrValue;
     }
@@ -38,11 +38,11 @@ export function updateItem<T>(
     // If the value hasn't been mutated
     // then we just return `existing` array
     if (value === existing[index]) {
-      return existing as T[];
+      return existing as RepairType<T>[];
     }
 
     const clone = existing.slice();
-    clone[index] = value;
+    clone[index] = value as RepairType<T>;
     return clone;
   };
 }

--- a/packages/store/operators/src/utils.ts
+++ b/packages/store/operators/src/utils.ts
@@ -25,3 +25,5 @@ export function invalidIndex(index: number): boolean {
 export function isNil<T>(value: T | null | undefined): value is null | undefined {
   return value === null || isUndefined(value);
 }
+
+export type RepairType<T> = T extends true ? boolean : (T extends false ? boolean : T);

--- a/packages/store/types/index.d.ts
+++ b/packages/store/types/index.d.ts
@@ -1,2 +1,2 @@
 /* file: packages/store/types/index.d.ts */
-// TypeScript Version: 3.1
+// TypeScript Version: 3.4

--- a/packages/store/types/tests/state-operators.append.lint.ts
+++ b/packages/store/types/tests/state-operators.append.lint.ts
@@ -29,9 +29,8 @@ describe('[TEST]: the append State Operator', () => {
     patch<Original>({ bools: append(null!) })(original); // $ExpectType { nums: number[]; strs: string[]; bools: boolean[]; }
     patch<Original>({ bools: append(undefined!) })(original); // $ExpectType { nums: number[]; strs: string[]; bools: boolean[]; }
     patch<Original>({ bools: append([true, false]) })(original); // $ExpectType { nums: number[]; strs: string[]; bools: boolean[]; }
-    // Commented out because they document an existing bug
-    // patch<Original>({ bools: append([true]) })(original); // $ExpectType Original
-    // patch<Original>({ bools: append([false]) })(original); // $ExpectType Original
+    patch<Original>({ bools: append([true]) })(original); // $ExpectType { nums: number[]; strs: string[]; bools: boolean[]; }
+    patch<Original>({ bools: append([false]) })(original); // $ExpectType { nums: number[]; strs: string[]; bools: boolean[]; }
   });
 
   it('should have the following valid complex usage', () => {

--- a/packages/store/types/tests/state-operators.iif.lint.ts
+++ b/packages/store/types/tests/state-operators.iif.lint.ts
@@ -112,14 +112,14 @@ describe('[TEST]: the iif State Operator', () => {
 
     const original: MyType = { bool: true, _bool: null };
 
-    // !>TS3.4! patch<MyType>({ bool: iif(null!, true) })(original); // $ExpectType { bool: boolean; _bool: boolean | null; __bool?: boolean | undefined; }
+    patch<MyType>({ bool: iif(null!, true) })(original); // $ExpectType { bool: boolean; _bool: boolean | null; __bool?: boolean | undefined; }
     patch<MyType>({ bool: iif(null!, false, true) })(original); // $ExpectType { bool: boolean; _bool: boolean | null; __bool?: boolean | undefined; }
-    // !>TS3.4! patch<MyType>({ bool: iif(undefined!, true) })(original); // $ExpectType { bool: boolean; _bool: boolean | null; __bool?: boolean | undefined; }
+    patch<MyType>({ bool: iif(undefined!, true) })(original); // $ExpectType { bool: boolean; _bool: boolean | null; __bool?: boolean | undefined; }
     patch<MyType>({ bool: iif(undefined!, false, true) })(original); // $ExpectType { bool: boolean; _bool: boolean | null; __bool?: boolean | undefined; }
 
-    // !>TS3.4! patch<MyType>({ bool: iif(() => true, true) })(original); // $ExpectType { bool: boolean; _bool: boolean | null; __bool?: boolean | undefined; }
-    // !>TS3.4! patch<MyType>({ bool: iif(true, true) })(original); // $ExpectType { bool: boolean; _bool: boolean | null; __bool?: boolean | undefined; }
-    // !>TS3.4! patch<MyType>({ bool: iif(val => val === true, true) })(original); // $ExpectType { bool: boolean; _bool: boolean | null; __bool?: boolean | undefined; }
+    patch<MyType>({ bool: iif(() => true, true) })(original); // $ExpectType { bool: boolean; _bool: boolean | null; __bool?: boolean | undefined; }
+    patch<MyType>({ bool: iif(true, true) })(original); // $ExpectType { bool: boolean; _bool: boolean | null; __bool?: boolean | undefined; }
+    patch<MyType>({ bool: iif(val => val === true, true) })(original); // $ExpectType { bool: boolean; _bool: boolean | null; __bool?: boolean | undefined; }
     patch<MyType>({ bool: iif(() => false, true, false) })(original); // $ExpectType { bool: boolean; _bool: boolean | null; __bool?: boolean | undefined; }
     patch<MyType>({ bool: iif(false, true, false) })(original); // $ExpectType { bool: boolean; _bool: boolean | null; __bool?: boolean | undefined; }
     patch<MyType>({ bool: iif(val => val === false, true, false) })(original); // $ExpectType { bool: boolean; _bool: boolean | null; __bool?: boolean | undefined; }

--- a/packages/store/types/tests/state-operators.insert-item.lint.ts
+++ b/packages/store/types/tests/state-operators.insert-item.lint.ts
@@ -31,11 +31,10 @@ describe('[TEST]: the insertItem State Operator', () => {
 
     patch<Original>({ bools: insertItem<boolean>(true) })(original); // $ExpectType { nums: number[]; strs: string[]; bools: boolean[]; }
     patch<Original>({ bools: insertItem<boolean>(true, 0) })(original); // $ExpectType { nums: number[]; strs: string[]; bools: boolean[]; }
-    // Commented out because they document an existing bug in TS@3.4
-    // patch<Original>({ bools: insertItem(true) })(original); // $ExpectType { nums: number[]; strs: string[]; bools: boolean[]; }
-    // patch<Original>({ bools: insertItem(true, 0) })(original); // $ExpectType { nums: number[]; strs: string[]; bools: boolean[]; }
-    // patch<Original>({ bools: insertItem(false) })(original); // $ExpectType { nums: number[]; strs: string[]; bools: boolean[]; }
-    // patch<Original>({ bools: insertItem(false, 0) })(original); // $ExpectType { nums: number[]; strs: string[]; bools: boolean[]; }
+    patch<Original>({ bools: insertItem(true) })(original); // $ExpectType { nums: number[]; strs: string[]; bools: boolean[]; }
+    patch<Original>({ bools: insertItem(true, 0) })(original); // $ExpectType { nums: number[]; strs: string[]; bools: boolean[]; }
+    patch<Original>({ bools: insertItem(false) })(original); // $ExpectType { nums: number[]; strs: string[]; bools: boolean[]; }
+    patch<Original>({ bools: insertItem(false, 0) })(original); // $ExpectType { nums: number[]; strs: string[]; bools: boolean[]; }
   });
 
   it('should have the following valid complex usage', () => {

--- a/packages/store/types/tests/state-operators.update-item.lint.ts
+++ b/packages/store/types/tests/state-operators.update-item.lint.ts
@@ -35,11 +35,10 @@ describe('[TEST]: the updateItem State Operator', () => {
 
     patch<Original>({ bools: updateItem<boolean>(0, true) })(original); // $ExpectType { nums: number[]; strs: string[]; bools: boolean[]; arrs: number[][]; objs: { name: string; }[]; }
     patch<Original>({ bools: updateItem<boolean>(0, true) })(original); // $ExpectType { nums: number[]; strs: string[]; bools: boolean[]; arrs: number[][]; objs: { name: string; }[]; }
-    // Commented out because they document an existing bug in TS@3.4
-    // patch<Original>({ bools: updateItem(0, true) })(original); // $ExpectType { nums: number[]; strs: string[]; bools: boolean[]; arrs: number[][]; objs: { name: string; }[]; }
-    // patch<Original>({ bools: updateItem(0, true) })(original); // $ExpectType { nums: number[]; strs: string[]; bools: boolean[]; arrs: number[][]; objs: { name: string; }[]; }
-    // patch<Original>({ bools: updateItem(0, false) })(original); // $ExpectType { nums: number[]; strs: string[]; bools: boolean[]; arrs: number[][]; objs: { name: string; }[]; }
-    // patch<Original>({ bools: updateItem(0, false) })(original); // $ExpectType { nums: number[]; strs: string[]; bools: boolean[]; arrs: number[][]; objs: { name: string; }[]; }
+    patch<Original>({ bools: updateItem(0, true) })(original); // $ExpectType { nums: number[]; strs: string[]; bools: boolean[]; arrs: number[][]; objs: { name: string; }[]; }
+    patch<Original>({ bools: updateItem(0, true) })(original); // $ExpectType { nums: number[]; strs: string[]; bools: boolean[]; arrs: number[][]; objs: { name: string; }[]; }
+    patch<Original>({ bools: updateItem(0, false) })(original); // $ExpectType { nums: number[]; strs: string[]; bools: boolean[]; arrs: number[][]; objs: { name: string; }[]; }
+    patch<Original>({ bools: updateItem(0, false) })(original); // $ExpectType { nums: number[]; strs: string[]; bools: boolean[]; arrs: number[][]; objs: { name: string; }[]; }
   });
 
   it('should have the following valid complex usage', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
After upgrading to the more recent versions of Typescript (3.4 for example) the types narrow too far and do not recognize true or false as compatible with boolean.

## What is the new behavior?
Introduced a `RepairType` conditional type to repair the type specificity.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
