### PR TITLE
feat(store): support passing type to `store.reset` method

### DIFF
--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -99,7 +99,7 @@ export class Store {
    * Reset the state to a specific point in time. This method is useful
    * for plugin's who need to modify the state directly or unit testing.
    */
-  reset(state: any) {
+  reset<T = any>(state: T): T {
     return this._internalStateOperations.getRootStateOperations().setState(state);
   }
 

--- a/packages/store/types/tests/dispatch.lint.ts
+++ b/packages/store/types/tests/dispatch.lint.ts
@@ -92,7 +92,7 @@ describe('[TEST]: Action Types', () => {
   it('should be correct type base API', () => {
     assertType(() => store.snapshot()); // $ExpectType any
     assertType(() => store.subscribe()); // $ExpectType Subscription
-    assertType(() => store.reset({})); // $ExpectType any
+    assertType(() => store.reset({})); // $ExpectType {}
     assertType(() => store.reset()); // $ExpectError
   });
 });

--- a/packages/store/types/tests/store.lint.ts
+++ b/packages/store/types/tests/store.lint.ts
@@ -1,0 +1,24 @@
+/// <reference types="@types/jest" />
+
+import { Store } from '@ngxs/store';
+import { assertType } from './utils/assert-type';
+
+describe('[TEST]: Action Types', () => {
+  let store: Store;
+
+  it('should be correct return type from reset', () => {
+    interface MyAppState {
+      a: number;
+      b: number;
+    }
+
+    const newState: MyAppState = { a: 1, b: 2 };
+
+    assertType(() => store.reset(newState)); // $ExpectType MyAppState
+    assertType(() => store.reset({ c: 3, d: '4' })); // $ExpectType { c: number; d: string; }
+    assertType(() => store.reset('Hello World')); // $ExpectType string
+    assertType(() => store.reset(NaN)); // $ExpectType number
+    assertType(() => store.reset([])); // $ExpectType never[]
+    assertType(() => store.reset(null)); // $ExpectType null
+  });
+});

--- a/packages/store/types/tests/store.lint.ts
+++ b/packages/store/types/tests/store.lint.ts
@@ -1,10 +1,19 @@
 /// <reference types="@types/jest" />
 
-import { Store } from '@ngxs/store';
+import { NgxsModule, Store } from '@ngxs/store';
 import { assertType } from './utils/assert-type';
+import { TestBed } from '@angular/core/testing';
 
 describe('[TEST]: Action Types', () => {
   let store: Store;
+
+  beforeAll(() => {
+    TestBed.configureTestingModule({
+      imports: [NgxsModule.forRoot()]
+    });
+
+    store = TestBed.get(Store);
+  });
 
   it('should be correct return type from reset', () => {
     interface MyAppState {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/ngxs/store/issues/1467

## What is the new behavior?

Now it is safer to get the type from the method

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
