### PR TITLE
fix: selectors should not be declaration order sensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 $ npm install @ngxs/store@dev
 ```
 
+- Fix: Selectors should not be declaration order sensitive [#1514](https://github.com/ngxs/store/pull/1514)
 - Fix: Selectors should be deterministic based on store being used [#1508](https://github.com/ngxs/store/pull/1508)
 - Fix: Add support for using State Tokens in sub states [#1509](https://github.com/ngxs/store/pull/1509)
 - Fix: Optimize selector runtime binding [#1510](https://github.com/ngxs/store/pull/1510)

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -32,14 +32,14 @@
       "path": "./@ngxs/store/fesm2015/ngxs-store.js",
       "package": "@ngxs/store",
       "target": "es2015",
-      "maxSize": "110.750KB",
+      "maxSize": "110.380KB",
       "compression": "none"
     },
     {
       "path": "./@ngxs/store/fesm5/ngxs-store.js",
       "package": "@ngxs/store",
       "target": "es5",
-      "maxSize": "130.180KB",
+      "maxSize": "129.830KB",
       "compression": "none"
     },
     {

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -32,14 +32,14 @@
       "path": "./@ngxs/store/fesm2015/ngxs-store.js",
       "package": "@ngxs/store",
       "target": "es2015",
-      "maxSize": "110.380KB",
+      "maxSize": "110.390KB",
       "compression": "none"
     },
     {
       "path": "./@ngxs/store/fesm5/ngxs-store.js",
       "package": "@ngxs/store",
       "target": "es5",
-      "maxSize": "129.830KB",
+      "maxSize": "129.840KB",
       "compression": "none"
     },
     {

--- a/docs/concepts/select.md
+++ b/docs/concepts/select.md
@@ -213,12 +213,9 @@ For instance, I can have a Dynamic Selector that will filter my pandas to the pr
 })
 export class ZooState {
   static pandas(type: string) {
-    return createSelector(
-      [ZooState],
-      (state: string[]) => {
-        return state.filter(s => s.indexOf('panda') > -1).filter(s => s.indexOf(type) > -1);
-      }
-    );
+    return createSelector([ZooState], (state: string[]) => {
+      return state.filter(s => s.indexOf('panda') > -1).filter(s => s.indexOf(type) > -1);
+    });
   }
 }
 ```
@@ -252,12 +249,9 @@ An interesting use case would be to allow for a selector to be reused to select 
 ```ts
 export class SharedSelectors {
   static getEntities(stateClass) {
-    return createSelector(
-      [stateClass],
-      (state: { entities: any[] }) => {
-        return state.entities;
-      }
-    );
+    return createSelector([stateClass], (state: { entities: any[] }) => {
+      return state.entities;
+    });
   }
 }
 ```
@@ -364,97 +358,7 @@ now we can use this `zooThemeParks` selector anywhere in our application.
 
 ### The Order of Interacting Selectors
 
-This topic may be helpful for those users who keep their selectors in separate classes. Let's look at the code below:
-
-```ts
-// counter.state.ts
-export interface CounterStateModel {
-  counter: number;
-}
-
-@State<CounterStateModel>({
-  name: 'counter',
-  defaults: {
-    counter: 0
-  }
-})
-export class CounterState {}
-
-// counter.query.ts
-export class CounterQuery {
-  @Selector([CounterQuery.getCounter])
-  static getCounterCube(counter: number): number {
-    return counter ** 3;
-  }
-
-  // Note: this selector being declared after its usage will cause an issue!!!
-  @Selector([CounterState])
-  static getCounter(state: CounterStateModel): number {
-    return state.counter;
-  }
-
-  @Selector([CounterQuery.getCounter])
-  static getCounterSquare(counter: number): number {
-    return counter ** 2;
-  }
-}
-```
-
-As you see in the code above there is a reusable selector `getCounter` that returns the `counter` property from the whole state. The `getCounter` selector is used by 2 other selectors `getCounterSquare` and `getCounterCube`. The snag lies in the `getCounterCube` selector because it's declared before the `getCounter` selector. Let's look at the code emitted by the TypeScript compiler:
-
-```ts
-__decorate([Selector([CounterQuery.getCounter])], CounterQuery, 'getCounterCube', null);
-__decorate([Selector([CounterState])], CounterQuery, 'getCounter', null);
-__decorate([Selector([CounterQuery.getCounter])], CounterQuery, 'getCounterSquare', null);
-```
-
-The `@Selector` decorator tries to access the `getCounter` selector that hasn't been decorated yet. How could we fix it? We have to change the order of selectors:
-
-```ts
-export class CounterQuery {
-  @Selector([CounterState])
-  static getCounter(state: CounterStateModel): number {
-    return state.counter;
-  }
-
-  @Selector([CounterQuery.getCounter])
-  static getCounterCube(counter: number): number {
-    return counter ** 3;
-  }
-
-  @Selector([CounterQuery.getCounter])
-  static getCounterSquare(counter: number): number {
-    return counter ** 2;
-  }
-}
-```
-
-Another solution could be the usage of the `createSelector` function rather than changing the order:
-
-```ts
-export class CounterQuery {
-  static getCounterCube() {
-    return createSelector(
-      [CounterQuery.getCounter()],
-      (counter: number) => counter ** 3
-    );
-  }
-
-  static getCounter() {
-    return createSelector(
-      [CounterState],
-      (state: CounterStateModel) => state.counter
-    );
-  }
-
-  static getCounterSquare() {
-    return createSelector(
-      [CounterQuery.getCounter()],
-      (counter: number) => counter ** 2
-    );
-  }
-}
-```
+In versions of NGXS prior to 3.6.1 there was an issue where the order which the selectors were declared would matter. This was fixed in PR [#1514](https://github.com/ngxs/store/pull/1514) and selectors can now be declared in any arbitrary order.
 
 ### Inheriting Selectors
 
@@ -463,12 +367,9 @@ When we have states that share similar structure, we can extract the shared sele
 ```ts
 export class EntitiesState {
   static entities<T>(): T[] {
-    return createSelector(
-      [this],
-      (state: { entities: T[] }) => {
-        return state.entities;
-      }
-    );
+    return createSelector([this], (state: { entities: T[] }) => {
+      return state.entities;
+    });
   }
 
   //...
@@ -559,12 +460,9 @@ export class ZooState {
   }
 
   static bees(type: string) {
-    return createSelector(
-      [ZooState],
-      (state: string[]) => {
-        return state.filter(s => s.indexOf('bee') > -1).filter(s => s.indexOf(type) > -1);
-      }
-    );
+    return createSelector([ZooState], (state: string[]) => {
+      return state.filter(s => s.indexOf('bee') > -1).filter(s => s.indexOf(type) > -1);
+    });
   }
 }
 ```
@@ -593,12 +491,9 @@ export class ZooState {
   }
 
   static bees(type: string) {
-    const selector = createSelector(
-      [ZooState],
-      (state: string[]) => {
-        return state.filter(s => s.indexOf('bee') > -1).filter(s => s.indexOf(type) > -1);
-      }
-    );
+    const selector = createSelector([ZooState], (state: string[]) => {
+      return state.filter(s => s.indexOf('bee') > -1).filter(s => s.indexOf(type) > -1);
+    });
     return selector;
   }
 }

--- a/packages/store/src/decorators/selector/selector.ts
+++ b/packages/store/src/decorators/selector/selector.ts
@@ -18,24 +18,16 @@ export function Selector<T>(selectors?: T[]): SelectorType<T> {
     }
 
     const originalFn = descriptor.value;
-    let memoizedFn: any = null;
+    const memoizedFn = createSelector(selectors, originalFn as any, {
+      containerClass: target,
+      selectorName: key.toString(),
+      getSelectorOptions() {
+        return {};
+      }
+    });
     const newDescriptor = {
       configurable: true,
       get() {
-        // Selector initialisation deferred to here so that it is at runtime, not decorator parse time
-        memoizedFn =
-          memoizedFn ||
-          createSelector(
-            selectors,
-            originalFn as any,
-            {
-              containerClass: target,
-              selectorName: key.toString(),
-              getSelectorOptions() {
-                return {};
-              }
-            }
-          );
         return memoizedFn;
       }
     };

--- a/packages/store/src/utils/selector-utils.ts
+++ b/packages/store/src/utils/selector-utils.ts
@@ -55,7 +55,9 @@ export function createSelector<T extends (...args: any[]) => any>(
     return returnValue;
   } as T;
   const memoizedFn = memoize(wrappedFn);
-  const selectorMetaData = setupSelectorMetadata<T>(memoizedFn, originalFn, creationMetadata);
+  Object.setPrototypeOf(memoizedFn, originalFn);
+
+  const selectorMetaData = setupSelectorMetadata<T>(originalFn, creationMetadata);
 
   const makeRootSelector: SelectorFactory = (context: RuntimeSelectorContext) => {
     const { argumentSelectorFunctions, selectorOptions } = getRuntimeSelectorInfo(
@@ -89,11 +91,10 @@ export function createSelector<T extends (...args: any[]) => any>(
 }
 
 function setupSelectorMetadata<T extends (...args: any[]) => any>(
-  memoizedFn: T,
   originalFn: T,
   creationMetadata: CreationMetadata | undefined
 ) {
-  const selectorMetaData = ensureSelectorMetadata(memoizedFn);
+  const selectorMetaData = ensureSelectorMetadata(originalFn);
   selectorMetaData.originalFn = originalFn;
   let getExplicitSelectorOptions = () => ({});
   if (creationMetadata) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1340, #1392, #1242, #1143 

There has been a long-standing issue with selectors where they don't work correctly if declared in an arbitrary order. The user was forced to declare referenced selectors in a class before their usage. This was even added to the docs because a solution was not possible... until now...

## What is the new behavior?
With the new internal structure of selectors and how they are given a runtime context by the store at the last possible moment the selectors could be improved to remove this order dependency. 

The one key trick to get this working was to add the selector metadata to the original function and set the prototype of the memoized function to be the original function. This allowed both the memoized function and the original function to share the exact same property descriptor for the metadata. This resolved the order dependency because the metadata becomes available from either the original or the memoized function.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
