### PR TITLE
docs(storage-plugin): enhance docs about `key` option

### DIFF
--- a/docs/plugins/storage.md
+++ b/docs/plugins/storage.md
@@ -31,11 +31,56 @@ initial state can be picked up by those plugins.
 ### Options
 The plugin has the following optional values:
 
-- `key`: Default key to persist. You can pass a string or array of strings that can be deeply nested via dot notation. If not provided, it defaults to all states using the `@@STATE` key.
+- `key`: State name to be persisted. You can pass a string or array of strings that can be deeply nested via dot notation. If not provided, it defaults to all states using the `@@STATE` key.
 - `storage`: Storage strategy to use. This defaults to LocalStorage but you can pass SessionStorage or anything that implements the StorageEngine API.
 - `deserialize`: Custom deserializer. Defaults to `JSON.parse`
 - `serialize`: Custom serializer, defaults to `JSON.stringify`
 - `migrations`: Migration strategies
+
+### Key option
+
+The `key` option is used to determine what states should be persisted in the storage. `key` shouldn't be a random string
+or array of string, it has to coincide with your state names. Let's look at the below example:
+
+```ts
+// novels.state.ts
+@State<Novel[]>({
+  name: 'novels',
+  defaults: []
+})
+export class NovelsState {}
+
+// detectives.state.ts
+@State<Detectives[]>({
+  name: 'detectives',
+  defaults: []
+})
+export class DetectivesState {}
+```
+
+In order to persist all states there is no need to provide the `key` option, so it's enough just to write:
+
+```ts
+NgxsStoragePluginModule.forRoot()
+```
+
+But what if we wanted to persist only `NovelsState`? Then we would have needed to pass its name to the `key` option:
+
+```ts
+NgxsStoragePluginModule.forRoot({
+  key: 'novels'
+})
+```
+
+And if we wanted to persist `NovelsState` and `DetectivesState`:
+
+```ts
+NgxsStoragePluginModule.forRoot({
+  key: ['novels', 'detectives']
+})
+```
+
+This is very neat to avoid persisting runtime-only states, that shouldn't be saved to any storage.
 
 ### Custom Storage Engine
 You can add your own storage engine by implementing the `StorageEngine` interface.

--- a/docs/plugins/storage.md
+++ b/docs/plugins/storage.md
@@ -51,7 +51,7 @@ or array of string, it has to coincide with your state names. Let's look at the 
 export class NovelsState {}
 
 // detectives.state.ts
-@State<Detectives[]>({
+@State<Detective[]>({
   name: 'detectives',
   defaults: []
 })

--- a/docs/plugins/storage.md
+++ b/docs/plugins/storage.md
@@ -79,7 +79,7 @@ NgxsStoragePluginModule.forRoot({
 })
 ```
 
-This is very handy to avoid persisting runtime-only states, that shouldn't be saved to any storage.
+This is very handy to avoid persisting runtime-only states that shouldn't be saved to any storage.
 
 ### Custom Storage Engine
 You can add your own storage engine by implementing the `StorageEngine` interface.

--- a/docs/plugins/storage.md
+++ b/docs/plugins/storage.md
@@ -31,7 +31,7 @@ initial state can be picked up by those plugins.
 ### Options
 The plugin has the following optional values:
 
-- `key`: State name to be persisted. You can pass a string or array of strings that can be deeply nested via dot notation. If not provided, it defaults to all states using the `@@STATE` key.
+- `key`: State name(s) to be persisted. You can pass a string or array of strings that can be deeply nested via dot notation. If not provided, it defaults to all states using the `@@STATE` key.
 - `storage`: Storage strategy to use. This defaults to LocalStorage but you can pass SessionStorage or anything that implements the StorageEngine API.
 - `deserialize`: Custom deserializer. Defaults to `JSON.parse`
 - `serialize`: Custom serializer, defaults to `JSON.stringify`
@@ -39,8 +39,7 @@ The plugin has the following optional values:
 
 ### Key option
 
-The `key` option is used to determine what states should be persisted in the storage. `key` shouldn't be a random string
-or array of string, it has to coincide with your state names. Let's look at the below example:
+The `key` option is used to determine what states should be persisted in the storage. `key` shouldn't be a random string, it has to coincide with your state names. Let's look at the below example:
 
 ```ts
 // novels.state.ts
@@ -80,7 +79,7 @@ NgxsStoragePluginModule.forRoot({
 })
 ```
 
-This is very neat to avoid persisting runtime-only states, that shouldn't be saved to any storage.
+This is very handy to avoid persisting runtime-only states, that shouldn't be saved to any storage.
 
 ### Custom Storage Engine
 You can add your own storage engine by implementing the `StorageEngine` interface.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #423 


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
PR description: currently the `key` option is a bit confusing for our users. We have to provide them information to understand that `key` is a name of state/states.