### PR TITLE
fix(store): do not re-throw error to the global handler if custom is provided

### DIFF
--- a/packages/store/src/internal/dispatcher.ts
+++ b/packages/store/src/internal/dispatcher.ts
@@ -39,7 +39,11 @@ export class InternalDispatcher {
 
     result.subscribe({
       error: error =>
-        this._ngxsExecutionStrategy.leave(() => this._errorHandler.handleError(error))
+        this._ngxsExecutionStrategy.leave(() => {
+          try {
+            this._errorHandler.handleError(error);
+          } catch {}
+        })
     });
 
     return result.pipe(leaveNgxs(this._ngxsExecutionStrategy));

--- a/packages/store/tests/dispatch.spec.ts
+++ b/packages/store/tests/dispatch.spec.ts
@@ -55,7 +55,7 @@ describe('Dispatch', () => {
     expect(observedCalls).toEqual(['handleError(...)', 'observer.error(...)']);
   }));
 
-  fit('should not propagate an unhandled exception', () => {
+  it('should not propagate an unhandled exception', () => {
     // Arrange
     const message = 'This is an eval error...';
 

--- a/packages/store/tests/dispatch.spec.ts
+++ b/packages/store/tests/dispatch.spec.ts
@@ -121,7 +121,7 @@ describe('Dispatch', () => {
     store.dispatch(new Increment());
 
     // Assert
-    expect(thrownMessage).toEqual(null);
+    expect(thrownMessage).toBeNull();
   });
 
   it('should run outside zone and return back in zone', async(() => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1145 #803 #781 #463 

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

:warning: :warning: **The whole PR description is below** :warning: :warning: 

This PR is a fix for old issues that reported about error handlers that were invoked twice. Let's look at the runtime behavior below:

![1](https://user-images.githubusercontent.com/7337691/66596629-e4aa2d80-eba5-11e9-8933-96fac42c3d6f.png)

There is a simple `Increment` action and such state:

```ts
@State({
  name: 'counter',
  defaults: 0
})
export class CounterState {
  @Action(Increment)
  increment() {
    throw new EvalError('This is an eval error...');
  }
}
```

And custom error handler looks as follows:

```ts
@Injectable({ providedIn: 'root' })
export class NgxsErrorHandler implements ErrorHandler {
  handleError(error: Error): void {
    console.log(`${NgxsErrorHandler.name}.handleError has been invoked with ${error.name}`);

    // re-throw
    throw error;
  }
}
```

---

What's actually happening there? We dispatch an action. Our action handler throws an `EvalError`. NGXS subscribes under the hood and provides `onError` listener where it does:

```ts
this._errorHandler.handleError(error);
```

NGXS invokes our custom `NgxsErrorHandler.handleError`, it logs to console and re-throws error via `throw error` (the pitfall is here). As this error is re-thrown - it gets caught by the Angular zone. When Angular forks zone it provides the `onHandleError` hook. This looks as follows:

```ts
onHandleError: (delegate: ZoneDelegate, current: Zone, target: Zone, error: any): boolean => {
  delegate.handleError(target, error);
  zone.runOutsideAngular(() => zone.onError.emit(error));
  return false; 
}
```

Zone intercepts all thrown exceptions inside `zone.run` and emits event via `onError.emit(error)`. Is this EventEmitter subscribed anywhere? Yes, when we invoke `bootstrapModule` Angular retrieves `ErrorHandler` under the hood and subscribes to the `onError`:

```ts
const exceptionHandler = moduleRef.injector.get(ErrorHandler, null);
if (!exceptionHandler) {
  throw new Error(
    'No ErrorHandler. Is platform module (BrowserModule) included?'
  );
}

ngZone.runOutsideAngular(() =>
  ngZone.onError.subscribe({
    next: error => {
      exceptionHandler.handleError(error);
    }
  })
);
```

:exclamation: **As you see that's why our message is logged twice, because `handleError` is invoked by NGXS and Angular** :exclamation: 

![zone](https://user-images.githubusercontent.com/7337691/66598951-dca0bc80-ebaa-11e9-83fc-57da3bd585d5.png)

---

**You may ask me why there are no tests?**

Because runtime behavior differs from testing behavior. The zone, that is used for testing, doesn't intercept errors like at runtime. That's why I cannot add tests. But as you see all tests are passed thus it's not a breaking change. The new behavior looks as follows:

![fixed](https://user-images.githubusercontent.com/7337691/66599664-7321ad80-ebac-11e9-9a5c-3321d9681e64.png)

---

**The same test I've added BUT without `try/catch` block, as you see below the `handleError` does re-throws it to the zone.js** :point_down: 

![without](https://user-images.githubusercontent.com/7337691/66702737-9450de00-ed13-11e9-8d91-9d2973ac95aa.png)
