### PR TITLE
fix(router-plugin): normalize URL by stripping base href

### DIFF
--- a/packages/router-plugin/src/router.state.ts
+++ b/packages/router-plugin/src/router.state.ts
@@ -9,7 +9,7 @@ import {
   GuardsCheckEnd,
   UrlSerializer
 } from '@angular/router';
-import { LocationStrategy } from '@angular/common';
+import { LocationStrategy, Location } from '@angular/common';
 import { Action, Selector, State, StateContext, Store } from '@ngxs/store';
 import { isAngularInTestMode } from '@ngxs/store/internals';
 import { filter, take } from 'rxjs/operators';
@@ -64,7 +64,8 @@ export class RouterState {
     private _serializer: RouterStateSerializer<RouterStateSnapshot>,
     private _ngZone: NgZone,
     private _urlSerializer: UrlSerializer,
-    private _locationStrategy: LocationStrategy
+    private _locationStrategy: LocationStrategy,
+    private _location: Location
   ) {
     this.setUpStoreListener();
     this.setUpStateRollbackEvents();
@@ -211,8 +212,13 @@ export class RouterState {
         // `url` is a recognized URL by the Angular's router, while `currentUrl` is an actual URL
         // entered in the browser's address bar
         // `PathLocationStrategy.prototype.path()` returns a concatenation of
-        // `PlatformLocation.pathname` and normalized `PlatformLocation.search`
-        const currentUrl = this._locationStrategy.path();
+        // `PlatformLocation.pathname` and normalized `PlatformLocation.search`.
+        // `Location.prototype.normalize` removes base href from the URL,
+        // if `baseHref` (declare in angular.json) for example is `/en`
+        // and the URL is `/test` - then `_locationStrategy.path()` will return `/en/test`,
+        // but `/en/test` is not known to the Angular's router, so we have to remove `/en`
+        // from the URL
+        const currentUrl = this._location.normalize(this._locationStrategy.path());
         const currentUrlTree = this._urlSerializer.parse(currentUrl);
         // We need to serialize the URL because in that example `/test/?redirect=https://google.com/`
         // Angular will recognize it as `/test?redirect=https:%2F%2Fwww.google.com%2F`

--- a/packages/router-plugin/src/router.state.ts
+++ b/packages/router-plugin/src/router.state.ts
@@ -213,10 +213,11 @@ export class RouterState {
         // entered in the browser's address bar
         // `PathLocationStrategy.prototype.path()` returns a concatenation of
         // `PlatformLocation.pathname` and normalized `PlatformLocation.search`.
-        // `Location.prototype.normalize` removes base href from the URL,
-        // if `baseHref` (declare in angular.json) for example is `/en`
+
+        // `Location.prototype.normalize` strips base href from the URL,
+        // if `baseHref` (declared in angular.json) for example is `/en`
         // and the URL is `/test` - then `_locationStrategy.path()` will return `/en/test`,
-        // but `/en/test` is not known to the Angular's router, so we have to remove `/en`
+        // but `/en/test` is not known to the Angular's router, so we have to strip `/en`
         // from the URL
         const currentUrl = this._location.normalize(this._locationStrategy.path());
         const currentUrlTree = this._urlSerializer.parse(currentUrl);


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Issue Number: #1174


## What is the new behavior?
`Location.normalize()` strips base href from the provided URL

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```