### PR TITLE
fix(logger-plugin): print next state even if error was thrown

### DIFF
--- a/packages/logger-plugin/tests/helpers/utils.ts
+++ b/packages/logger-plugin/tests/helpers/utils.ts
@@ -7,19 +7,33 @@ export class FormatActionCallStackOptions {
   payload?: any;
   error?: string;
   collapsed?: boolean;
+  snapshot?: any;
 }
 
-export function formatActionCallStack(opts: FormatActionCallStackOptions): CallStack {
-  const { action, prevState, nextState, payload, error, collapsed } = opts;
+export function formatActionCallStack(options: FormatActionCallStackOptions): CallStack {
+  const { action, prevState, nextState, payload, error, collapsed, snapshot } = options;
 
   const formattedPayload = payload
     ? [['log', '%c payload', 'color: #9E9E9E; font-weight: bold', payload]]
     : [];
 
-  return [
+  const formattedCallstack = [
     [collapsed ? 'groupCollapsed' : 'group', `action ${action} @ `],
     ...formattedPayload,
-    ['log', '%c prev state', 'color: #9E9E9E; font-weight: bold', { test: prevState }],
+    ['log', '%c prev state', 'color: #9E9E9E; font-weight: bold', { test: prevState }]
+  ];
+
+  if (error) {
+    // If error was thrown - then we have to log `next state after error`
+    formattedCallstack.push([
+      'log',
+      '%c next state after error',
+      'color: #FD8182; font-weight: bold',
+      snapshot
+    ]);
+  }
+
+  formattedCallstack.push(
     [
       'log',
       error ? '%c error' : '%c next state',
@@ -27,5 +41,7 @@ export function formatActionCallStack(opts: FormatActionCallStackOptions): CallS
       error ? {} : { test: { ...prevState, ...nextState } }
     ],
     ['groupEnd']
-  ];
+  );
+
+  return formattedCallstack;
 }


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
![prev](https://user-images.githubusercontent.com/7337691/63285771-32e63300-c2bf-11e9-86e4-5017cea90a58.png)



## What is the new behavior?
![after](https://user-images.githubusercontent.com/7337691/63285791-3d083180-c2bf-11e9-834e-a5b2efa11abc.png)


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
@splincode @markwhitfeld 

This is very small feature but as you can see at screenshots that the next state should be still logged into console. Given the following code:
```ts
catchError(error => {
  ctx.patchState({ counter });
  throw error;
})
```
We catch error, patch state and re-throw it. The state WILL be updated, but it will not be logged into console in the current behavior. That small feature fixes it.