### PR TITLE
fix(store): expose internal interfaces for NGXS_STATE_TOKEN(s)

### DIFF
--- a/packages/store/src/internal/internals.ts
+++ b/packages/store/src/internal/internals.ts
@@ -7,10 +7,12 @@ import {
   NgxsConfig,
   NgxsSimpleChange,
   SELECTOR_META_KEY,
+  StateContext,
   StoreOptions
 } from '../symbols';
 import { ActionHandlerMetaData } from '../actions/symbols';
 import { getValue } from '../utils/utils';
+import { InternalActions } from '../actions-stream';
 
 function asReadonly<T>(value: T): Readonly<T> {
   return value;
@@ -77,6 +79,29 @@ export type Callback<T = any, V = any> = (...args: V[]) => T;
 export interface RootStateDiff<T> {
   currentAppState: T;
   newAppState: T;
+}
+
+export interface StateAddedMap {
+  newStates: StateClassInternal[];
+}
+
+/**
+ * @description API can changes regardless of semver specification
+ */
+export interface StateContextFactoryInternal {
+  createStateContext<T>(metadata: MappedStore): StateContext<T>;
+}
+
+/**
+ * @description API can changes regardless of semver specification
+ */
+export interface StateFactoryInternal {
+  readonly states: MappedStore[];
+  readonly statesByName: StatesByName;
+  add(stateClasses: StateClassInternal[]): MappedStore[];
+  addAndReturnDefaults(stateClasses: StateClassInternal[]): StatesAndDefaults;
+  connectActionHandlers(): void;
+  invokeActions(actions$: InternalActions, action: any): Observable<any>;
 }
 
 /**

--- a/packages/store/src/internal/state-context-factory.ts
+++ b/packages/store/src/internal/state-context-factory.ts
@@ -2,17 +2,13 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { NgxsLifeCycle, NgxsSimpleChange, StateContext, StateOperator } from '../symbols';
-import { getStateDiffChanges, MappedStore } from '../internal/internals';
+import { getStateDiffChanges, MappedStore, StateContextFactoryInternal } from '../internal/internals';
 import { setValue, getValue } from '../utils/utils';
 import { InternalStateOperations } from '../internal/state-operations';
 import { simplePatch } from './state-operators';
 
-/**
- * State Context factory class
- * @ignore
- */
 @Injectable()
-export class StateContextFactory {
+export class StateContextFactory implements StateContextFactoryInternal {
   constructor(private _internalStateOperations: InternalStateOperations) {}
 
   /**

--- a/packages/store/src/internal/state-factory.ts
+++ b/packages/store/src/internal/state-factory.ts
@@ -1,3 +1,4 @@
+import { INITIAL_STATE_TOKEN, PlainObjectOf } from '@ngxs/store/internals';
 import { Injectable, Injector, Optional, SkipSelf, Inject } from '@angular/core';
 import { forkJoin, from, Observable, of, throwError } from 'rxjs';
 import {
@@ -19,7 +20,9 @@ import {
   MetaDataModel,
   nameToState,
   propGetter,
+  StateAddedMap,
   StateClassInternal,
+  StateFactoryInternal,
   StateKeyGraph,
   StatesAndDefaults,
   StatesByName,
@@ -31,14 +34,9 @@ import { ActionContext, ActionStatus, InternalActions } from '../actions-stream'
 import { InternalDispatchedActionResults } from '../internal/dispatcher';
 import { StateContextFactory } from '../internal/state-context-factory';
 import { StoreValidators } from '../utils/store-validators';
-import { INITIAL_STATE_TOKEN, PlainObjectOf } from '@ngxs/store/internals';
 
-/**
- * State factory class
- * @ignore
- */
 @Injectable()
-export class StateFactory {
+export class StateFactory implements StateFactoryInternal {
   private _connected = false;
 
   constructor(
@@ -147,7 +145,7 @@ export class StateFactory {
   /**
    * Bind the actions to the handlers
    */
-  connectActionHandlers() {
+  connectActionHandlers(): void {
     if (this._connected) return;
     this._actions
       .pipe(
@@ -169,7 +167,7 @@ export class StateFactory {
   /**
    * Invoke actions on the states.
    */
-  invokeActions(actions$: InternalActions, action: any) {
+  invokeActions(actions$: InternalActions, action: any): Observable<any> {
     const results = [];
 
     for (const metadata of this.states) {
@@ -212,9 +210,7 @@ export class StateFactory {
     return forkJoin(results);
   }
 
-  private addToStatesMap(
-    stateClasses: StateClassInternal[]
-  ): { newStates: StateClassInternal[] } {
+  private addToStatesMap(stateClasses: StateClassInternal[]): StateAddedMap {
     const newStates: StateClassInternal[] = [];
     const statesMap: StatesByName = this.statesByName;
 

--- a/packages/store/src/plugin_api.ts
+++ b/packages/store/src/plugin_api.ts
@@ -3,3 +3,4 @@ export { NGXS_PLUGINS, NgxsPlugin, NgxsPluginFn, NgxsNextPluginFn } from './symb
 export { StateStream } from './internal/state-stream';
 export { getActionTypeFromInstance, setValue, getValue } from './utils/utils';
 export { InitState, UpdateState } from './actions/actions';
+export { StateFactoryInternal, StateContextFactoryInternal } from './internal/internals';

--- a/packages/store/tests/internal-api.spec.ts
+++ b/packages/store/tests/internal-api.spec.ts
@@ -1,7 +1,7 @@
+import { NgxsModule, StateContextFactoryInternal, StateFactoryInternal } from '@ngxs/store';
 import { NGXS_STATE_CONTEXT_FACTORY, NGXS_STATE_FACTORY } from '@ngxs/store/internals';
 import { Inject, ModuleWithProviders, NgModule } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
-import { NgxsModule } from '@ngxs/store';
 
 import { StateFactory } from '../src/internal/state-factory';
 import { StateContextFactory } from '../src/internal/state-context-factory';
@@ -11,9 +11,9 @@ describe('Internal API', () => {
     class MyCustomPluginAccessor {
       constructor(
         @Inject(NGXS_STATE_FACTORY)
-        public factory: StateFactory,
+        public factory: StateFactoryInternal,
         @Inject(NGXS_STATE_CONTEXT_FACTORY)
-        public contextFactory: StateContextFactory
+        public contextFactory: StateContextFactoryInternal
       ) {}
     }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: https://github.com/ngxs/store/issues/1414

## What is the new behavior?

In order for plugins to have at least some interface for working with the internal API. 

Before

```ts
import { NGXS_STATE_FACTORY, NGXS_STATE_CONTEXT_FACTORY } from '@ngxs/store/internals';
class MyPluginAccessor {
  constructor(
    @Inject(NGXS_STATE_FACTORY)
    public factory: any,
    @Inject(NGXS_STATE_CONTEXT_FACTORY)
    public contextFactory: any
  ) {}
}
@NgModule()
class MyPluginModule {
  public static forRoot(): ModuleWithProviders<MyPluginModule> {
    return {
      ngModule: MyPluginModule,
      providers: [MyPluginAccessor]
    };
  }
}
@NgModule({
  imports: [NgxsModule.forRoot(), MyPluginModule.forRoot()]
})
export class AppModule {}
```

After

```ts
import { NGXS_STATE_FACTORY, NGXS_STATE_CONTEXT_FACTORY } from '@ngxs/store/internals';
import { StateContextFactoryInternal, StateFactoryInternal } from '@ngxs/store';

class MyPluginAccessor {
  constructor(
    @Inject(NGXS_STATE_FACTORY)
    public factory: StateFactoryInternal,
    @Inject(NGXS_STATE_CONTEXT_FACTORY)
    public contextFactory: StateContextFactoryInternal
  ) {}
}
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
