### PR TITLE
fix(devtools-plugin): remove `NgxsModule` from imports to ensure Ivy compatibility

### DIFF
--- a/packages/devtools-plugin/src/devtools.module.ts
+++ b/packages/devtools-plugin/src/devtools.module.ts
@@ -1,5 +1,5 @@
 import { NgModule, ModuleWithProviders, InjectionToken } from '@angular/core';
-import { NgxsModule, NGXS_PLUGINS } from '@ngxs/store';
+import { NGXS_PLUGINS } from '@ngxs/store';
 
 import { NgxsDevtoolsOptions, NGXS_DEVTOOLS_OPTIONS } from './symbols';
 import { NgxsReduxDevtoolsPlugin } from './devtools.plugin';
@@ -13,9 +13,7 @@ export function devtoolsOptionsFactory(options: NgxsDevtoolsOptions) {
 
 export const USER_OPTIONS = new InjectionToken('USER_OPTIONS');
 
-@NgModule({
-  imports: [NgxsModule]
-})
+@NgModule()
 export class NgxsReduxDevtoolsPluginModule {
   static forRoot(
     options?: NgxsDevtoolsOptions


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

```
Compiling @ngxs/devtools-plugin : fesm5 as esm5
Compiling @ngxs/devtools-plugin : fesm2015 as esm2015
Compiling @ngxs/devtools-plugin : esm2015 as esm2015
Error: Error on worker #2: Error: Failed to compile entry-point @ngxs/devtools-plugin due to compilation errors:
node_modules/@ngxs/store/src/module.d.ts(9,22): error TS-996002: Appears in the NgModule.imports of NgxsReduxDevtoolsPluginModule, but could not be resolved to an NgModule class
```

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

**This error is non-deterministic. It happens in 20% of cases when running the NGCC. The `NgxsModule` shouldn't be in the `imports` section there!**