### PR TITLE
fix(router-plugin): "includeHash" must be truthy requesting path

### DIFF
--- a/packages/router-plugin/src/router.state.ts
+++ b/packages/router-plugin/src/router.state.ts
@@ -217,10 +217,10 @@ export class RouterState {
 
         // `Location.prototype.normalize` strips base href from the URL,
         // if `baseHref` (declared in angular.json) for example is `/en`
-        // and the URL is `/test` - then `_locationStrategy.path()` will return `/en/test`,
-        // but `/en/test` is not known to the Angular's router, so we have to strip `/en`
+        // and the URL is `/test#anchor` - then `_locationStrategy.path(true)` will return `/en/test#anchor`,
+        // but `/en/test#anchor` is not known to the Angular's router, so we have to strip `/en`
         // from the URL
-        const currentUrl = this._location.normalize(this._locationStrategy.path());
+        const currentUrl = this._location.normalize(this._locationStrategy.path(true));
         const currentUrlTree = this._urlSerializer.parse(currentUrl);
         // We need to serialize the URL because in that example `/test/?redirect=https://google.com/`
         // Angular will recognize it as `/test?redirect=https:%2F%2Fwww.google.com%2F`


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1257 


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

`true` argument is `includeHash`. It is `false` by default, so `location.hash` is not included. Setting `includeHash` to `true` will also include `location.hash`.