### PR TITLE
fix(devtools-plugin): send action even if error was thrown

### DIFF
--- a/packages/devtools-plugin/src/devtools.plugin.ts
+++ b/packages/devtools-plugin/src/devtools.plugin.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, Injector } from '@angular/core';
 import { getActionTypeFromInstance, NgxsNextPluginFn, NgxsPlugin, Store } from '@ngxs/store';
-import { tap } from 'rxjs/operators';
+import { tap, catchError } from 'rxjs/operators';
 
 import {
   NGXS_DEVTOOLS_OPTIONS,
@@ -57,6 +57,11 @@ export class NgxsReduxDevtoolsPlugin implements NgxsPlugin {
 
           this.devtoolsExtension!.send({ ...action, type }, newState);
         }
+      }),
+      catchError(error => {
+        const type = getActionTypeFromInstance(action);
+        this.devtoolsExtension!.send({ ...action, type }, this.store.snapshot());
+        throw error;
       })
     );
   }

--- a/packages/devtools-plugin/src/devtools.plugin.ts
+++ b/packages/devtools-plugin/src/devtools.plugin.ts
@@ -48,22 +48,25 @@ export class NgxsReduxDevtoolsPlugin implements NgxsPlugin {
 
     return next(state, action).pipe(
       catchError(error => {
-        const type = getActionTypeFromInstance(action);
-        this.devtoolsExtension!.send({ ...action, type }, this.store.snapshot());
+        const newState = this.store.snapshot();
+        this.sendToDevTools(state, action, newState);
         throw error;
       }),
       tap(newState => {
-        // if init action, send initial state to dev tools
-        const isInitAction = getActionTypeFromInstance(action) === '@@INIT';
-        if (isInitAction) {
-          this.devtoolsExtension!.init(state);
-        } else {
-          const type = getActionTypeFromInstance(action);
-
-          this.devtoolsExtension!.send({ ...action, type }, newState);
-        }
+        this.sendToDevTools(state, action, newState);
       })
     );
+  }
+
+  private sendToDevTools(state: any, action: any, newState: any) {
+    const type = getActionTypeFromInstance(action);
+    // if init action, send initial state to dev tools
+    const isInitAction = type === '@@INIT';
+    if (isInitAction) {
+      this.devtoolsExtension!.init(state);
+    } else {
+      this.devtoolsExtension!.send({ ...action, type }, newState);
+    }
   }
 
   /**

--- a/packages/devtools-plugin/src/devtools.plugin.ts
+++ b/packages/devtools-plugin/src/devtools.plugin.ts
@@ -47,6 +47,11 @@ export class NgxsReduxDevtoolsPlugin implements NgxsPlugin {
     }
 
     return next(state, action).pipe(
+      catchError(error => {
+        const type = getActionTypeFromInstance(action);
+        this.devtoolsExtension!.send({ ...action, type }, this.store.snapshot());
+        throw error;
+      }),
       tap(newState => {
         // if init action, send initial state to dev tools
         const isInitAction = getActionTypeFromInstance(action) === '@@INIT';
@@ -57,11 +62,6 @@ export class NgxsReduxDevtoolsPlugin implements NgxsPlugin {
 
           this.devtoolsExtension!.send({ ...action, type }, newState);
         }
-      }),
-      catchError(error => {
-        const type = getActionTypeFromInstance(action);
-        this.devtoolsExtension!.send({ ...action, type }, this.store.snapshot());
-        throw error;
       })
     );
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Issue Number: #329

![prev-devtools](https://user-images.githubusercontent.com/7337691/63292231-df2f1600-c2cd-11e9-8467-b91bfd546bda.png)



## What is the new behavior?
![after-devtools](https://user-images.githubusercontent.com/7337691/63292245-e22a0680-c2cd-11e9-9b1d-dd5a2c306138.png)


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
@splincode @markwhitfeld 

This is very small bugfix for the old #329 issue. In the current behavior our `devtools-plugin` notifies Chrome extension only if everything is OK and no error is thrown. This PR fixes this behavior and notifies Chrome extension to log the state even if error was thrown. Given the following code:
```ts
catchError(error => {
  ctx.patchState({ counter });
  throw error;
})
```

This change will not be shown in the Chrome extension in the current behavior.