### PR TITLE
fix: add support for using state tokens in sub states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ $ npm install @ngxs/store@dev
 ```
 
 - Fix: Selectors should be deterministic based on store being used [#1508](https://github.com/ngxs/store/pull/1508)
+- Fix: Add support for using State Tokens in sub states [#1509](https://github.com/ngxs/store/pull/1509)
 - Build: Add router-plugin back to ivy integration test [#1506](https://github.com/ngxs/store/pull/1506)
 - Build: Run ngcc synchronously to get Ivy build working again [#1497](https://github.com/ngxs/store/pull/1497)
 

--- a/packages/store/src/state-token/state-token.ts
+++ b/packages/store/src/state-token/state-token.ts
@@ -1,16 +1,14 @@
 import { TokenName } from './symbols';
-import { ensureSelectorMetadata, propGetter } from '../internal/internals';
-import { SelectFactory } from '../decorators/select/select-factory';
+import { ensureSelectorMetadata, RuntimeSelectorContext } from '../internal/internals';
 
 export class StateToken<T = void> {
   constructor(private readonly name: TokenName<T>) {
     const selectorMetadata = ensureSelectorMetadata(<any>this);
-    selectorMetadata.selectFromAppState = (state: any): T => {
-      // This is lazy initialized with the select from app state function
-      // so that it can get the config at the last responsible moment
-      const getter = propGetter([this.name], SelectFactory.config!);
-      selectorMetadata.selectFromAppState = getter;
-      return getter(state);
+    selectorMetadata.selectFromAppState = (
+      state: any,
+      runtimeContext: RuntimeSelectorContext
+    ): T => {
+      return runtimeContext.getStateGetter(this.name)(state);
     };
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Currently, there exists an issue with the State Token construct that, if it is used with a sub-state, the selector cannot locate the state within the state tree. This is due to the fact that, when it was implemented, there didn't exist any deterministic construct to determine the location of a state by its' name. PR #1508 added this construct that we are now able to take advantage of.

## What is the new behavior?

The selector function for the State Token uses the runtime information passed from the store to determine the location of the State that the token represents.

There is an opportunity to optimize this further, but that optimization will be implemented in a subsequent PR and is not needed for this fix.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
