### PR TITLE
build: set the corrent path to the "integration/tsconfig.spec.json"

### DIFF
--- a/integration/jest.integration.config.js
+++ b/integration/jest.integration.config.js
@@ -2,6 +2,11 @@ const jestRootConfig = require('../jest.config');
 
 module.exports = {
   ...jestRootConfig,
+  globals: {
+    'ts-jest': {
+      tsConfig: '<rootDir>/integration/tsconfig.spec.json'
+    }
+  },
   displayName: 'integration',
   projects: ['<rootDir>/integration'],
   testMatch: ['<rootDir>/integration/**/*.spec.ts'],

--- a/integration/tsconfig.spec.json
+++ b/integration/tsconfig.spec.json
@@ -6,10 +6,9 @@
       "@ngxs/*": ["../@ngxs/*"],
       "@integration/*": ["./app/*"]
     },
-    "outDir": "./out-tsc/spec",
     "module": "commonjs",
     "target": "es5",
-    "types": ["jest"]
+    "types": ["jest", "node"]
   },
   "files": ["polyfills.ts"],
   "include": ["**/*.spec.ts"]


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

When running integration tests Jest should actually use `integration/tsconfig.spec.json` file. Currently it uses the root `tsconfig.json`.