### PR TITLE
fix(router-plugin): revert state back after "RouterCancel" is dispatched

### DIFF
--- a/packages/router-plugin/src/router.state.ts
+++ b/packages/router-plugin/src/router.state.ts
@@ -157,6 +157,7 @@ export class RouterState {
   }
 
   private dispatchRouterCancel(event: NavigationCancel): void {
+    this.routerStateSnapshot = this._serializer.serialize(this._router.routerState.snapshot);
     this.dispatchRouterAction(
       new RouterCancel(this.routerStateSnapshot, this.routerState, event)
     );

--- a/packages/router-plugin/tests/helpers.ts
+++ b/packages/router-plugin/tests/helpers.ts
@@ -1,0 +1,54 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { DOCUMENT } from '@angular/common';
+import { Store, Actions } from '@ngxs/store';
+import { ɵgetDOM as getDOM } from '@angular/platform-browser';
+import { destroyPlatform, createPlatform, Type } from '@angular/core';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+
+function createRootElement() {
+  const document = TestBed.get(DOCUMENT);
+  const root = getDOM().createElement('app-root', document);
+  getDOM().appendChild(document.body, root);
+}
+
+function removeRootElement() {
+  const document = TestBed.get(DOCUMENT);
+  const root = getDOM().querySelector(document, 'app-root');
+  document.body.removeChild(root);
+}
+
+function destroyPlatformBeforeBootstrappingTheNewOne() {
+  destroyPlatform();
+  createRootElement();
+}
+
+// As we create our custom platform via `bootstrapModule`
+// we have to destroy it after assetions and revert
+// the previous one
+function resetPlatformAfterBootstrapping() {
+  removeRootElement();
+  destroyPlatform();
+  createPlatform(TestBed);
+}
+
+export function freshPlatform(fn: Function): (...args: any[]) => any {
+  return async function testWithAFreshPlatform(this: any, ...args: any[]) {
+    try {
+      destroyPlatformBeforeBootstrappingTheNewOne();
+      return await fn.apply(this, args);
+    } finally {
+      resetPlatformAfterBootstrapping();
+    }
+  };
+}
+
+export const createPlatformAndGetStoreWithRouter = <T>(module: Type<T>) =>
+  platformBrowserDynamic()
+    .bootstrapModule(module)
+    .then(({ injector }) => {
+      const store: Store = injector.get(Store);
+      const router: Router = injector.get(Router);
+      const actions$: Actions = injector.get(Actions);
+      return { store, router, actions$ };
+    });

--- a/packages/router-plugin/tests/router-cancel.spec.ts
+++ b/packages/router-plugin/tests/router-cancel.spec.ts
@@ -1,0 +1,96 @@
+import { RouterTestingModule } from '@angular/router/testing';
+import { APP_BASE_HREF } from '@angular/common';
+import { Component, NgModule, Injectable } from '@angular/core';
+import { Routes, CanDeactivate, NavigationCancel } from '@angular/router';
+import { BrowserModule } from '@angular/platform-browser';
+import { NgxsModule } from '@ngxs/store';
+
+import { filter } from 'rxjs/operators';
+
+import { RouterState, NgxsRouterPluginModule } from '../';
+
+import { freshPlatform, createPlatformAndGetStoreWithRouter } from './helpers';
+
+@Component({
+  selector: 'app-root',
+  template: '<router-outlet></router-outlet>'
+})
+class RootComponent {}
+
+@Component({
+  selector: 'app-home',
+  template: ''
+})
+class HomeComponent {}
+
+@Component({
+  selector: 'app-blog',
+  template: ''
+})
+class BlogComponent {}
+
+@Injectable()
+class HomeGuard implements CanDeactivate<HomeComponent> {
+  async canDeactivate() {
+    return false;
+  }
+}
+
+const routes: Routes = [
+  {
+    path: '',
+    component: HomeComponent,
+    canDeactivate: [HomeGuard]
+  },
+  {
+    path: 'blog',
+    component: BlogComponent
+  }
+];
+
+function getTestModule() {
+  @NgModule({
+    imports: [
+      BrowserModule,
+      RouterTestingModule.withRoutes(routes, { initialNavigation: 'enabled' }),
+      NgxsModule.forRoot(),
+      NgxsRouterPluginModule.forRoot()
+    ],
+    declarations: [RootComponent, HomeComponent, BlogComponent],
+    bootstrap: [RootComponent],
+    providers: [HomeGuard, { provide: APP_BASE_HREF, useValue: '/' }]
+  })
+  class TestModule {}
+
+  return TestModule;
+}
+
+describe('RouterCancel', () => {
+  it(
+    'should persist the previous state if the "RouterCancel" action is dispatched',
+    freshPlatform(async () => {
+      // Assert
+      const { router, store } = await createPlatformAndGetStoreWithRouter(getTestModule());
+
+      let navigationCancelEmittedTimes = 0;
+
+      // Act
+      const subscription = router.events
+        .pipe(filter((event): event is NavigationCancel => event instanceof NavigationCancel))
+        .subscribe(() => {
+          navigationCancelEmittedTimes++;
+        });
+
+      await router.navigateByUrl('/');
+      await router.navigateByUrl('/blog');
+
+      const url = store.selectSnapshot(RouterState.url);
+
+      subscription.unsubscribe();
+
+      // Assert
+      expect(url).toBe('/');
+      expect(navigationCancelEmittedTimes).toBe(1);
+    })
+  );
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #542 


## What is the new behavior?
The state is reverted back

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
