### PR TITLE
fix(store): ensure state instance in metadata

### DIFF
--- a/packages/store/src/internal/state-factory.ts
+++ b/packages/store/src/internal/state-factory.ts
@@ -104,10 +104,13 @@ export class StateFactory {
     for (const name of sortedStates) {
       const stateClass: StateClassInternal = nameGraph[name];
       const depth: string = depths[name];
+
+      // external state metadata (ExampleState['NGXS_META'])
       const meta: MetaDataModel = stateClass[META_KEY]!;
 
       this.addRuntimeInfoToMeta(meta, depth);
 
+      // internal state metadata (only use in state factory)
       const stateMap: MappedStore = {
         name,
         depth,
@@ -115,6 +118,9 @@ export class StateFactory {
         instance: this._injector.get(stateClass),
         defaults: StateFactory.cloneDefaults(meta.defaults)
       };
+
+      // ensure unique instance in class meta data
+      meta.instance = stateMap.instance;
 
       // ensure our store hasn't already been added
       // but don't throw since it could be lazy

--- a/packages/store/src/internal/state-factory.ts
+++ b/packages/store/src/internal/state-factory.ts
@@ -104,13 +104,10 @@ export class StateFactory {
     for (const name of sortedStates) {
       const stateClass: StateClassInternal = nameGraph[name];
       const depth: string = depths[name];
-
-      // external state metadata (ExampleState['NGXS_META'])
       const meta: MetaDataModel = stateClass[META_KEY]!;
 
       this.addRuntimeInfoToMeta(meta, depth);
 
-      // internal state metadata (only use in state factory)
       const stateMap: MappedStore = {
         name,
         depth,
@@ -119,7 +116,6 @@ export class StateFactory {
         defaults: StateFactory.cloneDefaults(meta.defaults)
       };
 
-      // ensure unique instance in class meta data
       meta.instance = stateMap.instance;
 
       // ensure our store hasn't already been added

--- a/packages/store/tests/ensure-store.spec.ts
+++ b/packages/store/tests/ensure-store.spec.ts
@@ -1,14 +1,14 @@
 import {
-  State,
   Action,
-  getStoreMetadata,
   getSelectorMetadata,
-  Selector,
+  getStoreMetadata,
   NgxsModule,
+  Selector,
   SelectorOptions,
+  State,
   Store
 } from '@ngxs/store';
-import { async, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 
 import { SelectorMetaDataModel } from '../src/internal/internals';
 import { getSelectorFn } from '../src/utils/selector-utils';
@@ -56,13 +56,13 @@ describe('Ensure metadata', () => {
       public addTwo(): void {}
     }
 
-    beforeAll(async(() => {
+    beforeAll(() => {
       TestBed.configureTestingModule({
         imports: [NgxsModule.forRoot([CountState, MyCounterState])]
       });
 
       store = TestBed.get(Store);
-    }));
+    });
 
     it('should get the meta data from the CountState', () => {
       expect(store.snapshot()).toEqual({ count: { myCounter: 1 } });

--- a/packages/store/tests/ensure-store.spec.ts
+++ b/packages/store/tests/ensure-store.spec.ts
@@ -65,7 +65,7 @@ describe('Ensure metadata', () => {
     }));
 
     it('should get the meta data from the CountState', () => {
-      console.log(store.snapshot());
+      expect(store.snapshot()).toEqual({ count: { myCounter: 1 } });
 
       expect(getStoreMetadata(CountState)).toEqual({
         name: 'count',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

https://github.com/ngxs-labs/data/blob/master/src/lib/decorators/action/action.ts#L58

![image](https://user-images.githubusercontent.com/12021443/67527474-c2dd9a00-f6bf-11e9-93d8-2c153065de75.png)

Now, to get the state instance, I needed to use the stateFactory reference

Issue Number: https://github.com/ngxs/store/issues/1323

In fact, it turns out that you could provide a link to the state instance

## What is the new behavior?

```ts
// INSTEAD
import { ... } from '@ngxs/...';
const mapped: MappedStore = NgxsDataAccessor.ensureMappedState(repository.stateMeta);
const stateInstance: Type<unknown> = mapped.instance;

// USE
import { getStoreMetadata } from '@ngxs/store';
const stateInstance: Type<unknown> = getStoreMetadata(StateClassTarget).instance;
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
I really need this in the release, as it provides simplified access to states and their methods