### PR TITLE
feat(storage-plugin): use state classes as keys

### DIFF
--- a/docs/plugins/storage.md
+++ b/docs/plugins/storage.md
@@ -64,23 +64,77 @@ export class DetectivesState {}
 In order to persist all states there is no need to provide the `key` option, so it's enough just to write:
 
 ```ts
-NgxsStoragePluginModule.forRoot();
+@NgModule({
+  imports: [
+    NgxsStoragePluginModule.forRoot()
+  ]
+})
+export class AppModule {}
 ```
 
 But what if we wanted to persist only `NovelsState`? Then we would have needed to pass its name to the `key` option:
 
 ```ts
-NgxsStoragePluginModule.forRoot({
-  key: 'novels'
-});
+@NgModule({
+  imports: [
+    NgxsStoragePluginModule.forRoot({
+      key: 'novels'
+    })
+  ]
+})
+export class AppModule {}
+```
+
+It's also possible to provide a state class except of its name:
+
+```ts
+@NgModule({
+  imports: [
+    NgxsStoragePluginModule.forRoot({
+      key: NovelsState
+    })
+  ]
+})
+export class AppModule {}
 ```
 
 And if we wanted to persist `NovelsState` and `DetectivesState`:
 
 ```ts
-NgxsStoragePluginModule.forRoot({
-  key: ['novels', 'detectives']
-});
+@NgModule({
+  imports: [
+    NgxsStoragePluginModule.forRoot({
+      key: ['novels', 'detectives']
+    })
+  ]
+})
+export class AppModule {}
+```
+
+Or using state classes:
+
+```ts
+@NgModule({
+  imports: [
+    NgxsStoragePluginModule.forRoot({
+      key: [NovelsState, DetectivesState]
+    })
+  ]
+})
+export class AppModule {}
+```
+
+You can combine state classes and strings:
+
+```ts
+@NgModule({
+  imports: [
+    NgxsStoragePluginModule.forRoot({
+      key: ['novels', DetectivesState]
+    })
+  ]
+})
+export class AppModule {}
 ```
 
 This is very handy to avoid persisting runtime-only states that shouldn't be saved to any storage.

--- a/integration/app/app.server.module.ts
+++ b/integration/app/app.server.module.ts
@@ -6,7 +6,7 @@ import { ModuleMapLoaderModule } from '@nguniversal/module-map-ngfactory-loader'
 
 import { AppComponent } from '@integration/app.component';
 import { AppModule } from '@integration/app.module';
-import { TODOS_STORAGE_KEY } from '@integration/store/todos/todos.model';
+import { TodosState } from '@integration/store/todos/todos.state';
 
 @NgModule({
   imports: [
@@ -15,7 +15,7 @@ import { TODOS_STORAGE_KEY } from '@integration/store/todos/todos.model';
     NoopAnimationsModule,
     ServerTransferStateModule,
     ModuleMapLoaderModule,
-    NgxsStoragePluginModule.forRoot({ key: [TODOS_STORAGE_KEY] })
+    NgxsStoragePluginModule.forRoot({ key: [TodosState] })
   ],
   bootstrap: [AppComponent]
 })

--- a/packages/storage-plugin/src/internals.ts
+++ b/packages/storage-plugin/src/internals.ts
@@ -1,0 +1,64 @@
+import { isPlatformServer } from '@angular/common';
+import { StateClass } from '@ngxs/store/internals';
+
+import { StorageOption, StorageEngine, NgxsStoragePluginOptions } from './symbols';
+
+/**
+ * If the `key` option is not provided then the below constant
+ * will be used as a default key
+ */
+export const DEFAULT_STATE_KEY = '@@STATE';
+
+/**
+ * This key is used to retrieve static metadatas on state classes.
+ * This constant is taken from the core codebase
+ */
+const META_OPTIONS_KEY = 'NGXS_OPTIONS_META';
+
+function transformKeyOption(key: string | StateClass | (string | StateClass)[]): string[] {
+  if (!Array.isArray(key)) {
+    key = [key];
+  }
+
+  return key.map(keyOrStateClass => {
+    if (typeof keyOrStateClass === 'string') {
+      return keyOrStateClass;
+    }
+
+    const options = (keyOrStateClass as any)[META_OPTIONS_KEY];
+    return options.name;
+  });
+}
+
+export function storageOptionsFactory(
+  options: NgxsStoragePluginOptions | undefined
+): NgxsStoragePluginOptions {
+  if (options !== undefined && options.key) {
+    options.key = transformKeyOption(options.key);
+  }
+
+  return {
+    key: [DEFAULT_STATE_KEY],
+    storage: StorageOption.LocalStorage,
+    serialize: JSON.stringify,
+    deserialize: JSON.parse,
+    ...options
+  };
+}
+
+export function engineFactory(
+  options: NgxsStoragePluginOptions,
+  platformId: string
+): StorageEngine | null {
+  if (isPlatformServer(platformId)) {
+    return null;
+  }
+
+  if (options.storage === StorageOption.LocalStorage) {
+    return localStorage;
+  } else if (options.storage === StorageOption.SessionStorage) {
+    return sessionStorage;
+  }
+
+  return null;
+}

--- a/packages/storage-plugin/src/internals.ts
+++ b/packages/storage-plugin/src/internals.ts
@@ -10,12 +10,18 @@ import { StorageOption, StorageEngine, NgxsStoragePluginOptions } from './symbol
 export const DEFAULT_STATE_KEY = '@@STATE';
 
 /**
+ * Internal type definition for the `key` option provided
+ * in the `forRoot` method when importing module
+ */
+export type StorageKey = string | StateClass | (string | StateClass)[];
+
+/**
  * This key is used to retrieve static metadatas on state classes.
  * This constant is taken from the core codebase
  */
 const META_OPTIONS_KEY = 'NGXS_OPTIONS_META';
 
-function transformKeyOption(key: string | StateClass | (string | StateClass)[]): string[] {
+function transformKeyOption(key: StorageKey): string[] {
   if (!Array.isArray(key)) {
     key = [key];
   }

--- a/packages/storage-plugin/src/storage.module.ts
+++ b/packages/storage-plugin/src/storage.module.ts
@@ -1,43 +1,13 @@
 import { NgModule, ModuleWithProviders, PLATFORM_ID, InjectionToken } from '@angular/core';
-import { isPlatformServer } from '@angular/common';
 import { NGXS_PLUGINS } from '@ngxs/store';
 
-import { NgxsStoragePlugin } from './storage.plugin';
 import {
   NgxsStoragePluginOptions,
-  NGXS_STORAGE_PLUGIN_OPTIONS,
-  StorageOption,
   STORAGE_ENGINE,
-  StorageEngine
+  NGXS_STORAGE_PLUGIN_OPTIONS
 } from './symbols';
-
-export function storageOptionsFactory(options: NgxsStoragePluginOptions) {
-  return {
-    key: '@@STATE',
-    storage: StorageOption.LocalStorage,
-    serialize: JSON.stringify,
-    deserialize: JSON.parse,
-    ...options
-  };
-}
-
-export function engineFactory(
-  options: NgxsStoragePluginOptions,
-  platformId: any
-): StorageEngine | null {
-  if (isPlatformServer(platformId)) {
-    return null;
-  }
-
-  if (options.storage === StorageOption.LocalStorage) {
-    // todo: remove any here
-    return <any>localStorage;
-  } else if (options.storage === StorageOption.SessionStorage) {
-    return <any>sessionStorage;
-  }
-
-  return null;
-}
+import { NgxsStoragePlugin } from './storage.plugin';
+import { storageOptionsFactory, engineFactory } from './internals';
 
 export const USER_OPTIONS = new InjectionToken('USER_OPTIONS');
 

--- a/packages/storage-plugin/src/symbols.ts
+++ b/packages/storage-plugin/src/symbols.ts
@@ -1,4 +1,5 @@
 import { InjectionToken } from '@angular/core';
+import { StateClass } from '@ngxs/store/internals';
 
 export const enum StorageOption {
   LocalStorage,
@@ -9,7 +10,7 @@ export interface NgxsStoragePluginOptions {
   /**
    * Key for the state slice to store in the storage engine.
    */
-  key?: string | string[] | undefined;
+  key?: undefined | string | StateClass | (string | StateClass)[];
 
   /**
    * Storage engine to use. Deaults to localStorage but can provide

--- a/packages/storage-plugin/src/symbols.ts
+++ b/packages/storage-plugin/src/symbols.ts
@@ -1,5 +1,6 @@
 import { InjectionToken } from '@angular/core';
-import { StateClass } from '@ngxs/store/internals';
+
+import { StorageKey } from './internals';
 
 export const enum StorageOption {
   LocalStorage,
@@ -10,7 +11,7 @@ export interface NgxsStoragePluginOptions {
   /**
    * Key for the state slice to store in the storage engine.
    */
-  key?: undefined | string | StateClass | (string | StateClass)[];
+  key?: undefined | StorageKey;
 
   /**
    * Storage engine to use. Deaults to localStorage but can provide


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

**Foreword** :exclamation:

The `key` option was very unclear for our users. Most people got confused of what the heck is this option and how to use. That's why we had some issues and I made PRs to improve documentation.

---

This PR scatters cloud and gives our users the ability to provide state classes except of strings. For sure it's still possible to provide strings as this might be a breaking change.

---

This feature is a good alternative as it's preferred to have state keys only in one place.

---

What about size of PR? Seems like there is a lot of code added, but no. I moved token factories to the separate `internals.ts` file, because `storage.module.ts` file became bigger and bigger. I've only added the `transformKeyOption` function that retrieves state metadatas from state classes.