### PR TITLE
fix(store): group `Actions` subscriptions to remove memory leak

### DIFF
--- a/packages/store/src/actions-stream.ts
+++ b/packages/store/src/actions-stream.ts
@@ -67,6 +67,8 @@ export class InternalActions extends OrderedSubject<ActionContext> {}
  */
 @Injectable()
 export class Actions extends Subject<any> {
+  // This has to be `Subject<ActionContext>` in the v4. Because `InternalActions`
+  // is a `Subject<ActionContext>`. Leave it as `any` to avoid breaking changes
   constructor(
     internalActions$: InternalActions,
     internalExecutionStrategy: InternalNgxsExecutionStrategy

--- a/packages/store/src/actions-stream.ts
+++ b/packages/store/src/actions-stream.ts
@@ -89,7 +89,9 @@ export class Actions {
     // same as an execution strategy. That's why all initializations are run
     // inside the constructor
     this._internalActions$ = internalActions$.pipe(leaveNgxs(internalExecutionStrategy));
-
+    // These property are `bind`ed only once and then exposed publicly via getters
+    // thus there is no performance leak. Also those type definitions are inferred
+    // automatically
     this._pipe = this._internalActions$.pipe.bind(this._internalActions$);
     this._forEach = this._internalActions$.forEach.bind(this._internalActions$);
     this._subscribe = this._internalActions$.subscribe.bind(this._internalActions$);

--- a/packages/store/tests/actions-stream.spec.ts
+++ b/packages/store/tests/actions-stream.spec.ts
@@ -87,26 +87,21 @@ describe('The Actions stream', () => {
     ]);
   });
 
-  it('has to splice "observers" array after "unsubscribe" is invoked', () => {
-    // Arrange
-    function onNext() {}
-
-    // Act
+  it('has to add subscriber to the internal "_subscriptions" property', () => {
+    // Arrange & act
     TestBed.configureTestingModule({
       imports: [NgxsModule.forRoot()]
     });
 
     const actions$: Actions = TestBed.get(Actions);
-    const spy = jest.spyOn(actions$, 'subscribe');
-    const subscription = actions$.subscribe(onNext);
+    const subscription = actions$.subscribe(() => {});
 
-    const countOfObserversBefore = actions$.observers.length;
+    const isArrayBeforeUnsubscribe = Array.isArray(subscription['_subscriptions']);
     subscription.unsubscribe();
-    const countOfObserversAfter = actions$.observers.length;
+    const isNullyAfterUnsubscribe = subscription['_subscriptions'] === null;
 
     // Assert
-    expect(spy).toHaveBeenCalledWith(onNext);
-    expect(countOfObserversBefore).toBe(1);
-    expect(countOfObserversAfter).toBe(0);
+    expect(isArrayBeforeUnsubscribe).toBeTruthy();
+    expect(isNullyAfterUnsubscribe).toBeTruthy();
   });
 });

--- a/packages/store/tests/actions-stream.spec.ts
+++ b/packages/store/tests/actions-stream.spec.ts
@@ -1,12 +1,16 @@
-import { TestBed, async } from '@angular/core/testing';
-import { InternalActions, OrderedSubject, ActionStatus } from '../src/actions-stream';
+import { TestBed } from '@angular/core/testing';
 import { Subject } from 'rxjs';
 
+import { NgxsModule } from '../src/module';
+import { InternalActions, OrderedSubject, ActionStatus, Actions } from '../src/actions-stream';
+
 describe('The Actions stream', () => {
-  it('should not use Subject because of the following issue (note that 3rd subscriber receives the events out of order)', async(() => {
+  it('should not use Subject because of the following issue (note that 3rd subscriber receives the events out of order)', () => {
+    // Arrange
     const statuses$ = new Subject<string>();
     const callsRecorded = <string[]>[];
 
+    // Act
     statuses$.subscribe(status => callsRecorded.push('1st Subscriber:' + status));
     statuses$.subscribe(status => {
       callsRecorded.push('2nd Subscriber:' + status);
@@ -16,6 +20,7 @@ describe('The Actions stream', () => {
 
     statuses$.next('dispatch');
 
+    // Assert
     expect(callsRecorded).toEqual([
       '1st Subscriber:dispatch',
       '2nd Subscriber:dispatch',
@@ -24,12 +29,14 @@ describe('The Actions stream', () => {
       '3rd Subscriber:complete',
       '3rd Subscriber:dispatch'
     ]);
-  }));
+  });
 
-  it('should rather use OrderedSubject because it preserves the order of dispatch for subscribers', async(() => {
+  it('should rather use OrderedSubject because it preserves the order of dispatch for subscribers', () => {
+    // Arrange
     const statuses$ = new OrderedSubject<string>();
     const callsRecorded = <string[]>[];
 
+    // Act
     statuses$.subscribe(status => callsRecorded.push('1st Subscriber:' + status));
     statuses$.subscribe(status => {
       callsRecorded.push('2nd Subscriber:' + status);
@@ -39,6 +46,7 @@ describe('The Actions stream', () => {
 
     statuses$.next('dispatch');
 
+    // Assert
     expect(callsRecorded).toEqual([
       '1st Subscriber:dispatch',
       '2nd Subscriber:dispatch',
@@ -47,9 +55,10 @@ describe('The Actions stream', () => {
       '2nd Subscriber:complete',
       '3rd Subscriber:complete'
     ]);
-  }));
+  });
 
-  it('should preserve the order of dispatch for subscribers', async(() => {
+  it('should preserve the order of dispatch for subscribers', () => {
+    // Arrange & act
     TestBed.configureTestingModule({
       providers: [InternalActions]
     });
@@ -67,6 +76,7 @@ describe('The Actions stream', () => {
 
     internalActions.next({ status: ActionStatus.Dispatched, action: null });
 
+    // Assert
     expect(callsRecorded).toEqual([
       '1st Subscriber:DISPATCHED',
       '2nd Subscriber:DISPATCHED',
@@ -75,5 +85,28 @@ describe('The Actions stream', () => {
       '2nd Subscriber:SUCCESSFUL',
       '3rd Subscriber:SUCCESSFUL'
     ]);
-  }));
+  });
+
+  it('has to splice "observers" array after "unsubscribe" is invoked', () => {
+    // Arrange
+    function onNext() {}
+
+    // Act
+    TestBed.configureTestingModule({
+      imports: [NgxsModule.forRoot()]
+    });
+
+    const actions$: Actions = TestBed.get(Actions);
+    const spy = jest.spyOn(actions$, 'subscribe');
+    const subscription = actions$.subscribe(onNext);
+
+    const countOfObserversBefore = actions$.observers.length;
+    subscription.unsubscribe();
+    const countOfObserversAfter = actions$.observers.length;
+
+    // Assert
+    expect(spy).toHaveBeenCalledWith(onNext);
+    expect(countOfObserversBefore).toBe(1);
+    expect(countOfObserversAfter).toBe(0);
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     "lib": ["es2017", "dom"],
     "typeRoots": ["node_modules/@types"]
   },
-  "exclude": ["@ngxs/**", "integrations/**"]
+  "exclude": ["@ngxs/**", "integrations/**", "cypress"]
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1149 

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

:exclamation: **This PR is very important and requires views from the outside!** :exclamation: 

---

Let's start with a simple application. That's how I started debugging that `Actions` memory leak. See screenshots below:

![1](https://user-images.githubusercontent.com/7337691/66673945-6794bc00-ec6a-11e9-9c2a-0a0da737b760.png)

So we've got a basic application that has `app-leak` component with bound `ngIf` directive. This component looks as follows:

```ts
@Component({
  selector: 'app-leak',
  template: `
    <p>leak works!</p>
    <button (click)="dispatchFromLeak()">Dispatch from leak</button>
  `
})
export class LeakComponent implements OnDestroy {
  subscription: Subscription;

  constructor(private store: Store, private actions$: Actions) {
    this.subscription = actions$.subscribe({
      next: () => this.log()
    });
  }

  ngOnDestroy(): void {
    this.subscription.unsubscribe();
  }

  dispatchFromLeak() {
    this.store.dispatch(new Increment());
  }

  private log() {
    console.log('Action was emitted');
  }
}
```

Easy right? Let's keep on and do some heap snapshots to see if the `LeakComponent` gets garbage collected. On the below screenshot it's not destroyed:

![2](https://user-images.githubusercontent.com/7337691/66674044-9f9bff00-ec6a-11e9-811b-cfc108b6d80d.png)

That's how it has to be, right? Moving on. Let's look at the `AppComponent` code:

```ts
@Component({
  selector: 'app-root',
  template: `
    <app-leak *ngIf="shown"></app-leak>
    <button (click)="shown = !shown">Toggle leak component</button>
  `
})
export class AppComponent {
  shown = true;
}
```

Nothing complicated. I clicked the `Toggle leak component` button and destroyed the `app-leak` component. Then I clicked `Collect garbage` button in the Chrome memory section and collected snapshot again. That's what I got:

![3](https://user-images.githubusercontent.com/7337691/66674239-1a651a00-ec6b-11e9-9122-d33f727e04d8.png)

:scream: :scream: :scream: 

This is supernatural, right? I did it several times, collected garbage several times. And.... No, that didn't help. The `LeakComponent` definitely wasn't garbage collected!

---

Let's keep debugging. Do you know what I've noticed? The pitfall was inside this code:

```ts
this.subscription = actions$.subscribe({
  next: () => this.log()
});
```

Because I changed `next: () => this.log()` to `next: this.log`:

```ts
this.subscription = actions$.subscribe({
  next: this.log
});
```

And... It helped! Lol, the `LeakComponent` was garbage collected.

---

**BUT THIS IS NOT A WORKAROUND AND WE CANNOT ASK OUR USERS TO DO THIS!**

---

So what's wrong there?

**`this.log` doesn't capture `this` (unless `log` does it inside). `() => this.log()` does capture `this`.**

### As long as there is a reference to `() => this.log()`, `this` will not be GC'd

Who keeps the reference to `this`? And this is our `Actions` class. This is a singleton service but it's also a hot observable that keep references to tonn of system components around the whole application. Imagine that 100 components subscribe to the `Actions` stream. In terms of V8 it's called a circular reference memory leak. The quote below:

> Circular references are one of the main causes of memory leaks.

![5](https://user-images.githubusercontent.com/7337691/66675195-7d57b080-ec6d-11e9-85ca-23254db56c18.png)

---

:exclamation: **Why is this PR important?**

Because ALL applications that use NGXS right now have a lot of memory leaks.

:warning: **What have I done in this PR?** :warning: 

I grouped subscriptions together through the `add()` method. When a `Subscription` is unsubscribed, all its children (and its grandchildren) will be unsubscribed as well.

This resolves the issue:

![fixed](https://user-images.githubusercontent.com/7337691/66675374-e2aba180-ec6d-11e9-91ee-e33e826e1869.png)