### PR TITLE
test(store): share "freshPlatform" to make it reusable

### DIFF
--- a/packages/router-plugin/tests/helpers.ts
+++ b/packages/router-plugin/tests/helpers.ts
@@ -3,7 +3,7 @@ import { Store, Actions } from '@ngxs/store';
 import { Type } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
-export async function createNGXSRouterPluginTestingPlatform<T>(module: Type<T>) {
+export async function createNgxsRouterPluginTestingPlatform<T>(module: Type<T>) {
   const { injector } = await platformBrowserDynamic().bootstrapModule(module);
   const store: Store = injector.get(Store);
   const router: Router = injector.get(Router);

--- a/packages/router-plugin/tests/helpers.ts
+++ b/packages/router-plugin/tests/helpers.ts
@@ -1,54 +1,12 @@
-import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
-import { DOCUMENT } from '@angular/common';
 import { Store, Actions } from '@ngxs/store';
-import { ɵgetDOM as getDOM } from '@angular/platform-browser';
-import { destroyPlatform, createPlatform, Type } from '@angular/core';
+import { Type } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
-function createRootElement() {
-  const document = TestBed.get(DOCUMENT);
-  const root = getDOM().createElement('app-root', document);
-  getDOM().appendChild(document.body, root);
+export async function createNGXSRouterPluginTestingPlatform<T>(module: Type<T>) {
+  const { injector } = await platformBrowserDynamic().bootstrapModule(module);
+  const store: Store = injector.get(Store);
+  const router: Router = injector.get(Router);
+  const actions$: Actions = injector.get(Actions);
+  return { store, router, actions$ };
 }
-
-function removeRootElement() {
-  const document = TestBed.get(DOCUMENT);
-  const root = getDOM().querySelector(document, 'app-root');
-  document.body.removeChild(root);
-}
-
-function destroyPlatformBeforeBootstrappingTheNewOne() {
-  destroyPlatform();
-  createRootElement();
-}
-
-// As we create our custom platform via `bootstrapModule`
-// we have to destroy it after assetions and revert
-// the previous one
-function resetPlatformAfterBootstrapping() {
-  removeRootElement();
-  destroyPlatform();
-  createPlatform(TestBed);
-}
-
-export function freshPlatform(fn: Function): (...args: any[]) => any {
-  return async function testWithAFreshPlatform(this: any, ...args: any[]) {
-    try {
-      destroyPlatformBeforeBootstrappingTheNewOne();
-      return await fn.apply(this, args);
-    } finally {
-      resetPlatformAfterBootstrapping();
-    }
-  };
-}
-
-export const createPlatformAndGetStoreWithRouter = <T>(module: Type<T>) =>
-  platformBrowserDynamic()
-    .bootstrapModule(module)
-    .then(({ injector }) => {
-      const store: Store = injector.get(Store);
-      const router: Router = injector.get(Router);
-      const actions$: Actions = injector.get(Actions);
-      return { store, router, actions$ };
-    });

--- a/packages/router-plugin/tests/router-cancel.spec.ts
+++ b/packages/router-plugin/tests/router-cancel.spec.ts
@@ -4,12 +4,13 @@ import { Component, NgModule, Injectable } from '@angular/core';
 import { Routes, CanDeactivate, NavigationCancel } from '@angular/router';
 import { BrowserModule } from '@angular/platform-browser';
 import { NgxsModule } from '@ngxs/store';
+import { freshPlatform } from '@ngxs/store/internals/testing';
 
 import { filter } from 'rxjs/operators';
 
 import { RouterState, NgxsRouterPluginModule } from '../';
 
-import { freshPlatform, createPlatformAndGetStoreWithRouter } from './helpers';
+import { createNGXSRouterPluginTestingPlatform } from './helpers';
 
 @Component({
   selector: 'app-root',
@@ -70,7 +71,7 @@ describe('RouterCancel', () => {
     'should persist the previous state if the "RouterCancel" action is dispatched',
     freshPlatform(async () => {
       // Assert
-      const { router, store } = await createPlatformAndGetStoreWithRouter(getTestModule());
+      const { router, store } = await createNGXSRouterPluginTestingPlatform(getTestModule());
 
       let navigationCancelEmittedTimes = 0;
 

--- a/packages/router-plugin/tests/router-cancel.spec.ts
+++ b/packages/router-plugin/tests/router-cancel.spec.ts
@@ -10,7 +10,7 @@ import { filter } from 'rxjs/operators';
 
 import { RouterState, NgxsRouterPluginModule } from '../';
 
-import { createNGXSRouterPluginTestingPlatform } from './helpers';
+import { createNgxsRouterPluginTestingPlatform } from './helpers';
 
 @Component({
   selector: 'app-root',
@@ -71,7 +71,7 @@ describe('RouterCancel', () => {
     'should persist the previous state if the "RouterCancel" action is dispatched',
     freshPlatform(async () => {
       // Assert
-      const { router, store } = await createNGXSRouterPluginTestingPlatform(getTestModule());
+      const { router, store } = await createNgxsRouterPluginTestingPlatform(getTestModule());
 
       let navigationCancelEmittedTimes = 0;
 

--- a/packages/store/internals/testing/index.ts
+++ b/packages/store/internals/testing/index.ts
@@ -1,2 +1,3 @@
 export { NgxsTestBed } from './src/ngxs.setup';
 export { NgxsTesting } from './src/symbol';
+export { freshPlatform } from './src/fresh-platform';

--- a/packages/store/internals/testing/src/fresh-platform.ts
+++ b/packages/store/internals/testing/src/fresh-platform.ts
@@ -1,0 +1,41 @@
+import { TestBed } from '@angular/core/testing';
+import { DOCUMENT } from '@angular/common';
+import { ɵgetDOM as getDOM } from '@angular/platform-browser';
+import { destroyPlatform, createPlatform } from '@angular/core';
+
+function createRootElement() {
+  const document = TestBed.get(DOCUMENT);
+  const root = getDOM().createElement('app-root', document);
+  getDOM().appendChild(document.body, root);
+}
+
+function removeRootElement() {
+  const document = TestBed.get(DOCUMENT);
+  const root = getDOM().querySelector(document, 'app-root');
+  document.body.removeChild(root);
+}
+
+function destroyPlatformBeforeBootstrappingTheNewOne() {
+  destroyPlatform();
+  createRootElement();
+}
+
+// As we create our custom platform via `bootstrapModule`
+// we have to destroy it after assetions and revert
+// the previous one
+function resetPlatformAfterBootstrapping() {
+  removeRootElement();
+  destroyPlatform();
+  createPlatform(TestBed);
+}
+
+export function freshPlatform(fn: Function): (...args: any[]) => any {
+  return async function testWithAFreshPlatform(this: any, ...args: any[]) {
+    try {
+      destroyPlatformBeforeBootstrappingTheNewOne();
+      return await fn.apply(this, args);
+    } finally {
+      resetPlatformAfterBootstrapping();
+    }
+  };
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe:
```

## What is the current behavior?
`freshPlatform` is a wrapper that allows to provide custom platform during testing. It has to be a part of the `@ngxs/store/internals/testing` package to be reusable.

## What is the new behavior?
`freshPlatform` is reusable.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
