### PR TITLE
feat(websocket-plugin): implement `WebSocketConnected` action

### DIFF
--- a/docs/plugins/websocket.md
+++ b/docs/plugins/websocket.md
@@ -114,8 +114,8 @@ const ws = new Server({ server });
 
 server.listen(4200);
 
-ws.on('connection', (socket) => {
-  socket.on('message', (data) => {
+ws.on('connection', socket => {
+  socket.on('message', data => {
     // That's the object that we passed into `SendWebSocketMessage` constructor
     const { type, from, message } = JSON.parse(data);
 
@@ -129,7 +129,7 @@ ws.on('connection', (socket) => {
       // That's the same as `broadcast`
       // we want to send message to all connected
       // to the chat clients
-      ws.clients.forEach((client) => {
+      ws.clients.forEach(client => {
         client.send(event);
       });
     }
@@ -170,8 +170,9 @@ If you have difficulties with understanding how the plugin works, you can have a
 Here is a list of all the available actions you have:
 
 - `ConnectWebSocket`: Dispatch this action when you want to init the web socket. Optionally pass URL here.
-- `DisconnectWebSocket`: Dispatch this Action to disconnect a websockets.
-- `WebSocketDisconnected`: Action dispatched when web socket is disconnected. Use its handler for reconnecting.
+- `DisconnectWebSocket`: Dispatch this Action to disconnect a web socket.
+- `WebSocketConnected`: Action dispatched when a web socket is connected.
+- `WebSocketDisconnected`: Action dispatched when a web socket is disconnected. Use its handler for reconnecting.
 - `SendWebSocketMessage`: Send a message to the server.
 - `WebsocketMessageError`: Action dispatched by this plugin when an error ocurrs upon receiving a message.
 - `WebSocketConnectionUpdated`: Action dispatched by this plugin when a new connection is created on top of an existing one. Existing connection is closing.

--- a/packages/websocket-plugin/src/public_api.ts
+++ b/packages/websocket-plugin/src/public_api.ts
@@ -7,5 +7,6 @@ export {
   DisconnectWebSocket,
   WebSocketDisconnected,
   SendWebSocketMessage,
-  WebSocketConnectionUpdated
+  WebSocketConnectionUpdated,
+  WebSocketConnected
 } from './symbols';

--- a/packages/websocket-plugin/src/symbols.ts
+++ b/packages/websocket-plugin/src/symbols.ts
@@ -89,6 +89,15 @@ export class DisconnectWebSocket {
 }
 
 /**
+ * Action triggered when websocket is connected
+ */
+export class WebSocketConnected {
+  static get type() {
+    return '[WebSocket] Connected';
+  }
+}
+
+/**
  * Action triggered when websocket is disconnected
  */
 export class WebSocketDisconnected {

--- a/packages/websocket-plugin/src/websocket-handler.ts
+++ b/packages/websocket-plugin/src/websocket-handler.ts
@@ -12,7 +12,8 @@ import {
   WebsocketMessageError,
   WebSocketDisconnected,
   TypeKeyPropertyMissingError,
-  WebSocketConnectionUpdated
+  WebSocketConnectionUpdated,
+  WebSocketConnected
 } from './symbols';
 
 @Injectable()
@@ -34,6 +35,9 @@ export class WebSocketHandler {
         // and doesn't complete socket subject if it's falsy
         this.disconnect();
       }
+    },
+    openObserver: {
+      next: () => this.store.dispatch(new WebSocketConnected())
     }
   };
 

--- a/packages/websocket-plugin/tests/websocket.module.spec.ts
+++ b/packages/websocket-plugin/tests/websocket.module.spec.ts
@@ -20,9 +20,10 @@ import {
   SendWebSocketMessage,
   DisconnectWebSocket,
   WebSocketDisconnected,
-  WebsocketMessageError
+  WebsocketMessageError,
+  WebSocketConnectionUpdated,
+  WebSocketConnected
 } from '../';
-import { WebSocketConnectionUpdated } from '../src/symbols';
 
 type WebSocketMessage = string | Blob | ArrayBuffer | ArrayBufferView;
 
@@ -103,11 +104,27 @@ describe('NgxsWebsocketPlugin', () => {
 
     actions$.pipe(ofActionDispatched(WebSocketDisconnected)).subscribe(action => {
       // Assert
-      expect(action instanceof WebSocketDisconnected).toBeTruthy();
+      expect(action).toBeInstanceOf(WebSocketDisconnected);
       mockServer.stop(done);
     });
 
     store.dispatch(new DisconnectWebSocket());
+  });
+
+  it('should dispatch WebSocketConnected if connection is opened successfully', done => {
+    // Arrange
+    const mockServer = createModuleAndServer();
+    const store = getStore();
+    const actions$ = getActions$();
+
+    // Act
+    store.dispatch(new ConnectWebSocket());
+
+    actions$.pipe(ofActionDispatched(WebSocketConnected)).subscribe(action => {
+      // Assert
+      expect(action).toBeInstanceOf(WebSocketConnected);
+      mockServer.stop(done);
+    });
   });
 
   it('should dispatch WebSocketDisconnected if server closed connection', done => {
@@ -123,7 +140,7 @@ describe('NgxsWebsocketPlugin', () => {
 
     actions$.pipe(ofActionDispatched(WebSocketDisconnected)).subscribe(action => {
       // Assert
-      expect(action instanceof WebSocketDisconnected).toBeTruthy();
+      expect(action).toBeInstanceOf(WebSocketDisconnected);
       mockServer.stop(done);
     });
   });
@@ -143,7 +160,7 @@ describe('NgxsWebsocketPlugin', () => {
 
     actions$.pipe(ofActionDispatched(WebsocketMessageError)).subscribe(action => {
       // Assert
-      expect(action instanceof WebsocketMessageError).toBeTruthy();
+      expect(action).toBeInstanceOf(WebsocketMessageError);
       mockServer.stop(done);
     });
   });
@@ -194,7 +211,7 @@ describe('NgxsWebsocketPlugin', () => {
 
     actions$.pipe(ofActionDispatched(WebSocketConnectionUpdated)).subscribe(action => {
       // Assert
-      expect(action instanceof WebSocketConnectionUpdated).toBeTruthy();
+      expect(action).toBeInstanceOf(WebSocketConnectionUpdated);
       mockServer.stop(done);
     });
   });
@@ -291,7 +308,7 @@ describe('NgxsWebsocketPlugin', () => {
         });
 
       actions$.pipe(ofActionDispatched(WebSocketDisconnected)).subscribe(action => {
-        expect(action instanceof WebSocketDisconnected).toBeTruthy();
+        expect(action).toBeInstanceOf(WebSocketDisconnected);
         // Reconnect after disconnect
         connect(store);
       });
@@ -350,7 +367,7 @@ describe('NgxsWebsocketPlugin', () => {
         });
 
       actions$.pipe(ofActionDispatched(WebSocketDisconnected)).subscribe(action => {
-        expect(action instanceof WebSocketDisconnected).toBeTruthy();
+        expect(action).toBeInstanceOf(WebSocketDisconnected);
         // Reconnect after disconnect
         connect(store);
       });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

@markwhitfeld @splincode 

Gentlemen. This is a super lightweight PR (just 5 lines of code were added). Currently there is no possibility to determine if connection was opened successfully.

The RxJS `WebSocketSubject` has the `openObserver` option that lets us provide a listener for the  events, that occur on the underlying web socket.

Given the following chat application and task:

* show green circle (online status)
* show red circle (offline status)

Currently we expose only `WebSocketDisconnected` action. This is semantically inconvenient to work only with this action. `WebSocketConnected` is a new action that is dispatched when the underlying socket is connected successfully.

The below code demonstrates the first use-case:

```ts
@Component({
  selector: 'app-status',
  template: `
    <div class="status" [ngClass]="status"></div>
  `
})
class StatusComponent {
  @Input() status: string;
}

@Component({
  selector: 'app-chat',
  template: `
    <app-status [status]="status$ | async"></app-status>
  `
})
class ChatComponent {
  online$ = this.actions$.pipe(
    ofActionDispatched(WebSocketConnected),
    mapTo('online')
  );

  offline$ = this.actions$.pipe(
    ofActionDispatched(WebSocketDisconnected),
    mapTo('offline')
  );

  status$ = merge(this.online$, this.offline$);

  constructor(private actions$: Actions) {}
}
```