### PR TITLE
perf(logger): lazy inject the store once only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 $ npm install @ngxs/store@dev
 ```
 
-- Feature: Storage plugin - Add before and after serialize hooks [#1513](https://github.com/ngxs/store/pull/1513)
+- Feature: Storage Plugin - Add before and after serialize hooks [#1513](https://github.com/ngxs/store/pull/1513)
+- Performance: Logger Plugin - Plugin should lazy inject the store once [#1550](https://github.com/ngxs/store/pull/1550)
 
 # 3.6.2 2020-02-07
 

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -88,14 +88,14 @@
       "path": "./@ngxs/logger-plugin/fesm2015/ngxs-logger-plugin.js",
       "package": "@ngxs/logger-plugin",
       "target": "es2015",
-      "maxSize": "10.425KB",
+      "maxSize": "10.610KB",
       "compression": "none"
     },
     {
       "path": "./@ngxs/logger-plugin/fesm5/ngxs-logger-plugin.js",
       "package": "@ngxs/logger-plugin",
       "target": "es5",
-      "maxSize": "12.110KB",
+      "maxSize": "12.291KB",
       "compression": "none"
     },
     {

--- a/packages/logger-plugin/src/logger.plugin.ts
+++ b/packages/logger-plugin/src/logger.plugin.ts
@@ -9,6 +9,9 @@ import { LogWriter } from './log-writer';
 
 @Injectable()
 export class NgxsLoggerPlugin implements NgxsPlugin {
+  private store: Store;
+  private logWriter: LogWriter;
+
   constructor(
     @Inject(NGXS_LOGGER_PLUGIN_OPTIONS) private _options: NgxsLoggerPluginOptions,
     private _injector: Injector
@@ -19,11 +22,11 @@ export class NgxsLoggerPlugin implements NgxsPlugin {
       return next(state, event);
     }
 
-    const logWriter = new LogWriter(this._options);
+    this.logWriter = this.logWriter || new LogWriter(this._options);
     // Retrieve lazily to avoid cyclic dependency exception
-    const store = this._injector.get<Store>(Store);
+    this.store = this.store || this._injector.get<Store>(Store);
 
-    const actionLogger = new ActionLogger(event, store, logWriter);
+    const actionLogger = new ActionLogger(event, this.store, this.logWriter);
 
     actionLogger.dispatched(state);
 

--- a/packages/logger-plugin/src/logger.plugin.ts
+++ b/packages/logger-plugin/src/logger.plugin.ts
@@ -9,8 +9,8 @@ import { LogWriter } from './log-writer';
 
 @Injectable()
 export class NgxsLoggerPlugin implements NgxsPlugin {
-  private store: Store;
-  private logWriter: LogWriter;
+  private _store: Store;
+  private _logWriter: LogWriter;
 
   constructor(
     @Inject(NGXS_LOGGER_PLUGIN_OPTIONS) private _options: NgxsLoggerPluginOptions,
@@ -22,11 +22,11 @@ export class NgxsLoggerPlugin implements NgxsPlugin {
       return next(state, event);
     }
 
-    this.logWriter = this.logWriter || new LogWriter(this._options);
+    this._logWriter = this._logWriter || new LogWriter(this._options);
     // Retrieve lazily to avoid cyclic dependency exception
-    this.store = this.store || this._injector.get<Store>(Store);
+    this._store = this._store || this._injector.get<Store>(Store);
 
-    const actionLogger = new ActionLogger(event, this.store, this.logWriter);
+    const actionLogger = new ActionLogger(event, this._store, this._logWriter);
 
     actionLogger.dispatched(state);
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: performance tweak
```

## What is the current behavior?

I noticed that the logger was injecting the store on every single dispatched action. 
This is not ideal.

## What is the new behavior?
Initialize the store reference lazily only once.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
