### PR TITLE
fix(store): optimize selector runtime binding

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -32,14 +32,14 @@
       "path": "./@ngxs/store/fesm2015/ngxs-store.js",
       "package": "@ngxs/store",
       "target": "es2015",
-      "maxSize": "109.500KB",
+      "maxSize": "110.750KB",
       "compression": "none"
     },
     {
       "path": "./@ngxs/store/fesm5/ngxs-store.js",
       "package": "@ngxs/store",
       "target": "es5",
-      "maxSize": "129.000KB",
+      "maxSize": "130.180KB",
       "compression": "none"
     },
     {

--- a/packages/store/src/internal/internals.ts
+++ b/packages/store/src/internal/internals.ts
@@ -43,8 +43,6 @@ export interface RuntimeSelectorContext {
   getSelectorOptions(localOptions?: SharedSelectorOptions): SharedSelectorOptions;
 }
 
-export type SelectFromState = (state: any, runtimeContext: RuntimeSelectorContext) => any;
-
 export type SelectFromRootState = (rootState: any) => any;
 export type SelectorFactory = (runtimeContext: RuntimeSelectorContext) => SelectFromRootState;
 

--- a/packages/store/src/internal/internals.ts
+++ b/packages/store/src/internal/internals.ts
@@ -12,10 +12,6 @@ import {
 import { ActionHandlerMetaData } from '../actions/symbols';
 import { getValue } from '../utils/utils';
 
-function asReadonly<T>(value: T): Readonly<T> {
-  return value;
-}
-
 // inspired from https://stackoverflow.com/a/43674389
 export interface StateClassInternal<T = any, U = any> extends StateClass<T> {
   [META_KEY]?: MetaDataModel;
@@ -39,14 +35,19 @@ export interface MetaDataModel {
   defaults: any;
   path: string | null;
   selectFromAppState: SelectFromState | null;
+  makeRootSelector: SelectorFactory | null;
   children?: StateClassInternal[];
 }
 
 export interface RuntimeSelectorContext {
   getStateGetter(key: any): (state: any) => any;
+  getSelectorOptions(localOptions?: SharedSelectorOptions): SharedSelectorOptions;
 }
 
 export type SelectFromState = (state: any, runtimeContext: RuntimeSelectorContext) => any;
+
+export type SelectFromRootState = (rootState: any) => any;
+export type SelectorFactory = (runtimeContext: RuntimeSelectorContext) => SelectFromRootState;
 
 export interface SharedSelectorOptions {
   injectContainerState?: boolean;
@@ -55,6 +56,7 @@ export interface SharedSelectorOptions {
 
 export interface SelectorMetaDataModel {
   selectFromAppState: SelectFromState | null;
+  makeRootSelector: SelectorFactory | null;
   originalFn: Function | null;
   containerClass: any;
   selectorName: string | null;
@@ -98,6 +100,9 @@ export function ensureStoreMetadata(target: StateClassInternal): MetaDataModel {
         const getter = context.getStateGetter(defaultMetadata.name);
         return getter(state);
       },
+      makeRootSelector(context: RuntimeSelectorContext) {
+        return context.getStateGetter(defaultMetadata.name);
+      },
       children: []
     };
 
@@ -115,18 +120,6 @@ export function getStoreMetadata(target: StateClassInternal): MetaDataModel {
   return target[META_KEY]!;
 }
 
-// closure variable used to store the global options
-let _globalSelectorOptions: SharedSelectorOptions = {};
-
-export const globalSelectorOptions = asReadonly({
-  get(): Readonly<SharedSelectorOptions> {
-    return _globalSelectorOptions;
-  },
-  set(value: Readonly<SharedSelectorOptions>) {
-    _globalSelectorOptions = { ...value };
-  }
-});
-
 /**
  * Ensures metadata is attached to the selector and returns it.
  *
@@ -136,6 +129,7 @@ export function ensureSelectorMetadata(target: Function): SelectorMetaDataModel 
   if (!target.hasOwnProperty(SELECTOR_META_KEY)) {
     const defaultMetadata: SelectorMetaDataModel = {
       selectFromAppState: null,
+      makeRootSelector: null,
       originalFn: null,
       containerClass: null,
       selectorName: null,

--- a/packages/store/src/internal/internals.ts
+++ b/packages/store/src/internal/internals.ts
@@ -34,7 +34,6 @@ export interface MetaDataModel {
   actions: PlainObjectOf<ActionHandlerMetaData[]>;
   defaults: any;
   path: string | null;
-  selectFromAppState: SelectFromState | null;
   makeRootSelector: SelectorFactory | null;
   children?: StateClassInternal[];
 }
@@ -55,7 +54,6 @@ export interface SharedSelectorOptions {
 }
 
 export interface SelectorMetaDataModel {
-  selectFromAppState: SelectFromState | null;
   makeRootSelector: SelectorFactory | null;
   originalFn: Function | null;
   containerClass: any;
@@ -96,10 +94,6 @@ export function ensureStoreMetadata(target: StateClassInternal): MetaDataModel {
       actions: {},
       defaults: {},
       path: null,
-      selectFromAppState(state: any, context: RuntimeSelectorContext) {
-        const getter = context.getStateGetter(defaultMetadata.name);
-        return getter(state);
-      },
       makeRootSelector(context: RuntimeSelectorContext) {
         return context.getStateGetter(defaultMetadata.name);
       },
@@ -128,7 +122,6 @@ export function getStoreMetadata(target: StateClassInternal): MetaDataModel {
 export function ensureSelectorMetadata(target: Function): SelectorMetaDataModel {
   if (!target.hasOwnProperty(SELECTOR_META_KEY)) {
     const defaultMetadata: SelectorMetaDataModel = {
-      selectFromAppState: null,
       makeRootSelector: null,
       originalFn: null,
       containerClass: null,

--- a/packages/store/src/internal/state-factory.ts
+++ b/packages/store/src/internal/state-factory.ts
@@ -24,7 +24,8 @@ import {
   StatesAndDefaults,
   StatesByName,
   topologicalSort,
-  RuntimeSelectorContext
+  RuntimeSelectorContext,
+  SharedSelectorOptions
 } from './internals';
 import { getActionTypeFromInstance, getValue, setValue } from '../utils/utils';
 import { ofActionDispatched } from '../operators/of-action';
@@ -82,6 +83,13 @@ export class StateFactory {
           getStateGetter(key: string) {
             const path = stateFactory.statePaths[key];
             return path ? propGetter(path.split('.'), stateFactory._config) : () => undefined;
+          },
+          getSelectorOptions(localOptions?: SharedSelectorOptions) {
+            const globalSelectorOptions = stateFactory._config.selectorOptions;
+            return {
+              ...globalSelectorOptions,
+              ...(localOptions || {})
+            };
           }
         };
     return context;

--- a/packages/store/src/modules/ngxs-root.module.ts
+++ b/packages/store/src/modules/ngxs-root.module.ts
@@ -4,12 +4,8 @@ import { StateFactory } from '../internal/state-factory';
 import { InternalStateOperations } from '../internal/state-operations';
 import { Store } from '../store';
 import { SelectFactory } from '../decorators/select/select-factory';
-import { NgxsConfig, ROOT_STATE_TOKEN } from '../symbols';
-import {
-  globalSelectorOptions,
-  StateClassInternal,
-  StatesAndDefaults
-} from '../internal/internals';
+import { ROOT_STATE_TOKEN } from '../symbols';
+import { StateClassInternal, StatesAndDefaults } from '../internal/internals';
 import { LifecycleStateManager } from '../internal/lifecycle-state-manager';
 import { InitState } from '../actions/actions';
 import { setIvyEnabledInDevMode } from '../ivy/ivy-enabled-in-dev-mode';
@@ -28,13 +24,10 @@ export class NgxsRootModule {
     @Optional()
     @Inject(ROOT_STATE_TOKEN)
     states: StateClassInternal[] = [],
-    config: NgxsConfig,
     lifecycleStateManager: LifecycleStateManager
   ) {
     // Validate states on having the `@Injectable()` decorator in Ivy
     setIvyEnabledInDevMode();
-
-    globalSelectorOptions.set(config.selectorOptions || {});
 
     // Add stores to the state graph and return their defaults
     const results: StatesAndDefaults = factory.addAndReturnDefaults(states);

--- a/packages/store/src/public_api.ts
+++ b/packages/store/src/public_api.ts
@@ -20,7 +20,7 @@ export {
   getStoreMetadata,
   ensureStoreMetadata,
   ensureSelectorMetadata
-} from './internal/internals';
+} from './public_to_deprecate';
 export {
   ofAction,
   ofActionDispatched,

--- a/packages/store/src/public_to_deprecate.ts
+++ b/packages/store/src/public_to_deprecate.ts
@@ -1,0 +1,45 @@
+import {
+  getSelectorMetadata as getSelectorMetadataInternal,
+  getStoreMetadata as getStoreMetadataInternal,
+  ensureStoreMetadata as ensureStoreMetadataInternal,
+  ensureSelectorMetadata as ensureSelectorMetadataInternal,
+  StateClassInternal,
+  SharedSelectorOptions
+} from './internal/internals';
+import { PlainObjectOf } from '../internals/src/symbols';
+import { ActionHandlerMetaData } from './actions/symbols';
+
+interface MetaDataModel {
+  name: string | null;
+  actions: PlainObjectOf<ActionHandlerMetaData[]>;
+  defaults: any;
+  path: string | null;
+  // selectFromAppState: SelectFromState | null;
+  // makeRootSelector: SelectorFactory | null; // Don't expose new stuff
+  children?: StateClassInternal[];
+}
+
+interface SelectorMetaDataModel {
+  // selectFromAppState: SelectFromState | null;
+  // makeRootSelector: SelectorFactory | null; // Don't expose new stuff
+  originalFn: Function | null;
+  containerClass: any;
+  selectorName: string | null;
+  getSelectorOptions: () => SharedSelectorOptions;
+}
+
+export function ensureStoreMetadata(target: StateClassInternal<any, any>): MetaDataModel {
+  return ensureStoreMetadataInternal(target);
+}
+
+export function getStoreMetadata(target: StateClassInternal<any, any>): MetaDataModel {
+  return getStoreMetadataInternal(target);
+}
+
+export function ensureSelectorMetadata(target: Function): SelectorMetaDataModel {
+  return ensureSelectorMetadataInternal(target);
+}
+
+export function getSelectorMetadata(target: any): SelectorMetaDataModel {
+  return getSelectorMetadataInternal(target);
+}

--- a/packages/store/src/state-token/state-token.ts
+++ b/packages/store/src/state-token/state-token.ts
@@ -4,11 +4,10 @@ import { ensureSelectorMetadata, RuntimeSelectorContext } from '../internal/inte
 export class StateToken<T = void> {
   constructor(private readonly name: TokenName<T>) {
     const selectorMetadata = ensureSelectorMetadata(<any>this);
-    selectorMetadata.selectFromAppState = (
-      state: any,
+    selectorMetadata.makeRootSelector = (
       runtimeContext: RuntimeSelectorContext
-    ): T => {
-      return runtimeContext.getStateGetter(this.name)(state);
+    ): ((state: any) => T) => {
+      return runtimeContext.getStateGetter(this.name);
     };
   }
 

--- a/packages/store/src/state-token/state-token.ts
+++ b/packages/store/src/state-token/state-token.ts
@@ -1,12 +1,16 @@
 import { TokenName } from './symbols';
-import { ensureSelectorMetadata, RuntimeSelectorContext } from '../internal/internals';
+import {
+  ensureSelectorMetadata,
+  RuntimeSelectorContext,
+  SelectFromRootState
+} from '../internal/internals';
 
 export class StateToken<T = void> {
   constructor(private readonly name: TokenName<T>) {
     const selectorMetadata = ensureSelectorMetadata(<any>this);
     selectorMetadata.makeRootSelector = (
       runtimeContext: RuntimeSelectorContext
-    ): ((state: any) => T) => {
+    ): SelectFromRootState => {
       return runtimeContext.getStateGetter(this.name);
     };
   }

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -6,7 +6,7 @@ import { INITIAL_STATE_TOKEN, PlainObject } from '@ngxs/store/internals';
 
 import { InternalNgxsExecutionStrategy } from './execution/internal-ngxs-execution-strategy';
 import { InternalStateOperations } from './internal/state-operations';
-import { getSelectorFn } from './utils/selector-utils';
+import { getRootSelectorFactory } from './utils/selector-utils';
 import { StateStream } from './internal/state-stream';
 import { leaveNgxs } from './operators/leave-ngxs';
 import { NgxsConfig } from './symbols';
@@ -106,11 +106,9 @@ export class Store {
   }
 
   private getStoreBoundSelectorFn(selector: any) {
-    const fn = getSelectorFn(selector);
+    const makeSelectorFn = getRootSelectorFactory(selector);
     const runtimeContext = this._stateFactory.getRuntimeSelectorContext();
-    return (state: any) => {
-      return fn(state, runtimeContext);
-    };
+    return makeSelectorFn(runtimeContext);
   }
 
   private initStateStream(initialStateValue: any): void {

--- a/packages/store/tests/ensure-store.spec.ts
+++ b/packages/store/tests/ensure-store.spec.ts
@@ -10,7 +10,7 @@ import {
 import { TestBed } from '@angular/core/testing';
 
 import { SelectorMetaDataModel } from '../src/internal/internals';
-import { getSelectorFn } from '../src/utils/selector-utils';
+import { getRootSelectorFactory } from '../src/utils/selector-utils';
 
 describe('Ensure metadata', () => {
   it('should return undefined if not a state class', () => {
@@ -72,6 +72,7 @@ describe('Ensure metadata', () => {
         defaults: 0,
         path: null,
         selectFromAppState: expect.any(Function),
+        makeRootSelector: expect.any(Function),
         children: [MyCounterState]
       });
     });
@@ -83,6 +84,7 @@ describe('Ensure metadata', () => {
         defaults: 1,
         path: null,
         selectFromAppState: expect.any(Function),
+        makeRootSelector: expect.any(Function),
         children: undefined
       });
     });
@@ -102,7 +104,7 @@ describe('Ensure metadata', () => {
       expect(metadata.originalFn!(1)).toEqual(1); // state => state
 
       expect(metadata.getSelectorOptions()).toEqual({});
-      expect(metadata.selectFromAppState).toEqual(getSelectorFn(CountState.selectFn));
+      expect(metadata.makeRootSelector).toEqual(getRootSelectorFactory(CountState.selectFn));
     });
 
     it('should get the selector meta data from the CountState.canInheritSelectFn, MyCounterState.canInheritSelectFn', () => {
@@ -128,12 +130,12 @@ describe('Ensure metadata', () => {
       expect(countMetadata.getSelectorOptions()).toEqual({ suppressErrors: false });
       expect(myCounterMetadata.getSelectorOptions()).toEqual({ suppressErrors: false });
 
-      expect(countMetadata.selectFromAppState).toEqual(
-        getSelectorFn(CountState.canInheritSelectFn)
+      expect(countMetadata.makeRootSelector).toEqual(
+        getRootSelectorFactory(CountState.canInheritSelectFn)
       );
 
-      expect(myCounterMetadata.selectFromAppState).toEqual(
-        getSelectorFn(MyCounterState.canInheritSelectFn)
+      expect(myCounterMetadata.makeRootSelector).toEqual(
+        getRootSelectorFactory(MyCounterState.canInheritSelectFn)
       );
     });
 

--- a/packages/store/tests/ensure-store.spec.ts
+++ b/packages/store/tests/ensure-store.spec.ts
@@ -71,7 +71,6 @@ describe('Ensure metadata', () => {
         },
         defaults: 0,
         path: null,
-        selectFromAppState: expect.any(Function),
         makeRootSelector: expect.any(Function),
         children: [MyCounterState]
       });
@@ -83,7 +82,6 @@ describe('Ensure metadata', () => {
         actions: { decrement: [{ fn: 'decrement', options: {}, type: 'decrement' }] },
         defaults: 1,
         path: null,
-        selectFromAppState: expect.any(Function),
         makeRootSelector: expect.any(Function),
         children: undefined
       });
@@ -95,7 +93,7 @@ describe('Ensure metadata', () => {
     });
 
     it('should get the selector meta data from the CountState.selectFn', () => {
-      const metadata: SelectorMetaDataModel = getSelectorMetadata(CountState.selectFn);
+      const metadata = <SelectorMetaDataModel>getSelectorMetadata(CountState.selectFn);
 
       expect(metadata.selectorName).toEqual('selectFn');
       expect(metadata.containerClass).toEqual(CountState);
@@ -108,12 +106,12 @@ describe('Ensure metadata', () => {
     });
 
     it('should get the selector meta data from the CountState.canInheritSelectFn, MyCounterState.canInheritSelectFn', () => {
-      const countMetadata: SelectorMetaDataModel = getSelectorMetadata(
-        CountState.canInheritSelectFn
+      const countMetadata = <SelectorMetaDataModel>(
+        getSelectorMetadata(CountState.canInheritSelectFn)
       );
 
-      const myCounterMetadata: SelectorMetaDataModel = getSelectorMetadata(
-        MyCounterState.canInheritSelectFn
+      const myCounterMetadata = <SelectorMetaDataModel>(
+        getSelectorMetadata(MyCounterState.canInheritSelectFn)
       );
 
       expect(countMetadata.selectorName).toEqual('canInheritSelectFn');
@@ -154,8 +152,8 @@ describe('Ensure metadata', () => {
           }
         }
 
-        const metadata: SelectorMetaDataModel = getSelectorMetadata(
-          SuperCountState.canInheritSelectFn
+        const metadata = <SelectorMetaDataModel>(
+          getSelectorMetadata(SuperCountState.canInheritSelectFn)
         );
 
         expect(metadata.containerClass).toEqual(SuperCountState);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: N/A

There was still an aspect of dependency on shared state with selector options. This could cause interactions between tests where the root level selector options differs. This PR resolves this issue.

## What is the new behavior?

The selector function is no longer stored in the metadata but rather a factory function for creating selectors given a supplied runtime context. This solves many runtime workarounds that existed for the selector options.

## Does this PR introduce a breaking change?

```
[X] Yes
[ ] No
```
The selector and state metadata no longer has a `selectFromAppState` method. Although this is technically a breaking change there are no usages of this internal method by any plugins as far as a github search can determine. If it does become an issue there is a workaround that we can give to the plugin author.

Although there is an aspect of a breaking change this is of an internal metadata structure and as such will not affect the semantic versioning.

## Other information
