### PR TITLE
feat(declareAction): allow declarations of actions outside of state-classes

### DIFF
--- a/packages/store/src/utils/action-utils.ts
+++ b/packages/store/src/utils/action-utils.ts
@@ -1,0 +1,33 @@
+import { Action, ActionOptions, ActionType, StateContext } from '@ngxs/store';
+import { META_OPTIONS_KEY } from '@ngxs/store/src/symbols';
+
+export function declareAction<S, A>(
+  storeClass: any,
+  actions: ActionType | ActionType[],
+  fn: (ctx: StateContext<S>, action?: A) => any,
+  options?: ActionOptions
+): void {
+  if (!storeClass[META_OPTIONS_KEY]) {
+    throw new Error('storeClass is not a valid NGXS Store');
+  }
+
+  const methodName = getActionMethodName(actions);
+  storeClass.prototype[methodName] = function(_state: any, _action: any): any {
+    return fn(_state, _action);
+  };
+
+  Action(actions, options)({ constructor: storeClass }, methodName, {} as any);
+}
+
+const getActionMethodName = (actions: ActionType | ActionType[]) => {
+  if (!Array.isArray(actions)) {
+    actions = [actions];
+  }
+
+  const random = Math.random();
+  const postfix = random.toString(36).substr(2);
+  const actionNames = actions.map(a => a.type.replace(/[^a-zA-Z0-9]+/g, ''));
+  const actionName = actionNames.join('_').substring(0, 128);
+
+  return `${actionName}_${postfix}`;
+};

--- a/packages/store/tests/utils/action-utils.spec.ts
+++ b/packages/store/tests/utils/action-utils.spec.ts
@@ -1,0 +1,93 @@
+import { declareAction } from '@ngxs/store/src/utils/action-utils';
+import {
+  Actions,
+  NgxsModule,
+  ofActionDispatched,
+  State,
+  StateContext,
+  Store
+} from '@ngxs/store';
+import { TestBed } from '@angular/core/testing';
+import { Observable } from 'rxjs';
+
+describe('action-utils', () => {
+  @State<{}>({
+    name: 'actionUtilsStore',
+    defaults: {
+      name: 'morpheus'
+    }
+  })
+  class ActionUtilsStore {}
+
+  const Action = {
+    A: { type: 'actionA' },
+    B: { type: 'actionB' }
+  };
+
+  let store: Store;
+  let actions$: Observable<any>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [NgxsModule.forRoot([ActionUtilsStore])]
+    });
+
+    store = TestBed.get(Store);
+    actions$ = TestBed.get(Actions);
+  });
+
+  describe('declareAction()', () => {
+    it('registers a new action on the store', () => {
+      let counter = 0;
+      const actionHandler = () => counter++;
+
+      declareAction(ActionUtilsStore, Action.A, actionHandler);
+      store.dispatch(Action.A);
+
+      expect(counter).toBe(1);
+    });
+
+    it('combines multiple actions to one handler on the store', () => {
+      let counter = 0;
+      const actionHandler = () => counter++;
+
+      declareAction(ActionUtilsStore, [Action.A, Action.B], actionHandler);
+      store.dispatch(Action.A);
+      store.dispatch(Action.B);
+
+      expect(counter).toBe(2);
+    });
+
+    it('registers a new action on the store, which update the store', () => {
+      const expectedName = 'davinci';
+
+      declareAction(ActionUtilsStore, [Action.A], (ctx: StateContext<ActionUtilsStore>) => {
+        ctx.patchState({ name: expectedName });
+      });
+      store.dispatch(Action.A);
+
+      const actualName = store.selectSnapshot(s => s.actionUtilsStore.name);
+      expect(actualName).toBe('davinci');
+    });
+
+    it('registers a new action on the store, which will also triggers Action Handlers', () => {
+      let actionHandlerTriggered = 0;
+      actions$.pipe(ofActionDispatched(Action.A)).subscribe(() => {
+        actionHandlerTriggered++;
+      });
+
+      declareAction(ActionUtilsStore, [Action.A], () => {});
+      store.dispatch(Action.A);
+
+      expect(actionHandlerTriggered).toBe(1);
+    });
+
+    it('throws Error if no valid store is provided', () => {
+      const invalidStore = {};
+      const declareActionWithValidStore = () =>
+        declareAction(invalidStore, [Action.A, Action.B], () => {});
+
+      expect(declareActionWithValidStore).toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new feature about?
Especially large codebases can get the issue of ending up in sprawling and hard to test NGXS-state-classes. Breaking the state into smaller chunks is not always an option, especially when the data is very cohesive and the interaction between it is complex.

Thus we wanted to move actions into independent, testable and simple to grasp files. For this purpose, a small helper function was introduced which allows the declaration of actions which are handled outside of the state class.

Following this approach brought us in the desirable condition to have all actions and usefully grouped selectors in separate classes. Our file structure in large enterprise applications therefore usually looks ruffly like this:

```
/store
  /shop
    shop.state.ts
    shop.actions.ts
    actions/ 
      add-product-to-cart.action.ts
      add-product-to-cart.action.spec.ts
      fetch-products.action.ts
      fetch-products.action.spec.ts
    selectors/
      products.selector.ts
      prices.selector.ts
```

The responsibility of the state-class itself is just to group und bootstrap all the action declarations: 

```
@State<ShopStateModel>({ name: 'shop', defaults: DEFAULT_SHOP_STATE })
export class ShopState {
  constructor(productService: ProductService) {
    declareAction(ShopState, AddProductToCartAction, addProductToCart);
    declareAction(ShopState, FetchProductsAction, fetchProducts(productService));
    declareAction(ShopState, AnotherAction, ...);
    declareAction(ShopState, [ActionA, ActionB], ...);
  }
}
``` 

The actions are just idiomatic (higher-order) functions: 
```
export const addProductToCart =
  (ctx: StateContext<ShopStateModel>, act: AddProductToCartAction) => {
    ctx.patchState({cart: [act.product]})
}

export const fetchProducts =
  (productService: ProductService) =>
    (ctx: StateContext<ShopStateModel>, act: FetchProductsAction) => {
      productService.fetchProducts().subscribe(products => {
        ctx.patchState({products})
      });
    }
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
