### PR TITLE
fix: migrate based on higher versions in migrations

### DIFF
--- a/packages/storage-plugin/src/storage.plugin.ts
+++ b/packages/storage-plugin/src/storage.plugin.ts
@@ -54,11 +54,12 @@ export class NgxsStoragePlugin implements NgxsPlugin {
 
           if (options.migrations) {
             options.migrations.forEach(strategy => {
-              const versionMatch =
-                strategy.version === getValue(val, strategy.versionKey || 'version');
+              const versionKey = strategy.versionKey || 'version';
+              const isNewVersion = strategy.version > (getValue(val, versionKey) || 0);
               const keyMatch = (!strategy.key && isMaster) || strategy.key === key;
-              if (versionMatch && keyMatch) {
+              if (isNewVersion && keyMatch) {
                 val = strategy.migrate(val);
+                val = setValue(val, versionKey, strategy.version);
                 hasMigration = true;
               }
             });

--- a/packages/storage-plugin/src/symbols.ts
+++ b/packages/storage-plugin/src/symbols.ts
@@ -25,7 +25,7 @@ export interface NgxsStoragePluginOptions {
     /**
      * Version to key off.
      */
-    version: number | string;
+    version: number;
 
     /**
      * Method to migrate the previous state.

--- a/packages/storage-plugin/tests/storage.plugin.spec.ts
+++ b/packages/storage-plugin/tests/storage.plugin.spec.ts
@@ -164,7 +164,7 @@ describe('NgxsStoragePlugin', () => {
 
   it('should migrate global localstorage', () => {
     // Arrange
-    const data = JSON.stringify({ counter: { count: 100, version: 1 } });
+    const data = JSON.stringify({ counter: { count: 100 } });
     localStorage.setItem('@@STATE', data);
 
     // Act
@@ -178,8 +178,7 @@ describe('NgxsStoragePlugin', () => {
               versionKey: 'counter.version',
               migrate: (state: any) => {
                 state.counter = {
-                  counts: state.counter.count,
-                  version: 2
+                  counts: state.counter.count
                 };
                 return state;
               }
@@ -196,13 +195,13 @@ describe('NgxsStoragePlugin', () => {
 
     // Assert
     expect(localStorage.getItem('@@STATE')).toBe(
-      JSON.stringify({ counter: { counts: 100, version: 2 } })
+      JSON.stringify({ counter: { counts: 100, version: 1 } })
     );
   });
 
   it('should migrate single localstorage', () => {
     // Arrange
-    const data = JSON.stringify({ count: 100, version: 1 });
+    const data = JSON.stringify({ count: 100 });
     localStorage.setItem('counter', data);
 
     // Act
@@ -218,8 +217,7 @@ describe('NgxsStoragePlugin', () => {
               versionKey: 'version',
               migrate: (state: any) => {
                 state = {
-                  counts: state.count,
-                  version: 2
+                  counts: state.count
                 };
                 return state;
               }
@@ -235,7 +233,7 @@ describe('NgxsStoragePlugin', () => {
     store.selectSnapshot(CounterState);
 
     // Assert
-    expect(localStorage.getItem('counter')).toBe(JSON.stringify({ counts: 100, version: 2 }));
+    expect(localStorage.getItem('counter')).toBe(JSON.stringify({ counts: 100, version: 1 }));
   });
 
   it('should correct get data from session storage', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

You have to set the migration version of the next migration in the migrate function:

```
NgxsStoragePluginModule.forRoot({
  migrations: [
    {
      version: 1,
      key: 'zoo',
      versionKey: 'myVersion',
      migrate: (state) => {
        return {
          newAnimals: state.animals,
          version: 2 // Important to set this to the next version!
        }
      }
    }
  ]
})
```

Also, looking at the tests, you will need to set the version in the default state. If you didn't before running the migrations plugin for the first time, it will never trigger the first migration.

Issue Number: #1264 


## What is the new behavior?

When there is no version in the state, the storage-plugin will assume version 0. This way it will do migrations even if you forgot to set one in your default state before running the plugin for the first time. 

It will also save the version of a migration to the state, so you don't have to do it in your migrate function:

```
NgxsStoragePluginModule.forRoot({
  migrations: [
    {
      version: 1,
      key: 'zoo',
      versionKey: 'myVersion',
      migrate: (state) => {
        return {
          newAnimals: state.animals,
        }
      }
    }
  ]
})
```

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Because versions are now evaluated with `>`, version can now only be a number. Also, you will have to remove any code setting the version from migrate functions, and the next version you can add would be a version higher than the last one you set:

```
NgxsStoragePluginModule.forRoot({
  migrations: [
    {
      version: 1,
      key: 'zoo',
      versionKey: 'myVersion',
      migrate: (state) => {
        return {
          newAnimals: state.animals,
          // version: 2 (this should be removed from every migrate function)
        }
      }
    },
    {
     version: 3,
     key: 'zoo',
      versionKey: 'myVersion',
      migrate: (state) => {
        // Your next migration
      }
    }
  ]
})
```

## Other information

A bug that still remains is that you can mess up your application by messing up the order of the migrations. That's why I thought of changing it even more, so it just uses the index of the migration as a version. Let me know if this would be something you'd like to see in this PR, else I will add a warning about the order to the docs. 