### PR TITLE
fix(store): warn if the zone is not actual "NgZone"

### DIFF
--- a/packages/store/src/configs/messages.config.ts
+++ b/packages/store/src/configs/messages.config.ts
@@ -21,8 +21,8 @@ export const CONFIG_MESSAGES: ObjectKeyMap<Function> = {
     `State name '${current}' from ${newName} already exists in ${oldName}`,
   [VALIDATION_CODE.STATE_DECORATOR]: () => 'States must be decorated with @State() decorator',
   [VALIDATION_CODE.INCORRECT_PRODUCTION]: () =>
-    'Angular is running in the production mode but NGXS is still running in the development mode!\n' +
-    'Please set developmentMode to false on the NgxsModule options in the production mode.\n' +
+    'Angular is running in production mode but NGXS is still running in the development mode!\n' +
+    'Please set developmentMode to false on the NgxsModule options when in production mode.\n' +
     'NgxsModule.forRoot(states, { developmentMode: !environment.production })',
   [VALIDATION_CODE.INCORRECT_DEVELOPMENT]: () =>
     'RECOMMENDATION: Set developmentMode to true on the NgxsModule when Angular is running in development mode.\n' +

--- a/packages/store/src/configs/messages.config.ts
+++ b/packages/store/src/configs/messages.config.ts
@@ -21,8 +21,8 @@ export const CONFIG_MESSAGES: ObjectKeyMap<Function> = {
     `State name '${current}' from ${newName} already exists in ${oldName}`,
   [VALIDATION_CODE.STATE_DECORATOR]: () => 'States must be decorated with @State() decorator',
   [VALIDATION_CODE.INCORRECT_PRODUCTION]: () =>
-    'Angular is running in production mode but NGXS is still running in the development mode!\n' +
-    'Please set developmentMode to false on the NgxsModule options when in production mode.\n' +
+    'Angular is running in the production mode but NGXS is still running in the development mode!\n' +
+    'Please set developmentMode to false on the NgxsModule options in the production mode.\n' +
     'NgxsModule.forRoot(states, { developmentMode: !environment.production })',
   [VALIDATION_CODE.INCORRECT_DEVELOPMENT]: () =>
     'RECOMMENDATION: Set developmentMode to true on the NgxsModule when Angular is running in development mode.\n' +
@@ -33,5 +33,7 @@ export const CONFIG_MESSAGES: ObjectKeyMap<Function> = {
     '@Action() decorator cannot be used with static methods',
   [VALIDATION_CODE.SELECTOR_DECORATOR]: () => 'Selectors only work on methods',
   [VALIDATION_CODE.ZONE_WARNING]: () =>
-    'Your application was bootstrapped with nooped zone and your execution strategy requires an actual NgZone'
+    'Your application was bootstrapped with nooped zone and your execution strategy requires an actual NgZone!\n' +
+    'Please set the value of the executionStrategy property to NoopNgxsExecutionStrategy.\n' +
+    'NgxsModule.forRoot(states, { executionStrategy: NoopNgxsExecutionStrategy })'
 };

--- a/packages/store/src/configs/messages.config.ts
+++ b/packages/store/src/configs/messages.config.ts
@@ -9,7 +9,8 @@ export enum VALIDATION_CODE {
   INCORRECT_DEVELOPMENT = 'INCORRECT_DEVELOPMENT',
   SELECT_FACTORY_NOT_CONNECTED = 'SELECT_FACTORY_NOT_CONNECTED',
   ACTION_DECORATOR = 'ACTION_DECORATOR',
-  SELECTOR_DECORATOR = 'SELECTOR_DECORATOR'
+  SELECTOR_DECORATOR = 'SELECTOR_DECORATOR',
+  ZONE_WARNING = 'ZONE_WARNING'
 }
 
 export const CONFIG_MESSAGES: ObjectKeyMap<Function> = {
@@ -30,5 +31,7 @@ export const CONFIG_MESSAGES: ObjectKeyMap<Function> = {
     'SelectFactory not connected to store!',
   [VALIDATION_CODE.ACTION_DECORATOR]: () =>
     '@Action() decorator cannot be used with static methods',
-  [VALIDATION_CODE.SELECTOR_DECORATOR]: () => 'Selectors only work on methods'
+  [VALIDATION_CODE.SELECTOR_DECORATOR]: () => 'Selectors only work on methods',
+  [VALIDATION_CODE.ZONE_WARNING]: () =>
+    'Your application was bootstrapped with nooped zone and your execution strategy requires an actual NgZone'
 };

--- a/packages/store/src/execution/dispatch-outside-zone-ngxs-execution-strategy.ts
+++ b/packages/store/src/execution/dispatch-outside-zone-ngxs-execution-strategy.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable, NgZone, PLATFORM_ID } from '@angular/core';
 import { isPlatformServer } from '@angular/common';
 
 import { NgxsExecutionStrategy } from './symbols';
+import { CONFIG_MESSAGES, VALIDATION_CODE } from '../configs/messages.config';
 
 @Injectable()
 export class DispatchOutsideZoneNgxsExecutionStrategy implements NgxsExecutionStrategy {
@@ -34,13 +35,14 @@ export class DispatchOutsideZoneNgxsExecutionStrategy implements NgxsExecutionSt
     return func();
   }
 
-  private verifyZoneIsNotNooped(_: NgZone): void {
-    /* - Removed because unsafe for Angular 5 - investigate
-    if (ngZone instanceof NoopNgZone) {
-      console.warn(
-        'Your application was bootstrapped with nooped zone and your execution strategy requires an ngZone'
-      );
+  private verifyZoneIsNotNooped(ngZone: NgZone): void {
+    // `NoopNgZone` is not exposed publicly as it doesn't expect
+    // to be used outside of the core Angular code, thus we just have
+    // to check if the zone doesn't extend or instanceof `NgZone`
+    if (ngZone instanceof NgZone) {
+      return;
     }
-    */
+
+    console.warn(CONFIG_MESSAGES[VALIDATION_CODE.ZONE_WARNING]());
   }
 }

--- a/packages/store/tests/config-validator.spec.ts
+++ b/packages/store/tests/config-validator.spec.ts
@@ -11,6 +11,7 @@ describe('ConfigValidator', () => {
   let host: HostEnvironment;
 
   it('should be correct detect isNgDevMode when isTestMode = true', () => {
+    // Arrange & act
     TestBed.configureTestingModule({
       imports: [NgxsModule.forRoot([])]
     });
@@ -18,12 +19,14 @@ describe('ConfigValidator', () => {
     validator = TestBed.get(ConfigValidator);
     host = TestBed.get(HostEnvironment);
 
+    // Assert
     expect(host.isDevMode()).toBe(true);
     expect(host.isTestMode()).toBe(true);
     expect(validator.verifyDevMode()).toBe(undefined);
   });
 
   it('should be show warn message incorrect development mode', () => {
+    // Arrange & act
     const spy = jest.spyOn(console, 'warn').mockImplementation();
 
     TestBed.configureTestingModule({
@@ -35,6 +38,7 @@ describe('ConfigValidator', () => {
     host = TestBed.get(HostEnvironment);
 
     try {
+      // Assert
       expect(host.isDevMode()).toBe(true);
       expect(host.isTestMode()).toBe(false);
       const INCORRECT_DEVELOPMENT = CONFIG_MESSAGES[VALIDATION_CODE.INCORRECT_DEVELOPMENT]();
@@ -45,6 +49,7 @@ describe('ConfigValidator', () => {
   });
 
   it('should be show warn message when incorrect production mode', () => {
+    // Arrange & act
     const spy = jest.spyOn(console, 'warn').mockImplementation();
 
     TestBed.configureTestingModule({
@@ -59,6 +64,7 @@ describe('ConfigValidator', () => {
     host = TestBed.get(HostEnvironment);
 
     try {
+      // Assert
       expect(host.isDevMode()).toBe(false);
       expect(host.isTestMode()).toBe(false);
       const INCORRECT_PRODUCTION = CONFIG_MESSAGES[VALIDATION_CODE.INCORRECT_PRODUCTION]();

--- a/packages/store/tests/config-validator.spec.ts
+++ b/packages/store/tests/config-validator.spec.ts
@@ -9,9 +9,6 @@ import { CONFIG_MESSAGES, VALIDATION_CODE } from '../src/configs/messages.config
 describe('ConfigValidator', () => {
   let validator: ConfigValidator;
   let host: HostEnvironment;
-  let actualWarning: string;
-
-  console.warn = (...args: string[]) => (actualWarning = args[0]);
 
   it('should be correct detect isNgDevMode when isTestMode = true', () => {
     TestBed.configureTestingModule({
@@ -27,6 +24,8 @@ describe('ConfigValidator', () => {
   });
 
   it('should be show warn message incorrect development mode', () => {
+    const spy = jest.spyOn(console, 'warn').mockImplementation();
+
     TestBed.configureTestingModule({
       imports: [NgxsModule.forRoot([], { developmentMode: false })],
       providers: [{ provide: NG_DEV_MODE, useValue: () => false }]
@@ -35,14 +34,19 @@ describe('ConfigValidator', () => {
     validator = TestBed.get(ConfigValidator);
     host = TestBed.get(HostEnvironment);
 
-    expect(host.isDevMode()).toBe(true);
-    expect(host.isTestMode()).toBe(false);
-
-    const INCORRECT_DEVELOPMENT = CONFIG_MESSAGES[VALIDATION_CODE.INCORRECT_DEVELOPMENT]();
-    expect(actualWarning).toBe(INCORRECT_DEVELOPMENT);
+    try {
+      expect(host.isDevMode()).toBe(true);
+      expect(host.isTestMode()).toBe(false);
+      const INCORRECT_DEVELOPMENT = CONFIG_MESSAGES[VALIDATION_CODE.INCORRECT_DEVELOPMENT]();
+      expect(spy).toHaveBeenCalledWith(INCORRECT_DEVELOPMENT);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   it('should be show warn message when incorrect production mode', () => {
+    const spy = jest.spyOn(console, 'warn').mockImplementation();
+
     TestBed.configureTestingModule({
       imports: [NgxsModule.forRoot([], { developmentMode: true })],
       providers: [
@@ -54,10 +58,13 @@ describe('ConfigValidator', () => {
     validator = TestBed.get(ConfigValidator);
     host = TestBed.get(HostEnvironment);
 
-    expect(host.isDevMode()).toBe(false);
-    expect(host.isTestMode()).toBe(false);
-
-    const INCORRECT_PRODUCTION = CONFIG_MESSAGES[VALIDATION_CODE.INCORRECT_PRODUCTION]();
-    expect(actualWarning).toBe(INCORRECT_PRODUCTION);
+    try {
+      expect(host.isDevMode()).toBe(false);
+      expect(host.isTestMode()).toBe(false);
+      const INCORRECT_PRODUCTION = CONFIG_MESSAGES[VALIDATION_CODE.INCORRECT_PRODUCTION]();
+      expect(spy).toHaveBeenCalledWith(INCORRECT_PRODUCTION);
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/packages/store/tests/execution/dispatch-outside-zone-ngxs-execution-strategy.spec.ts
+++ b/packages/store/tests/execution/dispatch-outside-zone-ngxs-execution-strategy.spec.ts
@@ -311,16 +311,13 @@ describe('DispatchOutsideZoneNgxsExecutionStrategy', () => {
       class MockModule {}
 
       // Act
-      const warnings: string[] = [];
-
-      console.warn = (...args: string[]) => {
-        warnings.push(args[0]);
-      };
+      const spy = jest.spyOn(console, 'warn').mockImplementation();
 
       await platformBrowserDynamic().bootstrapModule(MockModule, { ngZone: 'noop' });
 
       // Assert
-      expect(warnings).toEqual([CONFIG_MESSAGES[VALIDATION_CODE.ZONE_WARNING]()]);
+      expect(spy).toHaveBeenCalledWith(CONFIG_MESSAGES[VALIDATION_CODE.ZONE_WARNING]());
+      spy.mockRestore();
     })
   );
 
@@ -356,18 +353,14 @@ describe('DispatchOutsideZoneNgxsExecutionStrategy', () => {
       }
 
       // Act
-      const warnings: string[] = [];
-
-      console.warn = (...args: string[]) => {
-        warnings.push(args[0]);
-      };
-
+      const spy = jest.spyOn(console, 'warn').mockImplementation();
       const ngZone = new CustomNgZone({ enableLongStackTrace: false });
 
       await platformBrowserDynamic().bootstrapModule(MockModule, { ngZone });
 
       // Assert
-      expect(warnings).toEqual([]);
+      expect(spy).toHaveBeenCalledTimes(0);
+      spy.mockRestore();
     })
   );
 });

--- a/packages/store/tests/execution/dispatch-outside-zone-ngxs-execution-strategy.spec.ts
+++ b/packages/store/tests/execution/dispatch-outside-zone-ngxs-execution-strategy.spec.ts
@@ -315,8 +315,8 @@ describe('DispatchOutsideZoneNgxsExecutionStrategy', () => {
 
       await platformBrowserDynamic().bootstrapModule(MockModule, { ngZone: 'noop' });
 
-      // Assert
       try {
+        // Assert
         const ZONE_WARNING = CONFIG_MESSAGES[VALIDATION_CODE.ZONE_WARNING]();
         expect(spy).toHaveBeenCalledWith(ZONE_WARNING);
       } finally {
@@ -326,6 +326,7 @@ describe('DispatchOutsideZoneNgxsExecutionStrategy', () => {
   );
 
   it('should not warn if custom zone that extends NgZone is provided', () => {
+    // Arrange
     @Injectable()
     class CustomNgZone extends NgZone {
       run<T>(fn: (...args: any[]) => T): T {
@@ -333,6 +334,7 @@ describe('DispatchOutsideZoneNgxsExecutionStrategy', () => {
       }
     }
 
+    // Act
     const spy = jest.spyOn(console, 'warn').mockImplementation();
 
     TestBed.configureTestingModule({
@@ -346,6 +348,7 @@ describe('DispatchOutsideZoneNgxsExecutionStrategy', () => {
     });
 
     try {
+      // Assert
       expect(spy).toHaveBeenCalledTimes(0);
     } finally {
       spy.mockRestore();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Nooped zone is used by people who prefer to run change detection manually in their apps, this requires permanent calls to tick. If the zone is nooped then nothing will happen actually and the user will not benefit from using our default execution strategy, because the zone does nothing basically.