### PR TITLE
fix(router-plugin): log async completion in separate group

### DIFF
--- a/packages/logger-plugin/src/action-logger.ts
+++ b/packages/logger-plugin/src/action-logger.ts
@@ -4,13 +4,14 @@ import { formatTime } from './internals';
 import { LogWriter } from './log-writer';
 
 export class ActionLogger {
+  private synchronousWorkEnded = false;
+  private actionCompleted = false;
+  private startedTime = new Date();
+
   constructor(private action: any, private store: Store, private logWriter: LogWriter) {}
 
   dispatched(state: any) {
-    const actionName = getActionTypeFromInstance(this.action);
-    const formattedTime = formatTime(new Date());
-
-    const message = `action ${actionName} @ ${formattedTime}`;
+    const message = this.getActionLogHeader();
     this.logWriter.startGroup(message);
 
     // print payload only if at least one property is supplied
@@ -22,14 +23,40 @@ export class ActionLogger {
   }
 
   completed(nextState: any) {
+    if (this.synchronousWorkEnded) {
+      const message = `(async work completed) ${this.getActionLogHeader()}`;
+      this.logWriter.startGroup(message);
+    }
     this.logWriter.logGreen('next state', nextState);
     this.logWriter.endGroup();
+    this.actionCompleted = true;
   }
 
   errored(error: any) {
+    if (this.synchronousWorkEnded) {
+      const message = `(async work error) ${this.getActionLogHeader()}`;
+      this.logWriter.startGroup(message);
+    }
     this.logWriter.logRedish('next state after error', this.store.snapshot());
     this.logWriter.logRedish('error', error);
     this.logWriter.endGroup();
+    this.actionCompleted = true;
+  }
+
+  syncWorkComplete() {
+    if (!this.actionCompleted) {
+      this.logWriter.logGreen('next state (synchronous)', this.store.snapshot());
+      this.logWriter.logGreen('( action doing async work... )', undefined);
+      this.logWriter.endGroup();
+    }
+    this.synchronousWorkEnded = true;
+  }
+
+  private getActionLogHeader() {
+    const actionName = getActionTypeFromInstance(this.action);
+    const formattedTime = formatTime(this.startedTime);
+    const message = `action ${actionName} (started @ ${formattedTime})`;
+    return message;
   }
 
   private _hasPayload(event: any) {

--- a/packages/logger-plugin/src/log-writer.ts
+++ b/packages/logger-plugin/src/log-writer.ts
@@ -8,11 +8,12 @@ export class LogWriter {
   }
 
   startGroup(message: string) {
-    const startGroupFn = this.options.collapsed
-      ? this.logger.groupCollapsed
-      : this.logger.group;
     try {
-      startGroupFn.call(this.logger, message);
+      if (this.options.collapsed) {
+        this.logger.groupCollapsed(message);
+      } else {
+        this.logger.group(message);
+      }
     } catch (e) {
       console.log(message);
     }

--- a/packages/logger-plugin/src/logger.plugin.ts
+++ b/packages/logger-plugin/src/logger.plugin.ts
@@ -1,4 +1,5 @@
 import { Injectable, Inject, Injector } from '@angular/core';
+import { Observable, defer, empty, merge } from 'rxjs';
 import { tap, catchError } from 'rxjs/operators';
 
 import { NgxsPlugin, NgxsNextPluginFn, Store } from '@ngxs/store';
@@ -27,7 +28,7 @@ export class NgxsLoggerPlugin implements NgxsPlugin {
 
     actionLogger.dispatched(state);
 
-    return next(state, event).pipe(
+    const result = next(state, event).pipe(
       tap(nextState => {
         actionLogger.completed(nextState);
       }),
@@ -36,5 +37,17 @@ export class NgxsLoggerPlugin implements NgxsPlugin {
         throw error;
       })
     );
+
+    return afterSubscribe(result, () => actionLogger.syncWorkComplete());
   }
+}
+
+function afterSubscribe<T>(source: Observable<T>, callback: VoidFunction) {
+  return merge(
+    source,
+    defer(() => {
+      callback();
+      return empty();
+    })
+  );
 }

--- a/packages/logger-plugin/tests/helpers/logger-spy.ts
+++ b/packages/logger-plugin/tests/helpers/logger-spy.ts
@@ -1,4 +1,4 @@
-import { CallStack } from './symbols';
+import { CallStack, Call } from './symbols';
 
 /**
  * Spy that mimics the required methods for custom logger implementation,
@@ -28,17 +28,33 @@ export class LoggerSpy {
   }
 
   get callStack(): string {
-    const callStackWithoutTime = this._callStack.map(call => {
-      const callSecondParam = call[1] as string;
-
-      // remove formatted time string
-      if (typeof callSecondParam === 'string') {
-        call[1] = callSecondParam.replace(/\d{2}:\d{2}:\d{2}.\d{3}/g, '');
-      }
-
-      return call;
-    });
-
+    const callStackWithoutTime = this.getCallStack();
     return LoggerSpy.createCallStack(callStackWithoutTime);
   }
+
+  getCallStack(options: { excludeStyles?: boolean } = {}): any[] {
+    return this._callStack.map(call => {
+      call = removeTime(call);
+      if (options.excludeStyles) {
+        call = removeStyle(call);
+      }
+      return call;
+    });
+  }
+}
+
+function removeTime(item: Call): Call {
+  const [first, second, ...rest] = item;
+  if (typeof second === 'string') {
+    return [first, second.replace(/\d{2}:\d{2}:\d{2}.\d{3}/g, ''), ...rest];
+  }
+  return item;
+}
+
+function removeStyle(item: Call): Call {
+  const [first, second /*third*/, , ...rest] = item;
+  if (typeof second === 'string' && second.startsWith('%c ')) {
+    return [first, second.substring(3), '', ...rest];
+  }
+  return item;
 }

--- a/packages/logger-plugin/tests/helpers/logger-spy.ts
+++ b/packages/logger-plugin/tests/helpers/logger-spy.ts
@@ -27,6 +27,10 @@ export class LoggerSpy {
     this._callStack.push(['log', message, ...optionalParams]);
   }
 
+  clear() {
+    this._callStack = [];
+  }
+
   get callStack(): string {
     const callStackWithoutTime = this.getCallStack();
     return LoggerSpy.createCallStack(callStackWithoutTime);
@@ -52,9 +56,9 @@ function removeTime(item: Call): Call {
 }
 
 function removeStyle(item: Call): Call {
-  const [first, second /*third*/, , ...rest] = item;
+  const [first, second, , ...rest] = item;
   if (typeof second === 'string' && second.startsWith('%c ')) {
-    return [first, second.substring(3), '', ...rest];
+    return [first, second.substring(3), ...rest];
   }
   return item;
 }

--- a/packages/logger-plugin/tests/helpers/symbols.ts
+++ b/packages/logger-plugin/tests/helpers/symbols.ts
@@ -1,1 +1,3 @@
-export type CallStack = (string | {})[][];
+export type CallParam = string | {};
+export type Call = CallParam[];
+export type CallStack = Call[];


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:  #276, #213 and #561

Currently the logger writes an action to the console with one group that closes after the action completes. This works great if all actions only do synchronous work but creates a mess in the console as soon as there is asynchronous completion of actions.

## What is the new behavior?
If an action will complete asynchronously then the console group for the action is closed after all synchronous work is done and a new group is opened when the asynchronous completion or error happens.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
