### PR TITLE
fix(router-plugin): manual path check should not fail for SSR

### DIFF
--- a/packages/router-plugin/src/router.state.ts
+++ b/packages/router-plugin/src/router.state.ts
@@ -8,7 +8,7 @@ import {
   ResolveEnd,
   GuardsCheckEnd
 } from '@angular/router';
-import { Location } from '@angular/common';
+import { Location, PlatformLocation } from '@angular/common';
 import { Action, Selector, State, StateContext, Store } from '@ngxs/store';
 import { isAngularInTestMode } from '@ngxs/store/internals';
 import { filter, take } from 'rxjs/operators';
@@ -62,7 +62,8 @@ export class RouterState {
     private _router: Router,
     private _serializer: RouterStateSerializer<RouterStateSnapshot>,
     private _ngZone: NgZone,
-    private location: Location
+    private _location: Location,
+    private _platformLocation: PlatformLocation
   ) {
     this.setUpStoreListener();
     this.setUpStateRollbackEvents();
@@ -206,8 +207,8 @@ export class RouterState {
         // `RouterNavigation` action will be dispatched and the user will be redirected to the
         // previously saved URL. We want to prevent such behavior, so we perform this check
         // in order to redirect user to the manually entered URL if it differs from the recognized one
-        if (url !== this.location.path()) {
-          this._router.navigateByUrl(location.pathname);
+        if (url !== this._location.path()) {
+          this._router.navigateByUrl(this._platformLocation.pathname);
         }
       });
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The manual path check gives an error when run in SSR.
It doesn't have a big impact other than an error being logged.

Issue Number: N/A


## What is the new behavior?
It uses the correct platform location instead of the browser specific `window.location` object.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
