### PR TITLE
feat(store): improved compile/runtime check type in Action

### DIFF
--- a/packages/store/src/actions/actions.ts
+++ b/packages/store/src/actions/actions.ts
@@ -1,8 +1,12 @@
 import { PlainObject } from '@ngxs/store/internals';
+import { NgxsAction } from './symbols';
+import { RequiredType } from './utils';
 
 /**
+ * @public
  * Init action
  */
+@RequiredType<NgxsAction>()
 export class InitState {
   static get type() {
     // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138
@@ -11,8 +15,10 @@ export class InitState {
 }
 
 /**
+ * @public
  * Update action
  */
+@RequiredType<NgxsAction>()
 export class UpdateState {
   static get type() {
     // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138

--- a/packages/store/src/actions/symbols.ts
+++ b/packages/store/src/actions/symbols.ts
@@ -1,12 +1,34 @@
-export interface ActionDef<T = any, U = any> {
-  type: string;
-
-  new (...args: T[]): U;
-}
-
-export type ActionType = ActionDef | { type: string };
+import { RequiredType, runtimeCheckMissingType } from './utils';
 
 /**
+ * @public
+ */
+export interface NgxsAction<T = any, U = any> {
+  type: string;
+  new?(...args: T[]): U;
+}
+
+/**
+ * @public
+ */
+@RequiredType<NgxsAction>()
+export abstract class AbstractAction<T = any> {
+  public static type: string = null!;
+  public type: string;
+
+  constructor(...args: any[]);
+  constructor(public payload?: T) {
+    runtimeCheckMissingType(this);
+  }
+}
+
+/**
+ * @public
+ */
+export type ActionType<T = any, U = T> = NgxsAction<T, U> | AbstractAction<T>;
+
+/**
+ * @public
  * Actions that can be provided in a action decorator.
  */
 export interface ActionOptions {
@@ -16,6 +38,9 @@ export interface ActionOptions {
   cancelUncompleted?: boolean;
 }
 
+/**
+ * @private
+ */
 export interface ActionHandlerMetaData {
   fn: string | symbol;
   options: ActionOptions;

--- a/packages/store/src/actions/utils.ts
+++ b/packages/store/src/actions/utils.ts
@@ -1,21 +1,27 @@
 /**
+ * @public
  * As a continuation #2947 issue, which allows the abstract modifier on method declarations
  * but disallows it on static methods declarations, I suggest to expand this functionality
  * to static methods declarations by allowing abstract static modifier on method declarations.
  * The related problem concerns static modifier on interface methods declaration, which is disallowed.
  * https://github.com/microsoft/TypeScript/issues/14600
- * @constructor
  * This decorator does not carry any load on runtime. Only type check on existence static type.
  */
 export function RequiredType<T extends {}>(): (constructor: T) => void {
   return (_constructor: T): void => {};
 }
 
+/**
+ * @private
+ */
 export function ensureActionType(target: any): string | null {
   const constructor: any = Object.getPrototypeOf(target || {}).constructor || {};
   return constructor.type || null;
 }
 
+/**
+ * @private
+ */
 export function runtimeCheckMissingType(target: any): void {
   const type: string | null = ensureActionType(target);
   if (!type) {

--- a/packages/store/src/actions/utils.ts
+++ b/packages/store/src/actions/utils.ts
@@ -1,0 +1,24 @@
+/**
+ * As a continuation #2947 issue, which allows the abstract modifier on method declarations
+ * but disallows it on static methods declarations, I suggest to expand this functionality
+ * to static methods declarations by allowing abstract static modifier on method declarations.
+ * The related problem concerns static modifier on interface methods declaration, which is disallowed.
+ * https://github.com/microsoft/TypeScript/issues/14600
+ * @constructor
+ * This decorator does not carry any load on runtime. Only type check on existence static type.
+ */
+export function RequiredType<T extends {}>(): (constructor: T) => void {
+  return (_constructor: T): void => {};
+}
+
+export function ensureActionType(target: any): string | null {
+  const constructor: any = Object.getPrototypeOf(target || {}).constructor || {};
+  return constructor.type || null;
+}
+
+export function runtimeCheckMissingType(target: any): void {
+  const type: string | null = ensureActionType(target);
+  if (!type) {
+    throw new Error('Action type is required');
+  }
+}

--- a/packages/store/src/public_api.ts
+++ b/packages/store/src/public_api.ts
@@ -31,5 +31,6 @@ export { Selector } from './decorators/selector';
 export { getActionTypeFromInstance, actionMatcher } from './utils/utils';
 export { createSelector } from './utils/selector-utils';
 export { NgxsExecutionStrategy } from './execution/symbols';
-export { ActionType, ActionOptions } from './actions/symbols';
+export { RequiredType } from './actions/utils';
+export { ActionType, NgxsAction, ActionOptions, AbstractAction } from './actions/symbols';
 export { NoopNgxsExecutionStrategy } from './execution/noop-ngxs-execution-strategy';

--- a/packages/store/tests/action.spec.ts
+++ b/packages/store/tests/action.spec.ts
@@ -1,5 +1,6 @@
-import { ErrorHandler } from '@angular/core';
+import { AbstractAction, NgxsAction, RequiredType } from '@ngxs/store';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ErrorHandler } from '@angular/core';
 import { delay } from 'rxjs/operators';
 import { throwError, of } from 'rxjs';
 
@@ -261,5 +262,32 @@ describe('Action', () => {
     store.dispatch({ type: 'OBJECT_LITERAL' });
 
     expect(callbacksCalled).toEqual(['onObjectLiteral']);
+  });
+
+  it('should be correct runtime/compile time check', () => {
+    try {
+      class MyBadAction extends AbstractAction {}
+      new MyBadAction();
+    } catch (e) {
+      expect(e.message).toEqual('Action type is required');
+    }
+
+    class ConcreteAction extends AbstractAction {
+      public static type = 'CONCRETE_ACTION';
+    }
+
+    const concrete = new ConcreteAction('world');
+    expect(ConcreteAction.type).toEqual('CONCRETE_ACTION');
+    expect(concrete.payload).toEqual('world');
+
+    @RequiredType<NgxsAction>()
+    class MyAction {
+      public static type = 'MY_ACTION';
+      constructor(public payload: string) {}
+    }
+
+    const required: MyAction = new MyAction('ANY');
+    expect(MyAction.type).toEqual('MY_ACTION');
+    expect(required.payload).toEqual('ANY');
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Right now we have no check that the user has passed the correct action

```ts
class MyState {
 @Action({ HELLO_WORLD: '1' }) add() { // SUCCESS COMPILE
 }
}
```

```ts
class MyBestAction {}

class MyState {
 @Action(MyBestAction) add() { // SUCCESS COMPILE
 }
}
```

## What is the new behavior?


```ts
class MyState {
 @Action({ HELLO_WORLD: '1' }) add() { // COMPILE ERROR (missing type)
 }
}
```

```ts
class MyBestAction {}

class MyState {
 @Action(MyBestAction) add() { // COMPILE ERROR (missing type)
 }
}
```

```ts
class MyBestAction {
 public type = 'HELLO WORLD';
}

class MyState {
 @Action(MyBestAction) add() { // COMPILE ERROR (missing static type)
 }
}
```

```ts
class MyBestAction {
 public static type = 'HELLO WORLD';
}

class MyState {
 @Action(MyBestAction) add() { // SUCCESS COMPILE
 }
}
```

--------------

Motivation to use inheritance AbstractAction

```ts
class MyBestAction extends AbstractAction {}

class MyState {
 @Action(MyBestAction) add() { // RUNTIME ERROR (type is required)
 }
}
```

or use compile guard RequiredType

```ts
@RequiredType<NgxsAction>()
class MyBestAction extends AbstractAction {} // COMPILE ERROR (missing static type)

class MyState {
 @Action(MyBestAction) add() {
 }
}
```

```ts
@RequiredType<NgxsAction>()
class MyBestAction extends AbstractAction {
  public static type = 'HELLO_WORLD_ACTION';
} 

class MyState {
 @Action(MyBestAction) add() { // SUCCESS COMPILE AND WORKS IN RUNTIME
 }
}
```

Also

```ts
@RequiredType<NgxsAction>()
class MyBestAction {
  public static type = 'HELLO_WORLD_ACTION';
} 

class MyState {
 @Action(MyBestAction) add() { // SUCCESS COMPILE AND WORKS IN RUNTIME
 }
}
```

## Does this PR introduce a breaking change?

```
[x] Yes - must pass the required field action type in `Action` decorator
[ ] No
```

