### PR TITLE
fix: selectors should be deterministic based on store being used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 $ npm install @ngxs/store@dev
 ```
 
+- Fix: Selectors should be deterministic based on store being used [#1508](https://github.com/ngxs/store/pull/1508)
 - Build: Add router-plugin back to ivy integration test [#1506](https://github.com/ngxs/store/pull/1506)
 - Build: Run ngcc synchronously to get Ivy build working again [#1497](https://github.com/ngxs/store/pull/1497)
 

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -32,14 +32,14 @@
       "path": "./@ngxs/store/fesm2015/ngxs-store.js",
       "package": "@ngxs/store",
       "target": "es2015",
-      "maxSize": "107.080KB",
+      "maxSize": "109.260KB",
       "compression": "none"
     },
     {
       "path": "./@ngxs/store/fesm5/ngxs-store.js",
       "package": "@ngxs/store",
       "target": "es5",
-      "maxSize": "126.870KB",
+      "maxSize": "128.540KB",
       "compression": "none"
     },
     {

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -32,14 +32,14 @@
       "path": "./@ngxs/store/fesm2015/ngxs-store.js",
       "package": "@ngxs/store",
       "target": "es2015",
-      "maxSize": "109.260KB",
+      "maxSize": "109.500KB",
       "compression": "none"
     },
     {
       "path": "./@ngxs/store/fesm5/ngxs-store.js",
       "package": "@ngxs/store",
       "target": "es5",
-      "maxSize": "128.540KB",
+      "maxSize": "129.000KB",
       "compression": "none"
     },
     {

--- a/packages/store/internals/src/memoize.ts
+++ b/packages/store/internals/src/memoize.ts
@@ -24,7 +24,7 @@ function areArgumentsShallowlyEqual(
 
 /**
  * Memoize a function on its last inputs only.
- * Oringinally from: https://github.com/reduxjs/reselect/blob/master/src/index.js
+ * Originally from: https://github.com/reduxjs/reselect/blob/master/src/index.js
  *
  * @ignore
  */

--- a/packages/store/src/decorators/select/symbols.ts
+++ b/packages/store/src/decorators/select/symbols.ts
@@ -3,7 +3,6 @@ import { Observable } from 'rxjs';
 import { CONFIG_MESSAGES, VALIDATION_CODE } from '../../configs/messages.config';
 import { propGetter } from '../../internal/internals';
 import { SelectFactory } from './select-factory';
-import { META_KEY } from '../../symbols';
 import { StateToken } from '../../state-token/state-token';
 import { ExtractTokenType } from '../../state-token/symbols';
 
@@ -25,8 +24,6 @@ export function createSelectorFn(name: string, rawSelector?: any, paths: string[
       ? [rawSelector, ...paths]
       : rawSelector.split('.');
     return propGetter(propsArray, SelectFactory.config!);
-  } else if (rawSelector[META_KEY] && rawSelector[META_KEY].path) {
-    return propGetter(rawSelector[META_KEY].path.split('.'), SelectFactory.config!);
   }
 
   return rawSelector;

--- a/packages/store/src/internal/internals.ts
+++ b/packages/store/src/internal/internals.ts
@@ -43,7 +43,6 @@ export interface MetaDataModel {
 }
 
 export interface RuntimeSelectorContext {
-  getStatePath(key: any): string;
   getStateGetter(key: any): (state: any) => any;
 }
 
@@ -68,7 +67,7 @@ export interface MappedStore {
   actions: PlainObjectOf<ActionHandlerMetaData[]>;
   defaults: any;
   instance: any;
-  depth: string;
+  path: string;
 }
 
 export interface StatesAndDefaults {
@@ -384,7 +383,7 @@ export function getStateDiffChanges<T>(
   mappedStore: MappedStore,
   diff: RootStateDiff<T>
 ): NgxsSimpleChange {
-  const previousValue: T = getValue(diff.currentAppState, mappedStore.depth);
-  const currentValue: T = getValue(diff.newAppState, mappedStore.depth);
+  const previousValue: T = getValue(diff.currentAppState, mappedStore.path);
+  const currentValue: T = getValue(diff.newAppState, mappedStore.path);
   return new NgxsSimpleChange(previousValue, currentValue, !mappedStore.isInitialised);
 }

--- a/packages/store/src/internal/internals.ts
+++ b/packages/store/src/internal/internals.ts
@@ -42,7 +42,12 @@ export interface MetaDataModel {
   children?: StateClassInternal[];
 }
 
-export type SelectFromState = (state: any) => any;
+export interface RuntimeSelectorContext {
+  getStatePath(key: any): string;
+  getStateGetter(key: any): (state: any) => any;
+}
+
+export type SelectFromState = (state: any, runtimeContext: RuntimeSelectorContext) => any;
 
 export interface SharedSelectorOptions {
   injectContainerState?: boolean;
@@ -90,7 +95,10 @@ export function ensureStoreMetadata(target: StateClassInternal): MetaDataModel {
       actions: {},
       defaults: {},
       path: null,
-      selectFromAppState: null,
+      selectFromAppState(state: any, context: RuntimeSelectorContext) {
+        const getter = context.getStateGetter(defaultMetadata.name);
+        return getter(state);
+      },
       children: []
     };
 

--- a/packages/store/src/internal/state-context-factory.ts
+++ b/packages/store/src/internal/state-context-factory.ts
@@ -22,11 +22,11 @@ export class StateContextFactory {
     const root = this._internalStateOperations.getRootStateOperations();
 
     function getState(currentAppState: any): T {
-      return getValue(currentAppState, mappedStore.depth);
+      return getValue(currentAppState, mappedStore.path);
     }
 
     function setStateValue(currentAppState: any, newValue: T): any {
-      const newAppState = setValue(currentAppState, mappedStore.depth, newValue);
+      const newAppState = setValue(currentAppState, mappedStore.path, newValue);
       const instance: NgxsLifeCycle = mappedStore.instance;
 
       if (instance.ngxsOnChanges) {

--- a/packages/store/src/internal/state-factory.ts
+++ b/packages/store/src/internal/state-factory.ts
@@ -70,16 +70,21 @@ export class StateFactory {
 
   private _statePaths: PlainObjectOf<string> = {};
 
-  public getRuntimeSelectorContext: () => RuntimeSelectorContext = memoize(() => {
+  private get statePaths(): PlainObjectOf<string> {
+    return this._parentFactory ? this._parentFactory.statePaths : this._statePaths;
+  }
+
+  public getRuntimeSelectorContext = memoize(() => {
     const stateFactory = this;
-    return this._parentFactory
+    const context: RuntimeSelectorContext = this._parentFactory
       ? this._parentFactory.getRuntimeSelectorContext()
       : {
           getStateGetter(key: string) {
-            const path = stateFactory._statePaths[key];
+            const path = stateFactory.statePaths[key];
             return path ? propGetter(path.split('.'), stateFactory._config) : () => undefined;
           }
         };
+    return context;
   });
 
   private static cloneDefaults(defaults: any): any {
@@ -247,7 +252,7 @@ export class StateFactory {
   }
 
   private addRuntimeInfoToMeta(meta: MetaDataModel, path: string): void {
-    this._statePaths[meta.name!] = path;
+    this.statePaths[meta.name!] = path;
     // TODO: v4 - we plan to get rid of the path property because it is non-deterministic
     // we can do this when we get rid of the incorrectly exposed getStoreMetadata
     // We will need to come up with an alternative in v4 because this is used by many plugins

--- a/packages/store/src/public_api.ts
+++ b/packages/store/src/public_api.ts
@@ -5,6 +5,16 @@ export { State } from './decorators/state';
 export { Select } from './decorators/select/select';
 export { SelectorOptions } from './decorators/selector-options';
 export { Actions } from './actions-stream';
+
+// TODO: v4 - We need to come up with an alternative api to exposing this metadata
+//   because it is currently used by the following (after a github search):
+// - https://github.com/ngxs-labs/emitter/blob/81d21d135400d7e3765fc579e09aea29b1b92bf7/emitter/src/lib/core/decorators/receiver.ts#L91
+// - https://github.com/ngxs-labs/data/blob/73a320059f21924eb975a86adae5169a404071fd/src/lib/decorators/persistence/persistence.ts#L13
+// - https://github.com/ng-turkey/ngxs-reset-plugin/blob/0f22f22e277c7de5b340d1917aae303d01020cee/src/lib/reset.plugin.ts#L19
+// tslint:disable: max-line-length
+// - https://github.com/ngxs-labs/firebase-plugin/blob/7251d877aeadefea8c3c891b7b55e7653a9f289c/src/lib/decorators/ngxs-firestore-connect.ts#L23
+// - https://github.com/stefan-schubert/ngxs-extensions/blob/922ee2f87eba17823b5efab142b656b0d29f827d/src/lib/core/decorators/reset-state.decorator.ts#L18
+// tslint:enable: max-line-length
 export {
   getSelectorMetadata,
   getStoreMetadata,

--- a/packages/store/src/utils/selector-utils.ts
+++ b/packages/store/src/utils/selector-utils.ts
@@ -7,7 +7,8 @@ import {
   globalSelectorOptions,
   SelectFromState,
   SelectorMetaDataModel,
-  SharedSelectorOptions
+  SharedSelectorOptions,
+  RuntimeSelectorContext
 } from '../internal/internals';
 
 const SELECTOR_OPTIONS_META_KEY = 'NGXS_SELECTOR_OPTIONS_META';
@@ -30,7 +31,7 @@ interface CreationMetadata {
 
 interface RuntimeSelectorInfo {
   selectorOptions: SharedSelectorOptions;
-  argumentSelectorFunctions: ((state: any) => any)[];
+  argumentSelectorFunctions: SelectFromState[];
 }
 
 /**
@@ -57,7 +58,10 @@ export function createSelector<T extends (...args: any[]) => any>(
   const selectorMetaData = setupSelectorMetadata<T>(memoizedFn, originalFn, creationMetadata);
   let runtimeInfo: RuntimeSelectorInfo;
 
-  const selectFromAppState = (state: any) => {
+  const selectFromAppState: SelectFromState = (
+    state: any,
+    context: RuntimeSelectorContext
+  ) => {
     const results = [];
 
     runtimeInfo = runtimeInfo || getRuntimeSelectorInfo(selectorMetaData, selectors);
@@ -65,7 +69,7 @@ export function createSelector<T extends (...args: any[]) => any>(
     const { argumentSelectorFunctions } = runtimeInfo;
 
     // Determine arguments from the app state using the selectors
-    results.push(...argumentSelectorFunctions.map(argFn => argFn(state)));
+    results.push(...argumentSelectorFunctions.map(argFn => argFn(state, context)));
 
     // if the lambda tries to access a something on the
     // state that doesn't exist, it will throw a TypeError.

--- a/packages/store/tests/ensure-store.spec.ts
+++ b/packages/store/tests/ensure-store.spec.ts
@@ -71,7 +71,7 @@ describe('Ensure metadata', () => {
         },
         defaults: 0,
         path: null,
-        selectFromAppState: null,
+        selectFromAppState: expect.any(Function),
         children: [MyCounterState]
       });
     });
@@ -82,7 +82,7 @@ describe('Ensure metadata', () => {
         actions: { decrement: [{ fn: 'decrement', options: {}, type: 'decrement' }] },
         defaults: 1,
         path: null,
-        selectFromAppState: null,
+        selectFromAppState: expect.any(Function),
         children: undefined
       });
     });
@@ -103,9 +103,6 @@ describe('Ensure metadata', () => {
 
       expect(metadata.getSelectorOptions()).toEqual({});
       expect(metadata.selectFromAppState).toEqual(getSelectorFn(CountState.selectFn));
-
-      // TODO(splincode): is normal for CountState?
-      expect(getSelectorFn(CountState.selectFn)(0)).toBeUndefined();
     });
 
     it('should get the selector meta data from the CountState.canInheritSelectFn, MyCounterState.canInheritSelectFn', () => {
@@ -138,10 +135,6 @@ describe('Ensure metadata', () => {
       expect(myCounterMetadata.selectFromAppState).toEqual(
         getSelectorFn(MyCounterState.canInheritSelectFn)
       );
-
-      // TODO(splincode): is normal for CountState, MyCounterState?
-      expect(getSelectorFn(CountState.canInheritSelectFn)(0)).toEqual(NaN);
-      expect(getSelectorFn(MyCounterState.canInheritSelectFn)(0)).toEqual(NaN);
     });
 
     it('should get the selector meta data from the SuperCountState.canInheritSelectFn', () => {

--- a/packages/store/tests/store-isolation.spec.ts
+++ b/packages/store/tests/store-isolation.spec.ts
@@ -3,6 +3,8 @@ import { TestBed } from '@angular/core/testing';
 import { Store } from '../src/store';
 import { NgxsModule } from '../src/module';
 import { State } from '../src/decorators/state';
+import { Selector } from '../src/decorators/selector/selector';
+import { SelectorOptions } from '../src/decorators/selector-options';
 
 describe('Store (isolation)', () => {
   describe('when selecting a child state', () => {
@@ -61,6 +63,79 @@ describe('Store (isolation)', () => {
       const result = store.selectSnapshot(ChildState);
       // Assert
       expect(result).toBeUndefined();
+    });
+  });
+
+  describe('when selecting a child state using a selector', () => {
+    @State<string>({ name: 'child' })
+    class ChildState {
+      @Selector() static getPath(state: string) {
+        return state;
+      }
+    }
+
+    @State<{ path: string }>({ name: 'parent', children: [ChildState] })
+    @SelectorOptions({ injectContainerState: false })
+    class ParentState {
+      @Selector([ParentState, ChildState.getPath])
+      static getPaths(parent: any, childPath: string) {
+        return `${parent && parent.path}, ${childPath}`;
+      }
+    }
+
+    function setToTestState(store: Store) {
+      store.reset({ parent: { path: 'parent', child: 'parent.child' }, child: 'child' });
+    }
+
+    it('should select undefined if not initialised in store', () => {
+      // Arrange
+      TestBed.configureTestingModule({
+        imports: [
+          NgxsModule.forRoot([], {
+            selectorOptions: { suppressErrors: false }
+          })
+        ]
+      });
+      const store: Store = TestBed.get(Store);
+      setToTestState(store);
+      // Act
+      const result = store.selectSnapshot(ParentState.getPaths);
+      // Assert
+      expect(result).toEqual('undefined, undefined');
+    });
+
+    it('should select successfully if initialised in store', () => {
+      // Arrange
+      TestBed.configureTestingModule({
+        imports: [
+          NgxsModule.forRoot([ChildState, ParentState], {
+            selectorOptions: { suppressErrors: false }
+          })
+        ]
+      });
+      const store: Store = TestBed.get(Store);
+      setToTestState(store);
+      // Act
+      const result = store.selectSnapshot(ParentState.getPaths);
+      // Assert
+      expect(result).toEqual('parent, parent.child');
+    });
+
+    it('should select undefined if not initialised in store in subsequent test', () => {
+      // Arrange
+      TestBed.configureTestingModule({
+        imports: [
+          NgxsModule.forRoot([], {
+            selectorOptions: { suppressErrors: false }
+          })
+        ]
+      });
+      const store: Store = TestBed.get(Store);
+      setToTestState(store);
+      // Act
+      const result = store.selectSnapshot(ParentState.getPaths);
+      // Assert
+      expect(result).toEqual('undefined, undefined');
     });
   });
 });

--- a/packages/store/tests/store-isolation.spec.ts
+++ b/packages/store/tests/store-isolation.spec.ts
@@ -1,0 +1,71 @@
+import { TestBed } from '@angular/core/testing';
+
+import { Store } from '../src/store';
+import { NgxsModule } from '../src/module';
+import { State } from '../src/decorators/state';
+
+describe('Store (isolation)', () => {
+  describe('when selecting a child state', () => {
+    @State<string>({
+      name: 'child'
+    })
+    class ChildState {}
+
+    @State<{}>({
+      name: 'parent',
+      children: [ChildState]
+    })
+    class ParentState {}
+
+    it('should select undefined if not initialised in store', () => {
+      // Arrange
+      TestBed.configureTestingModule({
+        imports: [
+          NgxsModule.forRoot([], {
+            selectorOptions: { suppressErrors: false }
+          })
+        ]
+      });
+      const store: Store = TestBed.get(Store);
+      store.reset({ child: 'child' });
+      // Act
+      const result = store.selectSnapshot(ChildState);
+      // Assert
+      expect(result).toBeUndefined();
+    });
+
+    it('should select successfully if initialised in store', () => {
+      // Arrange
+      TestBed.configureTestingModule({
+        imports: [
+          NgxsModule.forRoot([ChildState, ParentState], {
+            selectorOptions: { suppressErrors: false }
+          })
+        ]
+      });
+      const store: Store = TestBed.get(Store);
+      store.reset({ parent: { child: 'parent.child' }, child: 'child' });
+      // Act
+      const result = store.selectSnapshot(ChildState);
+      // Assert
+      expect(result).toEqual('parent.child');
+    });
+
+    it('should select undefined if not initialised in store in subsequent test', () => {
+      // Arrange
+      TestBed.configureTestingModule({
+        imports: [
+          NgxsModule.forRoot([], {
+            selectorOptions: { suppressErrors: false }
+          })
+        ]
+      });
+      const store: Store = TestBed.get(Store);
+      store.reset({ parent: { child: 'parent.child' }, child: 'child' });
+      // Act
+      const result = store.selectSnapshot(ChildState);
+      // Assert
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/packages/store/tests/store-isolation.spec.ts
+++ b/packages/store/tests/store-isolation.spec.ts
@@ -6,15 +6,10 @@ import { State } from '../src/decorators/state';
 
 describe('Store (isolation)', () => {
   describe('when selecting a child state', () => {
-    @State<string>({
-      name: 'child'
-    })
+    @State<string>({ name: 'child' })
     class ChildState {}
 
-    @State<{}>({
-      name: 'parent',
-      children: [ChildState]
-    })
+    @State<{}>({ name: 'parent', children: [ChildState] })
     class ParentState {}
 
     it('should select undefined if not initialised in store', () => {

--- a/packages/store/tests/store-isolation.spec.ts
+++ b/packages/store/tests/store-isolation.spec.ts
@@ -5,6 +5,10 @@ import { NgxsModule } from '../src/module';
 import { State } from '../src/decorators/state';
 import { Selector } from '../src/decorators/selector/selector';
 import { SelectorOptions } from '../src/decorators/selector-options';
+import { NgModule, NgModuleFactoryLoader } from '@angular/core';
+import { RouterTestingModule, SpyNgModuleFactoryLoader } from '@angular/router/testing';
+import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
 
 describe('Store (isolation)', () => {
   describe('when selecting a child state', () => {
@@ -131,6 +135,88 @@ describe('Store (isolation)', () => {
         ]
       });
       const store: Store = TestBed.get(Store);
+      setToTestState(store);
+      // Act
+      const result = store.selectSnapshot(ParentState.getPaths);
+      // Assert
+      expect(result).toEqual('undefined, undefined');
+    });
+  });
+
+  describe('when selecting a lazy child state using a selector', () => {
+    @State<string>({ name: 'child' })
+    class ChildState {
+      @Selector() static getPath(state: string) {
+        return state;
+      }
+    }
+
+    @State<{ path: string }>({ name: 'parent', children: [ChildState] })
+    @SelectorOptions({ injectContainerState: false })
+    class ParentState {
+      @Selector([ParentState, ChildState.getPath])
+      static getPaths(parent: any, childPath: string) {
+        return `${parent && parent.path}, ${childPath}`;
+      }
+    }
+
+    @NgModule({ imports: [CommonModule, NgxsModule.forFeature([ChildState, ParentState])] })
+    class LazyModule {}
+
+    function setup() {
+      TestBed.configureTestingModule({
+        imports: [
+          RouterTestingModule,
+          NgxsModule.forRoot([], {
+            selectorOptions: { suppressErrors: false }
+          })
+        ]
+      });
+
+      const store: Store = TestBed.get(Store);
+      const router: Router = TestBed.get(Router);
+      const loader: SpyNgModuleFactoryLoader = TestBed.get(NgModuleFactoryLoader);
+      loader.stubbedModules = {
+        lazyModule: LazyModule
+      };
+      router.resetConfig([{ path: 'lazy-path', loadChildren: 'lazyModule' }]);
+      async function navigateToLazyRoute() {
+        return await router.navigateByUrl('/lazy-path');
+      }
+      return {
+        store,
+        navigateToLazyRoute
+      };
+    }
+
+    function setToTestState(store: Store) {
+      store.reset({ parent: { path: 'parent', child: 'parent.child' }, child: 'child' });
+    }
+
+    it('should select undefined if not initialised in store', () => {
+      // Arrange
+      const { store } = setup();
+      setToTestState(store);
+      // Act
+      const result = store.selectSnapshot(ParentState.getPaths);
+      // Assert
+      expect(result).toEqual('undefined, undefined');
+    });
+
+    it('should select successfully if lazy route initialised in store', async () => {
+      // Arrange
+      const { navigateToLazyRoute, store } = setup();
+      await navigateToLazyRoute();
+      setToTestState(store);
+      // Act
+      const result = store.selectSnapshot(ParentState.getPaths);
+      // Assert
+      expect(result).toEqual('parent, parent.child');
+    });
+
+    it('should select undefined if not initialised in store in subsequent test', () => {
+      // Arrange
+      const { store } = setup();
       setToTestState(store);
       // Act
       const result = store.selectSnapshot(ParentState.getPaths);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently, when the ngxs module is loaded for some states it updates the metadata of those states with the path for those states within the state tree. This is a problem because the metadata should be immutable to prevent one test from affecting the next. Although we cannot remove the behavior with the `path` because it is being used by some plugins, but we can decouple the selectors from this property so that they become deterministic based on the store that invoked them.

Issue Number: #1504, #1180 

## What is the new behavior?

Selectors now use the state paths as determined from the store that invoked them. This results in the selectors becoming deterministic and avoids the testing issues as described in the above issues.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
