### PR TITLE
chore: publish should retry at least once

### DIFF
--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -47,14 +47,22 @@ export function execute(script: string, options: ExecOptions = {}): Promise<stri
 export async function publishAllPackagesToNpm(version: any, tag: string) {
   const packages = getPackages();
   for (const pack of packages) {
-    const packageDescription = `${pack.buildPath} ${version} @${tag}`;
     try {
-      const script = `yarn publish --access public --non-interactive --no-git-tag-version --new-version ${version} --tag ${tag}`;
-      const output = await execute(script, { cwd: pack.buildPath });
-      console.log(`Published ${packageDescription} /r/n -> ${output}`);
-    } catch ({ error, stdErr }) {
-      console.log(`Error Publishing ${packageDescription} /r/n -> ${error}`);
-      throw error;
+      await publishPackage(pack, version, tag);
+    } catch (error) {
+      // One retry
+      await publishPackage(pack, version, tag);
     }
+  }
+}
+async function publishPackage(pack: Package, version: any, tag: string) {
+  const packageDescription = `${pack.buildPath} ${version} @${tag}`;
+  try {
+    const script = `yarn publish --access public --non-interactive --no-git-tag-version --new-version ${version} --tag ${tag}`;
+    const output = await execute(script, { cwd: pack.buildPath });
+    console.log(`Published ${packageDescription} /r/n -> ${output}`);
+  } catch ({ error, stdErr }) {
+    console.log(`Error Publishing ${packageDescription} /r/n -> ${error}`);
+    throw error;
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
During the last publish (v3.5) there was a glitch that caused one package to fail to be published.
We should retry at least once

## What is the new behavior?
Retry pcakage publishing at least once.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
