### PR TITLE
feat(hmr-plugin): add option for persisting state after the root module is disposed

### DIFF
--- a/docs/plugins/hmr.md
+++ b/docs/plugins/hmr.md
@@ -113,7 +113,7 @@ const bootstrap = () => platformBrowserDynamic().bootstrapModule(AppModule);
 
 if (environment.hmr) {
   import('@ngxs/hmr-plugin').then(plugin => {
-    plugin.hmr(module, bootstrap).catch((err: Error) => console.error(err))
+    plugin.hmr(module, bootstrap).catch((err: Error) => console.error(err));
   });
 } else {
   bootstrap().catch((err: Error) => console.log(err));
@@ -179,4 +179,24 @@ export class MyState {
     ctx.setState({ ... })
   }
 }
+```
+
+### HMR Options
+
+The following options are available:
+
+- `autoClearLogs` - Clear log after each hmr update (default value is `true`).
+- `deferTime` - Deferred time before loading the old state (default value is `100` ms);
+- `persistAfterDestroy` - Additionally persist state when the AppModule is disposed (default value is `false`).
+
+```ts
+import('@ngxs/hmr-plugin').then(plugin => {
+  plugin
+    .hmr(module, bootstrap, {
+      deferTime: 100,
+      autoClearLogs: true,
+      persistAfterDestroy: true
+    })
+    .catch((err: Error) => console.error(err));
+});
 ```

--- a/docs/plugins/hmr.md
+++ b/docs/plugins/hmr.md
@@ -185,7 +185,7 @@ export class MyState {
 
 The following options are available:
 
-- `autoClearLogs` - Clear log after each hmr update (default value is `true`).
+- `autoClearLogs` - Clear logs after each refresh (default value is `true`).
 - `deferTime` - Deferred time before loading the old state (default value is `100` ms);
 - `persistAfterDestroy` - Additionally persist state when the AppModule is disposed (default value is `false`).
 

--- a/packages/hmr-plugin/src/hmr-bootstrap.ts
+++ b/packages/hmr-plugin/src/hmr-bootstrap.ts
@@ -29,6 +29,9 @@ export async function hmr<T>(
     webpackModule.hot!.dispose((data: HmrDataTransfer) => {
       data.snapshot = manager.beforeModuleOnDestroy();
       manager.createNewModule();
+      if (options.persistAfterDestroyed) {
+        manager.context.store.reset(data.snapshot);
+      }
     });
   });
 }

--- a/packages/hmr-plugin/src/hmr-bootstrap.ts
+++ b/packages/hmr-plugin/src/hmr-bootstrap.ts
@@ -29,7 +29,7 @@ export async function hmr<T>(
     webpackModule.hot!.dispose((data: HmrDataTransfer) => {
       data.snapshot = manager.beforeModuleOnDestroy();
       manager.createNewModule();
-      if (options.persistAfterDestroyed) {
+      if (options.persistAfterDestroy) {
         manager.context.store.reset(data.snapshot);
       }
     });

--- a/packages/hmr-plugin/src/symbols.ts
+++ b/packages/hmr-plugin/src/symbols.ts
@@ -37,6 +37,12 @@ export interface NgxsHmrOptions {
    * (default: 100ms)
    */
   deferTime?: number;
+
+  /**
+   * @description
+   * additionally persist state after destruction AppModule
+   */
+  persistAfterDestroyed?: boolean;
 }
 
 type ModuleId = string | number;

--- a/packages/hmr-plugin/src/symbols.ts
+++ b/packages/hmr-plugin/src/symbols.ts
@@ -40,9 +40,9 @@ export interface NgxsHmrOptions {
 
   /**
    * @description
-   * additionally persist state after destruction AppModule
+   * Additionally persist state when the AppModule is disposed
    */
-  persistAfterDestroyed?: boolean;
+  persistAfterDestroy?: boolean;
 }
 
 type ModuleId = string | number;

--- a/packages/hmr-plugin/src/symbols.ts
+++ b/packages/hmr-plugin/src/symbols.ts
@@ -26,14 +26,14 @@ export type BootstrapModuleFn<T = any> = () => Promise<NgModuleRef<T>>;
 export interface NgxsHmrOptions {
   /**
    * @description
-   * clear log after each hmr update
+   * Clear logs after each refresh
    * (default: true)
    */
   autoClearLogs?: boolean;
 
   /**
    * @description
-   * deferred time before loading the old state
+   * Deferred time before loading the old state
    * (default: 100ms)
    */
   deferTime?: number;

--- a/packages/hmr-plugin/src/tests/hmr-helpers.ts
+++ b/packages/hmr-plugin/src/tests/hmr-helpers.ts
@@ -7,7 +7,7 @@ import { NgModuleRef, Type } from '@angular/core';
 
 import { Actions, Store } from '../../../store/src/public_api';
 import { MockState, WebpackMockModule } from './hmr-mock';
-import { BootstrapModuleFn, hmr } from '../public_api';
+import { BootstrapModuleFn, hmr, NgxsHmrOptions } from '../public_api';
 
 export function setup<T>(moduleType: Type<T>) {
   TestBed.resetTestEnvironment();
@@ -22,14 +22,18 @@ interface HmrMockTestBedOptions {
   storedValue?: any;
 }
 
-export async function hmrTestBed<T>(moduleType: Type<T>, options: HmrMockTestBedOptions = {}) {
+export async function hmrTestBed<T>(
+  moduleType: Type<T>,
+  options: HmrMockTestBedOptions = {},
+  hmrOptions: NgxsHmrOptions = {}
+) {
   const { bootstrap } = setup(moduleType);
   const webpackModule = new WebpackMockModule();
 
   const snapshotContainer: { snapshot?: any } = webpackModule.hot.data;
   snapshotContainer.snapshot = options.storedValue;
 
-  const appModule: NgModuleRef<T> = await hmr(webpackModule, bootstrap);
+  const appModule: NgModuleRef<T> = await hmr(webpackModule, bootstrap, hmrOptions);
   const actions$ = appModule.injector.get<Actions>(Actions);
   const store = appModule.injector.get<Store>(Store);
   const getStoredValue = () => snapshotContainer.snapshot;

--- a/packages/hmr-plugin/src/tests/hmr-manager.spec.ts
+++ b/packages/hmr-plugin/src/tests/hmr-manager.spec.ts
@@ -292,85 +292,83 @@ describe('HMR Plugin', () => {
     expect((appModule as any)['_destroyed']).toEqual(true);
   });
 
-  describe('side effect destroy state when called reset in ngOnDestroy', () => {
-    it('state provided before module destroy', fakeAsync(async () => {
-      const { webpackModule, store } = await hmrTestBed(AppMockModuleNoHmrLifeCycle);
+  it('state has to be provided before module is disposed', fakeAsync(async () => {
+    const { webpackModule, store } = await hmrTestBed(AppMockModuleNoHmrLifeCycle);
 
-      expect(store.snapshot()).toEqual({
-        mock_state: { value: 'test' }
-      });
+    expect(store.snapshot()).toEqual({
+      mock_state: { value: 'test' }
+    });
 
-      webpackModule.destroyModule();
+    webpackModule.destroyModule();
 
-      tick(1000);
+    tick(1000);
 
-      expect(store.snapshot()).toEqual({
-        mock_state: { value: 'test' }
-      });
-    }));
+    expect(store.snapshot()).toEqual({
+      mock_state: { value: 'test' }
+    });
+  }));
 
-    it('state provided before module destroy with reset in ngOnDestroy', fakeAsync(async () => {
-      class AppMockWithDestroyModule extends AppMockModuleNoHmrLifeCycle implements OnDestroy {
-        public ngOnDestroy(): void {
-          // side effect for hmr
-          store.reset({});
-        }
+  it('state has to be provided before module is disposed with calling reset in ngOnDestroy', fakeAsync(async () => {
+    class AppMockWithDestroyModule extends AppMockModuleNoHmrLifeCycle implements OnDestroy {
+      public ngOnDestroy(): void {
+        // side effect for hmr
+        store.reset({});
       }
+    }
 
-      const { webpackModule, store } = await hmrTestBed(AppMockWithDestroyModule);
+    const { webpackModule, store } = await hmrTestBed(AppMockWithDestroyModule);
 
-      expect(store.snapshot()).toEqual({
-        mock_state: { value: 'test' }
-      });
+    expect(store.snapshot()).toEqual({
+      mock_state: { value: 'test' }
+    });
 
-      webpackModule.destroyModule();
+    webpackModule.destroyModule();
 
-      tick(1000);
+    tick(1000);
 
-      expect(store.snapshot()).toEqual({});
-    }));
+    expect(store.snapshot()).toEqual({});
+  }));
 
-    it('state provided after module destroy', fakeAsync(async () => {
-      class AppMockWithDestroyModule extends AppMockModuleNoHmrLifeCycle implements OnDestroy {
-        public ngOnDestroy(): void {
-          // side effect for hmr
-          store.reset({});
-        }
+  it('state has to be provided after module is disposed', fakeAsync(async () => {
+    class AppMockWithDestroyModule extends AppMockModuleNoHmrLifeCycle implements OnDestroy {
+      public ngOnDestroy(): void {
+        // side effect for hmr
+        store.reset({});
       }
+    }
 
-      const { webpackModule, store } = await hmrTestBed(
-        AppMockWithDestroyModule,
-        {},
-        {
-          persistAfterDestroyed: true
-        }
-      );
+    const { webpackModule, store } = await hmrTestBed(
+      AppMockWithDestroyModule,
+      {},
+      {
+        persistAfterDestroy: true
+      }
+    );
 
-      expect(store.snapshot()).toEqual({ mock_state: { value: 'test' } });
+    expect(store.snapshot()).toEqual({ mock_state: { value: 'test' } });
 
-      webpackModule.destroyModule();
+    webpackModule.destroyModule();
 
-      tick(1000);
+    tick(1000);
 
-      expect(store.snapshot()).toEqual({ mock_state: { value: 'test' } });
+    expect(store.snapshot()).toEqual({ mock_state: { value: 'test' } });
 
-      store.reset({ ...store.snapshot(), hello: 'world' });
+    store.reset({ ...store.snapshot(), hello: 'world' });
 
-      const { webpackModule: moduleTickV2, store: storeV2 } = await hmrTestBed(
-        AppMockWithDestroyModule,
-        {
-          storedValue: store.snapshot()
-        },
-        {
-          persistAfterDestroyed: true
-        }
-      );
+    const { webpackModule: moduleTickV2, store: storeV2 } = await hmrTestBed(
+      AppMockWithDestroyModule,
+      {
+        storedValue: store.snapshot()
+      },
+      {
+        persistAfterDestroy: true
+      }
+    );
 
-      moduleTickV2.destroyModule();
+    moduleTickV2.destroyModule();
 
-      tick(1000);
+    tick(1000);
 
-      expect(storeV2.snapshot()).toEqual({ mock_state: { value: 'test' }, hello: 'world' });
-    }));
-  });
+    expect(storeV2.snapshot()).toEqual({ mock_state: { value: 'test' }, hello: 'world' });
+  }));
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ngxs/store/issues/1347

## What is the new behavior?

If during the method of ngOnDestroy the state is deleted before it is saved, we can save the state again after.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
