### PR TITLE
fix(hmr-plugin): trigger ngOnDestroy for all components in app tree

### DIFF
--- a/packages/hmr-plugin/src/hmr-manager.ts
+++ b/packages/hmr-plugin/src/hmr-manager.ts
@@ -57,6 +57,7 @@ export class HmrManager<T extends Partial<NgxsHmrLifeCycle<S>>, S = NgxsHmrSnaps
     const elements: ComponentRef<any>[] = appRef.components.map(c => c.location.nativeElement);
     const createNewModule: () => void = createNewHosts(elements);
     removeNgStyles();
+    this.ngModule.destroy();
     createNewModule();
   }
 

--- a/packages/hmr-plugin/src/tests/hmr-helpers.ts
+++ b/packages/hmr-plugin/src/tests/hmr-helpers.ts
@@ -3,11 +3,13 @@ import {
   platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
 import { getTestBed, TestBed } from '@angular/core/testing';
-import { Type } from '@angular/core';
+import { NgModuleRef, Type } from '@angular/core';
 
 import { Actions, Store } from '../../../store/src/public_api';
 import { MockState, WebpackMockModule } from './hmr-mock';
 import { BootstrapModuleFn, hmr } from '../public_api';
+
+type NgxHmrModuleRef = NgModuleRef<any> & { _destroyed?: boolean };
 
 export function setup<T>(moduleType: Type<T>) {
   TestBed.resetTestEnvironment();
@@ -24,7 +26,7 @@ export async function hmrTestBed<T>(moduleType: Type<T>, options: { storedValue?
 
   const snapshotContainer: { snapshot?: any } = webpackModule.hot.data;
   snapshotContainer.snapshot = options.storedValue;
-  const appModule = await hmr(webpackModule, bootstrap);
+  const appModule: NgxHmrModuleRef = await hmr(webpackModule, bootstrap);
   const actions$ = appModule.injector.get<Actions>(Actions);
   const store = appModule.injector.get<Store>(Store);
   const getStoredValue = () => snapshotContainer.snapshot;

--- a/packages/hmr-plugin/src/tests/hmr-helpers.ts
+++ b/packages/hmr-plugin/src/tests/hmr-helpers.ts
@@ -9,8 +9,6 @@ import { Actions, Store } from '../../../store/src/public_api';
 import { MockState, WebpackMockModule } from './hmr-mock';
 import { BootstrapModuleFn, hmr } from '../public_api';
 
-type NgxHmrModuleRef = NgModuleRef<any> & { _destroyed?: boolean };
-
 export function setup<T>(moduleType: Type<T>) {
   TestBed.resetTestEnvironment();
   TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
@@ -26,7 +24,7 @@ export async function hmrTestBed<T>(moduleType: Type<T>, options: { storedValue?
 
   const snapshotContainer: { snapshot?: any } = webpackModule.hot.data;
   snapshotContainer.snapshot = options.storedValue;
-  const appModule: NgxHmrModuleRef = await hmr(webpackModule, bootstrap);
+  const appModule: NgModuleRef<T> = await hmr(webpackModule, bootstrap);
   const actions$ = appModule.injector.get<Actions>(Actions);
   const store = appModule.injector.get<Store>(Store);
   const getStoredValue = () => snapshotContainer.snapshot;

--- a/packages/hmr-plugin/src/tests/hmr-manager.spec.ts
+++ b/packages/hmr-plugin/src/tests/hmr-manager.spec.ts
@@ -285,9 +285,9 @@ describe('HMR Plugin', () => {
 
   it('should be correct destroy old module', async () => {
     const { appModule, webpackModule } = await hmrTestBed(AppMockModule);
-    expect(appModule._destroyed).toEqual(false);
+    expect((appModule as any)['_destroyed']).toEqual(false);
 
     webpackModule.destroyModule();
-    expect(appModule._destroyed).toEqual(true);
+    expect((appModule as any)['_destroyed']).toEqual(true);
   });
 });

--- a/packages/hmr-plugin/src/tests/hmr-manager.spec.ts
+++ b/packages/hmr-plugin/src/tests/hmr-manager.spec.ts
@@ -282,4 +282,12 @@ describe('HMR Plugin', () => {
       expect(e.message).toEqual('Store not found, maybe you forgot to import the NgxsModule');
     }
   });
+
+  it('should be correct destroy old module', async () => {
+    const { appModule, webpackModule } = await hmrTestBed(AppMockModule);
+    expect(appModule._destroyed).toEqual(false);
+
+    webpackModule.destroyModule();
+    expect(appModule._destroyed).toEqual(true);
+  });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ngxs/store/issues/1190

## What is the new behavior?

Trigger ngOnDestroy for all components before destroy AppModule for avoid memory leak


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
