### PR TITLE
feat(store): add implicitReturnState options for compatibility v3/v4

### DIFF
--- a/docs/advanced/options.md
+++ b/docs/advanced/options.md
@@ -4,15 +4,14 @@ You can provide an `NgxsModuleOptions` object as the second argument of your `Ng
 
 - `developmentMode` - Setting this to `true` will add additional debugging features that are useful for development time. This includes freezing your state and actions to guarantee immutability. (Default value is `false`)
 - `selectorOptions` - A nested options object for providing a global options setting to be used for selectors. This can be overridden at the class or specific selector method level using the `SelectorOptions` decorator. The following options are available:
-  - `suppressErrors` - Setting this to `true` will cause any error within a selector to result in the selector returning `undefined`. Setting this to `false` results in these errors propogating through the stack that triggered the evaluation of the selector that caused the error. **NOTE:** *The default for this setting will be changing to `false` in NGXS v4. The default value in NGXS v3.x is `true`.*
-  - `injectContainerState` - Setting this to `false` will prevent the injection of the container state model as the first parameter of a selector method (defined within a state class) that joins to other selectors for its parameters. When this setting is `true` all selectors defined within a state class will receive the container class' state model as their first parameter. As a result every selector would be re-evaluated after any change to that state. **NOTE:** *This is not ideal, therefore this setting default will be changing to `false` in NGXS v4. The default value in NGXS v3.x is `true`.*
+  - `suppressErrors` - Setting this to `true` will cause any error within a selector to result in the selector returning `undefined`. Setting this to `false` results in these errors propogating through the stack that triggered the evaluation of the selector that caused the error. **NOTE:** _The default for this setting will be changing to `false` in NGXS v4. The default value in NGXS v3.x is `true`._
+  - `injectContainerState` - Setting this to `false` will prevent the injection of the container state model as the first parameter of a selector method (defined within a state class) that joins to other selectors for its parameters. When this setting is `true` all selectors defined within a state class will receive the container class' state model as their first parameter. As a result every selector would be re-evaluated after any change to that state. **NOTE:** _This is not ideal, therefore this setting default will be changing to `false` in NGXS v4. The default value in NGXS v3.x is `true`._
   - See [here](../concepts/select.md#joining-selectors) for examples of the effect this setting has on your selectors.
 - `compatibility` - A nested options object that allows for the following compatibility options:
   - `strictContentSecurityPolicy` - Set this to `true` in order to enable support for pages where a Strict Content Security Policy has been enabled. This setting circumvent some optimisations that violate a strict CSP through the use of `new Function(...)`. (Default value is `false`)
   - `implicitReturnState` - Legacy values are deprecated since v4 and should not be used for new applications:
 
-
-    * legacy_enabled - default for compatibility.
+* legacy_enabled - default for compatibility.
 
 ```ts
 interface SubAppModel {
@@ -31,13 +30,14 @@ class AppState {
        // in terms of return type should return SubAppModel
        // however, the return value returns the entire state tree (appState)
        ctx.dispatch(new MyAction()).subscribe((appState) => { .. })
-       // subApp and appState references equals to { stateA: { .. }, subApp: { hello: true, world: true } }
+       // subApp and appState references equals to
+       // { stateA: { .. }, subApp: { hello: true, world: true } }
    }
 }
 ```
 
-    * legacy_disabled - uses the correct return type from setState, also dispatch should not return anything
-
+* legacy_disabled 
+    
 ```ts
 @State<SubAppModel>({
    name: 'subApp',
@@ -71,9 +71,10 @@ export const ngxsConfig: NgxsModuleOptions = {
     injectContainerState: false
   },
   compatibility: {
-    strictContentSecurityPolicy: true
+    strictContentSecurityPolicy: true,
+    implicitReturnState: 'legacy_disabled'
   },
-  // Execution strategy overridden for illustrative purposes 
+  // Execution strategy overridden for illustrative purposes
   // (only do this if you know what you are doing)
   executionStrategy: NoopNgxsExecutionStrategy
 };

--- a/docs/advanced/options.md
+++ b/docs/advanced/options.md
@@ -9,6 +9,51 @@ You can provide an `NgxsModuleOptions` object as the second argument of your `Ng
   - See [here](../concepts/select.md#joining-selectors) for examples of the effect this setting has on your selectors.
 - `compatibility` - A nested options object that allows for the following compatibility options:
   - `strictContentSecurityPolicy` - Set this to `true` in order to enable support for pages where a Strict Content Security Policy has been enabled. This setting circumvent some optimisations that violate a strict CSP through the use of `new Function(...)`. (Default value is `false`)
+  - `implicitReturnState` - Legacy values are deprecated since v4 and should not be used for new applications:
+
+
+    * legacy_enabled - default for compatibility.
+
+```ts
+interface SubAppModel {
+   hello: boolean;
+   world: boolean;
+}
+
+@State<SubAppModel>({
+   name: 'subApp',
+   defaults: { ... }
+})
+class AppState {
+   @Action([..])
+   action(ctx: StateContext<SubAppModel>) {
+       const subApp: SubAppModel = ctx.setState({ .. });
+       // in terms of return type should return SubAppModel
+       // however, the return value returns the entire state tree (appState)
+       ctx.dispatch(new MyAction()).subscribe((appState) => { .. })
+       // subApp and appState references equals to { stateA: { .. }, subApp: { hello: true, world: true } }
+   }
+}
+```
+
+    * legacy_disabled - uses the correct return type from setState, also dispatch should not return anything
+
+```ts
+@State<SubAppModel>({
+   name: 'subApp',
+   defaults: { ... }
+})
+class AppState {
+   @Action([..])
+   action(ctx: StateContext<SubAppModel>) {
+       const subApp: SubAppModel = ctx.setState({ .. });
+       ctx.dispatch(new MyAction()).subscribe((appState) => { .. })
+       // subApp equals to { hello: true, world: true }
+       // appState equals to undefined
+   }
+}
+```
+
 - `executionStrategy` - An advanced option that is used to gain specific control over the way that NGXS executes code that is considered to be inside the NGXS context (ie. within `@Action` handlers) and the context under which the NGXS behaviours are observed (outside the NGXS context). These observable behaviours are: `@Select(...)`, `store.select(...)`, `actions.subscribe(...)` or `store.dispatch(...).subscribe(...)`  
   Developers who prefer to manually control the change detection mechanism in their application may choose to use the `NoopNgxsExecutionStrategy` which does not interfere with zones and therefore relies on the external context to handle change detection (for example: `OnPush` or the Ivy rendering engine). Developers can also choose to implement their own strategy by providing an Angular service class that implements the `NgxsExecutionStrategy` interface. The default value of `null` will result in the default strategy being used. This default strategy runs NGXS operations outside Angular's zone but all observable behaviours of NGXS are run back inside Angular's zone. (The default value is `null`)
 

--- a/docs/advanced/options.md
+++ b/docs/advanced/options.md
@@ -4,8 +4,8 @@ You can provide an `NgxsModuleOptions` object as the second argument of your `Ng
 
 - `developmentMode` - Setting this to `true` will add additional debugging features that are useful for development time. This includes freezing your state and actions to guarantee immutability. (Default value is `false`)
 - `selectorOptions` - A nested options object for providing a global options setting to be used for selectors. This can be overridden at the class or specific selector method level using the `SelectorOptions` decorator. The following options are available:
-  - `suppressErrors` - Setting this to `true` will cause any error within a selector to result in the selector returning `undefined`. Setting this to `false` results in these errors propogating through the stack that triggered the evaluation of the selector that caused the error. **NOTE:** _The default for this setting will be changing to `false` in NGXS v4. The default value in NGXS v3.x is `true`._
-  - `injectContainerState` - Setting this to `false` will prevent the injection of the container state model as the first parameter of a selector method (defined within a state class) that joins to other selectors for its parameters. When this setting is `true` all selectors defined within a state class will receive the container class' state model as their first parameter. As a result every selector would be re-evaluated after any change to that state. **NOTE:** _This is not ideal, therefore this setting default will be changing to `false` in NGXS v4. The default value in NGXS v3.x is `true`._
+  - `suppressErrors` - Setting this to `true` will cause any error within a selector to result in the selector returning `undefined`. Setting this to `false` results in these errors propogating through the stack that triggered the evaluation of the selector that caused the error. **NOTE:** *The default for this setting will be changing to `false` in NGXS v4. The default value in NGXS v3.x is `true`.*
+  - `injectContainerState` - Setting this to `false` will prevent the injection of the container state model as the first parameter of a selector method (defined within a state class) that joins to other selectors for its parameters. When this setting is `true` all selectors defined within a state class will receive the container class' state model as their first parameter. As a result every selector would be re-evaluated after any change to that state. **NOTE:** *This is not ideal, therefore this setting default will be changing to `false` in NGXS v4. The default value in NGXS v3.x is `true`.*
   - See [here](../concepts/select.md#joining-selectors) for examples of the effect this setting has on your selectors.
 - `compatibility` - A nested options object that allows for the following compatibility options:
   - `strictContentSecurityPolicy` - Set this to `true` in order to enable support for pages where a Strict Content Security Policy has been enabled. This setting circumvent some optimisations that violate a strict CSP through the use of `new Function(...)`. (Default value is `false`)
@@ -74,7 +74,7 @@ export const ngxsConfig: NgxsModuleOptions = {
     strictContentSecurityPolicy: true,
     implicitReturnState: 'legacy_disabled'
   },
-  // Execution strategy overridden for illustrative purposes
+  // Execution strategy overridden for illustrative purposes 
   // (only do this if you know what you are doing)
   executionStrategy: NoopNgxsExecutionStrategy
 };

--- a/packages/store/src/symbols.ts
+++ b/packages/store/src/symbols.ts
@@ -37,6 +37,35 @@ export class NgxsConfig {
      * (default: false)
      */
     strictContentSecurityPolicy: boolean;
+
+    /**
+     * Legacy values are deprecated since v4 and should not be used for new applications:
+     * legacy_enabled - Default for compatibility.
+     *
+     ***********************************************************************
+     * @State<SubAppModel>({
+     *  name: 'subApp'
+     * })
+     * class AppState {
+     *   @Action([..])
+     *   action(ctx: StateContext<SubAppModel>) {
+     *     const value: SubAppModel = ctx.setState({ .. })
+     *     // in terms of return type should return SubAppModel
+     *     // however, the return value returns the entire state tree (appState)
+     *   }
+     * }
+     *
+     * Also dispatch should not return anything
+     * this.store.dispatch(new MyAction()).subscribe((appState) => {
+     *   // however returns the entire state tree (appState)
+     * }})
+     ***********************************************************************
+     *
+     * 'legacy_disabled' - uses the correct return type from setState,
+     * also dispatch should not return anything
+     *
+     */
+    implicitReturnState?: 'legacy_enabled' | 'legacy_disabled';
   };
   /**
    * Determines the execution context to perform async operations inside. An implementation can be
@@ -67,7 +96,8 @@ export class NgxsConfig {
 
   constructor() {
     this.compatibility = {
-      strictContentSecurityPolicy: false
+      strictContentSecurityPolicy: false,
+      implicitReturnState: 'legacy_enabled' // TODO: default is legacy_enabled in v3, will change in v4
     };
     this.executionStrategy = DispatchOutsideZoneNgxsExecutionStrategy;
   }

--- a/packages/store/tests/compat.spec.ts
+++ b/packages/store/tests/compat.spec.ts
@@ -1,0 +1,147 @@
+import { async, TestBed } from '@angular/core/testing';
+import { Action, NgxsModule, State, StateContext, Store } from '@ngxs/store';
+
+describe('Compatibility options (implicit return state)', () => {
+  interface SubSubStateModel {
+    name: string;
+  }
+
+  interface SubStateModel {
+    hello: boolean;
+    world: boolean;
+    baz?: SubSubStateModel;
+  }
+
+  interface StateModel {
+    first: string;
+    second: string;
+    bar?: SubStateModel;
+  }
+
+  interface OtherStateModel {
+    under: string;
+  }
+
+  @State<SubSubStateModel>({
+    name: 'baz',
+    defaults: {
+      name: 'Danny'
+    }
+  })
+  class MySubSubState {}
+
+  @State<SubStateModel>({
+    name: 'bar',
+    defaults: {
+      hello: true,
+      world: true
+    },
+    children: [MySubSubState]
+  })
+  class MySubState {
+    @Action({ type: 'legacySetState' })
+    legacySetState(ctx: StateContext<SubStateModel>): void {
+      const result: SubStateModel = ctx.setState((state: SubStateModel) => ({
+        ...state,
+        hello: false,
+        world: false
+      }));
+
+      expect(result).toEqual({
+        under_: { under: 'score' },
+        foo: {
+          first: 'Hello',
+          second: 'World',
+          bar: { hello: false, world: false, baz: { name: 'Danny' } }
+        }
+      });
+    }
+
+    @Action({ type: 'featureSetState' })
+    featureSetState(ctx: StateContext<SubStateModel>): void {
+      const result: SubStateModel = ctx.setState((state: SubStateModel) => ({
+        ...state,
+        hello: false,
+        world: false
+      }));
+
+      expect(result).toEqual({ hello: false, world: false, baz: { name: 'Danny' } });
+    }
+  }
+
+  @State<StateModel>({
+    name: 'foo',
+    defaults: {
+      first: 'Hello',
+      second: 'World'
+    },
+    children: [MySubState]
+  })
+  class MyState {}
+
+  @State<OtherStateModel>({
+    name: 'under_',
+    defaults: {
+      under: 'score'
+    }
+  })
+  class MyOtherState {}
+
+  let store: Store;
+
+  it('should be correct legacy setState with returned AppState from dispatch', async(() => {
+    TestBed.configureTestingModule({
+      imports: [NgxsModule.forRoot([MySubState, MySubSubState, MyState, MyOtherState])]
+    });
+
+    store = TestBed.get(Store);
+
+    expect(store.snapshot()).toEqual({
+      under_: { under: 'score' },
+      foo: {
+        first: 'Hello',
+        second: 'World',
+        bar: { hello: true, world: true, baz: { name: 'Danny' } }
+      }
+    });
+
+    store.dispatch({ type: 'legacySetState' }).subscribe(state => {
+      expect(state).toEqual({
+        under_: { under: 'score' },
+        foo: {
+          first: 'Hello',
+          second: 'World',
+          bar: { hello: false, world: false, baz: { name: 'Danny' } }
+        }
+      });
+    });
+  }));
+
+  it('should be correct feature setState with returned void from dispatch', async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NgxsModule.forRoot([MySubState, MySubSubState, MyState, MyOtherState], {
+          compatibility: {
+            strictContentSecurityPolicy: false,
+            implicitReturnState: 'legacy_disabled'
+          }
+        })
+      ]
+    });
+
+    store = TestBed.get(Store);
+
+    expect(store.snapshot()).toEqual({
+      under_: { under: 'score' },
+      foo: {
+        first: 'Hello',
+        second: 'World',
+        bar: { hello: true, world: true, baz: { name: 'Danny' } }
+      }
+    });
+
+    store.dispatch({ type: 'featureSetState' }).subscribe((state: void) => {
+      expect(state).toEqual(undefined);
+    });
+  }));
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ngxs/store/issues/827

![image](https://user-images.githubusercontent.com/12021443/66241500-e7210900-e707-11e9-844f-7f717cf0eab7.png)

`setState`, `patchState` should be return T instead the either state
`dispatch` should be return void

## What is the new behavior?

Ability to switch to the desired mode before switching to ngxs V4


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
