### PR TITLE
refactor(store): decompose selectorOptionsMetaAccessor

### DIFF
--- a/packages/store/src/decorators/selector-options.ts
+++ b/packages/store/src/decorators/selector-options.ts
@@ -1,5 +1,4 @@
-import { SharedSelectorOptions } from '../internal/internals';
-import { selectorOptionsMetaAccessor } from '../utils/selector-utils';
+import { ensureSelectorOptions, SharedSelectorOptions } from '../internal/internals';
 
 /**
  * Decorator for setting selector options at a method or class level.
@@ -15,11 +14,11 @@ export function SelectorOptions(options: SharedSelectorOptions) {
         // Method Decorator
         const originalFn = descriptor.value || (<any>descriptor).originalFn;
         if (originalFn) {
-          selectorOptionsMetaAccessor.defineOptions(originalFn, options);
+          ensureSelectorOptions(originalFn, options);
         }
       } else {
         // Class Decorator
-        selectorOptionsMetaAccessor.defineOptions(target, options);
+        ensureSelectorOptions(target, options);
       }
     }
   );

--- a/packages/store/src/decorators/selector-options.ts
+++ b/packages/store/src/decorators/selector-options.ts
@@ -1,4 +1,4 @@
-import { ensureSelectorOptions, SharedSelectorOptions } from '../internal/internals';
+import { defineSelectorOptions, SharedSelectorOptions } from '../internal/internals';
 
 /**
  * Decorator for setting selector options at a method or class level.
@@ -14,11 +14,11 @@ export function SelectorOptions(options: SharedSelectorOptions) {
         // Method Decorator
         const originalFn = descriptor.value || (<any>descriptor).originalFn;
         if (originalFn) {
-          ensureSelectorOptions(originalFn, options);
+          defineSelectorOptions(originalFn, options);
         }
       } else {
         // Class Decorator
-        ensureSelectorOptions(target, options);
+        defineSelectorOptions(target, options);
       }
     }
   );

--- a/packages/store/src/internal/internals.ts
+++ b/packages/store/src/internal/internals.ts
@@ -1,3 +1,4 @@
+import { PlainObjectOf, StateClass } from '@ngxs/store/internals';
 import { Observable } from 'rxjs';
 
 import {
@@ -5,11 +6,10 @@ import {
   META_OPTIONS_KEY,
   NgxsConfig,
   SELECTOR_META_KEY,
+  SELECTOR_OPTIONS_META_KEY,
   StoreOptions
 } from '../symbols';
 import { ActionHandlerMetaData } from '../actions/symbols';
-
-import { PlainObjectOf, StateClass } from '@ngxs/store/internals';
 
 function asReadonly<T>(value: T): Readonly<T> {
   return value;
@@ -19,6 +19,7 @@ function asReadonly<T>(value: T): Readonly<T> {
 export interface StateClassInternal<T = any, U = any> extends StateClass<T> {
   [META_KEY]?: MetaDataModel;
   [META_OPTIONS_KEY]?: StoreOptions<U>;
+  [SELECTOR_OPTIONS_META_KEY]?: SharedSelectorOptions;
 }
 
 export type StateKeyGraph = PlainObjectOf<string[]>;
@@ -365,4 +366,30 @@ export function topologicalSort(graph: StateKeyGraph): string[] {
  */
 export function isObject(obj: any) {
   return (typeof obj === 'object' && obj !== null) || typeof obj === 'function';
+}
+
+export function ensureSelectorOptions(
+  target: StateClassInternal | Function | null,
+  options: SharedSelectorOptions = {}
+): SharedSelectorOptions {
+  if (target && !target.hasOwnProperty(SELECTOR_OPTIONS_META_KEY)) {
+    Object.defineProperty(target, SELECTOR_OPTIONS_META_KEY, { value: options });
+  }
+
+  return getSelectorOptions(target);
+}
+
+export function defineSelectorOptions(
+  target: StateClassInternal | Function | null,
+  options: SharedSelectorOptions = {}
+): void {
+  if (target) {
+    Object.defineProperty(target, SELECTOR_OPTIONS_META_KEY, { value: options });
+  }
+}
+
+export function getSelectorOptions(
+  target: StateClassInternal | Function | null
+): SharedSelectorOptions {
+  return (target && (target as any)[SELECTOR_OPTIONS_META_KEY]) || {};
 }

--- a/packages/store/src/internal/internals.ts
+++ b/packages/store/src/internal/internals.ts
@@ -368,17 +368,6 @@ export function isObject(obj: any) {
   return (typeof obj === 'object' && obj !== null) || typeof obj === 'function';
 }
 
-export function ensureSelectorOptions(
-  target: StateClassInternal | Function | null,
-  options: SharedSelectorOptions = {}
-): SharedSelectorOptions {
-  if (target && !target.hasOwnProperty(SELECTOR_OPTIONS_META_KEY)) {
-    Object.defineProperty(target, SELECTOR_OPTIONS_META_KEY, { value: options });
-  }
-
-  return getSelectorOptions(target);
-}
-
 export function defineSelectorOptions(
   target: StateClassInternal | Function | null,
   options: SharedSelectorOptions = {}

--- a/packages/store/src/public_api.ts
+++ b/packages/store/src/public_api.ts
@@ -9,7 +9,10 @@ export {
   getSelectorMetadata,
   getStoreMetadata,
   ensureStoreMetadata,
-  ensureSelectorMetadata
+  ensureSelectorMetadata,
+  ensureSelectorOptions,
+  getSelectorOptions,
+  defineSelectorOptions
 } from './internal/internals';
 export {
   ofAction,

--- a/packages/store/src/public_api.ts
+++ b/packages/store/src/public_api.ts
@@ -9,10 +9,7 @@ export {
   getSelectorMetadata,
   getStoreMetadata,
   ensureStoreMetadata,
-  ensureSelectorMetadata,
-  ensureSelectorOptions,
-  getSelectorOptions,
-  defineSelectorOptions
+  ensureSelectorMetadata
 } from './internal/internals';
 export {
   ofAction,

--- a/packages/store/src/symbols.ts
+++ b/packages/store/src/symbols.ts
@@ -15,6 +15,7 @@ export const NG_DEV_MODE = new InjectionToken('NG_DEV_MODE');
 export const META_KEY = 'NGXS_META';
 export const META_OPTIONS_KEY = 'NGXS_OPTIONS_META';
 export const SELECTOR_META_KEY = 'NGXS_SELECTOR_META';
+export const SELECTOR_OPTIONS_META_KEY = 'NGXS_SELECTOR_OPTIONS_META';
 
 export type NgxsLifeCycle = Partial<NgxsOnInit> & Partial<NgxsAfterBootstrap>;
 export type NgxsPluginFn = (state: any, mutation: any, next: NgxsNextPluginFn) => any;

--- a/packages/store/tests/selector.spec.ts
+++ b/packages/store/tests/selector.spec.ts
@@ -14,14 +14,13 @@ import { NgxsConfig } from '../src/symbols';
 import { SelectorOptions } from '../src/decorators/selector-options';
 import { CONFIG_MESSAGES, VALIDATION_CODE } from '../src/configs/messages.config';
 import {
-  ensureSelectorOptions,
-  ensureSelectorMetadata,
   getSelectorMetadata,
   getSelectorOptions,
   globalSelectorOptions,
   SelectorMetaDataModel,
   StateClassInternal,
-  defineSelectorOptions
+  defineSelectorOptions,
+  ensureSelectorMetadata
 } from '../src/internal/internals';
 
 describe('Selector', () => {
@@ -880,12 +879,12 @@ describe('Selector', () => {
         public static meCustom(): void {}
       }
 
-      ensureSelectorOptions(MyTestState, {
+      defineSelectorOptions(MyTestState, {
         suppressErrors: false,
         injectContainerState: true
       });
 
-      ensureSelectorOptions(MyTestState.meCustom, {
+      defineSelectorOptions(MyTestState.meCustom, {
         suppressErrors: true,
         injectContainerState: false
       });
@@ -902,7 +901,7 @@ describe('Selector', () => {
 
       const invalidValue: StateClassInternal = null!;
 
-      ensureSelectorOptions(invalidValue, {
+      defineSelectorOptions(invalidValue, {
         suppressErrors: false,
         injectContainerState: true
       });
@@ -951,7 +950,7 @@ describe('Selector', () => {
 
       expect(getSelectorOptions(metadataState.containerClass)).toEqual({});
 
-      ensureSelectorOptions(MyTestState, {
+      defineSelectorOptions(MyTestState, {
         suppressErrors: false,
         injectContainerState: false
       });
@@ -996,7 +995,7 @@ describe('Selector', () => {
         suppressErrors: true
       });
 
-      ensureSelectorOptions(MySelectorState, {
+      defineSelectorOptions(MySelectorState, {
         suppressErrors: false,
         injectContainerState: true
       });
@@ -1006,7 +1005,7 @@ describe('Selector', () => {
         injectContainerState: true
       });
 
-      ensureSelectorOptions(MySelectorState.mySelector, {
+      defineSelectorOptions(MySelectorState.mySelector, {
         suppressErrors: true,
         injectContainerState: true
       });
@@ -1054,6 +1053,8 @@ describe('Selector', () => {
     });
 
     it('should be correct when invalid container class', () => {
+      globalSelectorOptions.set({});
+
       expect(mergeSelectorOptions(null!)).toEqual({});
 
       const metadata: SelectorMetaDataModel = setupSelectorMetadata(


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

In our project, we needed to dynamically define the selector options

## What is the new behavior?

Now we can dynamically set the settings in runtime

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
