### PR TITLE
docs: add @Injectable above every state class declaration

### DIFF
--- a/docs/advanced/action-handlers.md
+++ b/docs/advanced/action-handlers.md
@@ -45,6 +45,7 @@ Below is a action handler that filters for `RouteNavigate` actions and then tell
 route.
 
 ```ts
+import { Injectable } from '@angular/core';
 import { Actions, ofActionDispatched } from '@ngxs/store';
 
 @Injectable({ providedIn: 'root' })

--- a/docs/advanced/actions-life-cycle.md
+++ b/docs/advanced/actions-life-cycle.md
@@ -144,6 +144,7 @@ export class GetDetectives {
     detectives: []
   }
 })
+@Injectable()
 export class BooksState {
   constructor(private booksService: BooksService) {}
 

--- a/docs/advanced/cancellation.md
+++ b/docs/advanced/cancellation.md
@@ -8,6 +8,7 @@ This is useful for canceling previous requests like in a typeahead.
 For basic scenarios, we can use the `cancelUncompleted` action decorator option.
 
 ```ts
+import { Injectable } from '@angular/core';
 import { State, Action } from '@ngxs/store';
 
 @State<ZooStateModel>({
@@ -15,6 +16,7 @@ import { State, Action } from '@ngxs/store';
     animals: []
   }
 })
+@Injectable()
 export class ZooState {
   constructor(private animalService: AnimalService, private actions$: Actions) {}
 
@@ -32,6 +34,7 @@ export class ZooState {
 For more advanced cases, we can use normal Rx operators.
 
 ```ts
+import { Injectable } from '@angular/core';
 import { State, Action, Actions, ofAction } from '@ngxs/store';
 import { tap } from 'rxjs/operators';
 
@@ -40,6 +43,7 @@ import { tap } from 'rxjs/operators';
     animals: []
   }
 })
+@Injectable()
 export class ZooState {
   constructor(private animalService: AnimalService, private actions$: Actions) {}
 

--- a/docs/advanced/composition.md
+++ b/docs/advanced/composition.md
@@ -9,6 +9,7 @@ You can compose multiple stores together using class inheritance. This is quite 
     type: null
   }
 })
+@Injectable()
 class ZooState {
   @Action(Eat)
   eat(ctx: StateContext) {
@@ -19,6 +20,7 @@ class ZooState {
 @State({
   name: 'stlzoo'
 })
+@Injectable()
 class StLouisZooState extends ZooState {
   @Action(Drink)
   drink(ctx: StateContext) {

--- a/docs/advanced/lazy.md
+++ b/docs/advanced/lazy.md
@@ -23,6 +23,7 @@ How are feature states added to the global state graph? Assume you've got a `Zoo
   name: 'zoos',
   defaults: []
 })
+@Injectable()
 export class ZoosState {}
 ```
 
@@ -33,6 +34,7 @@ And it's registered in the root module via `NgxsModule.forRoot([ZoosState])`. As
   name: 'offices',
   defaults: []
 })
+@Injectable()
 export class OfficesState {}
 ```
 

--- a/docs/advanced/life-cycle.md
+++ b/docs/advanced/life-cycle.md
@@ -17,6 +17,7 @@ export interface ZooStateModel {
     animals: []
   }
 })
+@Injectable()
 export class ZooState implements NgxsOnChanges {
   ngxsOnChanges(change: NgxsSimpleChange) {
     console.log('prev state', change.previousValue);
@@ -43,6 +44,7 @@ export interface ZooStateModel {
     animals: []
   }
 })
+@Injectable()
 export class ZooState implements NgxsOnInit {
   ngxsOnInit(ctx: StateContext<ZooStateModel>) {
     console.log('State initialized, now getting animals');
@@ -66,6 +68,7 @@ export interface ZooStateModel {
     animals: []
   }
 })
+@Injectable()
 export class ZooState implements NgxsAfterBootstrap {
   ngxsAfterBootstrap(ctx: StateContext<ZooStateModel>) {
     console.log('The application has been fully rendered');
@@ -185,6 +188,7 @@ export class ConfigService {
   name: 'version',
   defaults: null
 })
+@Injectable()
 export class VersionState implements NgxsOnInit {
   constructor(private configService: ConfigService) {}
 
@@ -222,6 +226,7 @@ There are different solutions. Let's look at the simplest. The first solution wo
   name: 'version',
   defaults: null
 })
+@Injectable()
 export class VersionState implements NgxsAfterBootstrap {
   constructor(private configService: ConfigService) {}
 
@@ -243,6 +248,7 @@ export class SetVersion {
   name: 'version',
   defaults: null
 })
+@Injectable()
 export class VersionState {
   @Action(SetVersion)
   setVersion(ctx: StateContext<string | null>, action: SetVersion): void {

--- a/docs/advanced/mapped-sub-states.md
+++ b/docs/advanced/mapped-sub-states.md
@@ -18,23 +18,18 @@ interface Animal {
     { type: 'panda', age: 'young', name: 'Jimmy' }
   ]
 })
+@Injectable()
 export class ZooState {
   static pandas(age: string) {
-    return createSelector(
-      [ZooState],
-      (state: Animal[]) => {
-        return state.filter(animal => animal.type === 'panda' && animal.age === age);
-      }
-    );
+    return createSelector([ZooState], (state: Animal[]) => {
+      return state.filter(animal => animal.type === 'panda' && animal.age === age);
+    });
   }
 
   static zebras(age: string) {
-    return createSelector(
-      [ZooState],
-      (state: Animal[]) => {
-        return state.filter(animal => animal.type === 'zebra' && animal.age === age);
-      }
-    );
+    return createSelector([ZooState], (state: Animal[]) => {
+      return state.filter(animal => animal.type === 'zebra' && animal.age === age);
+    });
   }
 
   static pandasAndZebras(age: string) {
@@ -78,32 +73,24 @@ interface ZooStateModel {
     }
   }
 })
+@Injectable()
 export class ZooState {
   static getZooAnimals(zooName: string) {
-    return createSelector(
-      [ZooState],
-      (state: ZooStateModel[]) => state[zooName].animals
-    );
+    return createSelector([ZooState], (state: ZooStateModel[]) => state[zooName].animals);
   }
 
   static pandas(zooName: string) {
-    return createSelector(
-      [ZooState.getAnimals(zooName)],
-      (state: Animal[]) => {
-        return state.filter(animal => animal.type === 'panda' && animal.age === 'young');
-      }
-    );
+    return createSelector([ZooState.getAnimals(zooName)], (state: Animal[]) => {
+      return state.filter(animal => animal.type === 'panda' && animal.age === 'young');
+    });
   }
 
   static pandasWithoutMemoize(zooName: string) {
-    return createSelector(
-      [ZooState],
-      (state: ZooStateModel) => {
-        return state[zooName].animals.filter(
-          animal => animal.type === 'panda' && animal.age === 'young'
-        );
-      }
-    );
+    return createSelector([ZooState], (state: ZooStateModel) => {
+      return state[zooName].animals.filter(
+        animal => animal.type === 'panda' && animal.age === 'young'
+      );
+    });
   }
 }
 ```

--- a/docs/advanced/operators.md
+++ b/docs/advanced/operators.md
@@ -13,6 +13,7 @@ The basic idea of operators is that we could describe the modifications to the s
 From theory to practice - let's take the following example:
 
 ```ts
+import { Injectable } from '@angular/core';
 import { State, Action, StateContext } from '@ngxs/store';
 import { patch } from '@ngxs/store/operators';
 
@@ -33,6 +34,7 @@ export class CreateMonkeys {
     pandas: []
   }
 })
+@Injectable()
 export class AnimalsState {
   @Action(CreateMonkeys)
   createMonkeys(ctx: StateContext<AnimalsStateModel>) {
@@ -111,6 +113,7 @@ These operators introduce a new way of declarative state mutation.
 Let's look at more advanced examples:
 
 ```ts
+import { Injectable } from '@angular/core';
 import { State, Action, StateContext } from '@ngxs/store';
 import { patch, append, removeItem, insertItem, updateItem } from '@ngxs/store/operators';
 
@@ -141,6 +144,7 @@ export class ChangePandaName {
     pandas: ['Michael', 'John']
   }
 })
+@Injectable()
 export class AnimalsState {
   @Action(AddZebra)
   addZebra(ctx: StateContext<AnimalsStateModel>, { payload }: AddZebra) {
@@ -198,6 +202,7 @@ interface CitiesStateModel {
     ids: []
   }
 })
+@Injectable()
 export class CitiesState {
   @Action(AddCity)
   addCity(ctx: StateContext<CitiesStateModel>, { payload }: AddCity) {

--- a/docs/advanced/shared-state.md
+++ b/docs/advanced/shared-state.md
@@ -15,6 +15,7 @@ preferences in order to be able to sort your animals. This is achievable with `s
     sort: [{ prop: 'name', dir: 'asc' }]
   }
 })
+@Injectable()
 export class PreferencesState {
   @Selector()
   static getSort(state: PreferencesStateModel) {
@@ -28,6 +29,7 @@ export class PreferencesState {
     animals: []
   ]
 })
+@Injectable()
 export class AnimalState {
 
   constructor(private store: Store) {}

--- a/docs/advanced/sub-states.md
+++ b/docs/advanced/sub-states.md
@@ -48,6 +48,7 @@ export interface CartStateModel {
   },
   children: [CartSavedState]
 })
+@Injectable()
 export class CartState {}
 ```
 
@@ -66,6 +67,7 @@ export interface CartSavedStateModel {
     items: []
   }
 })
+@Injectable()
 export class CartSavedState {}
 ```
 
@@ -127,6 +129,7 @@ export class SetCheckedoutAndItems {
   },
   children: [CartSavedState]
 })
+@Injectable()
 export class CartState {
   @Action(SetCheckedoutAndItems)
   setCheckedoutAndItems(

--- a/docs/advanced/token.md
+++ b/docs/advanced/token.md
@@ -27,6 +27,7 @@ const TODOS_STATE_TOKEN = new StateToken<TodoStateModel[]>('todos');
   name: TODOS_STATE_TOKEN,
   defaults: []
 })
+@Injectable()
 class TodosState {
   // ...
 }
@@ -48,6 +49,7 @@ const TODOS_STATE_TOKEN = new StateToken<TodoStateModel[]>('todos');
   name: TODOS_STATE_TOKEN,
   defaults: [] // if you specify the wrong state type, will be a compilation error
 })
+@Injectable()
 class TodosState {
   @Selector([TODOS_STATE_TOKEN]) // if you specify the wrong state type, will be a compilation error
   static completedList(state: TodoStateModel[]): TodoStateModel[] {
@@ -65,6 +67,7 @@ const TODOS_STATE_TOKEN = new StateToken<TodoStateModel[]>('todos');
   name: TODOS_STATE_TOKEN,
   defaults: {} // compilation error - array was expected, inferred from the token type
 })
+@Injectable()
 class TodosState {
   @Selector([TODOS_STATE_TOKEN]) // compilation error - TodoStateModel[] does not match string[]
   static completedList(state: string[]): string[] {

--- a/docs/concepts/select.md
+++ b/docs/concepts/select.md
@@ -96,12 +96,14 @@ the state portion you are dealing with.
 Let's create a selector that will return a list of pandas from the animals.
 
 ```ts
+import { Injectable } from '@angular/core';
 import { State, Selector } from '@ngxs/store';
 
 @State<string[]>({
   name: 'animals',
   defaults: []
 })
+@Injectable()
 export class ZooState {
   @Selector()
   static pandas(state: string[]) {
@@ -172,6 +174,7 @@ For instance, I can have a Lazy Selector that will filter my pandas to the provi
   name: 'animals',
   defaults: []
 })
+@Injectable()
 export class ZooState {
   @Selector()
   static pandas(state: string[]) {
@@ -211,6 +214,7 @@ For instance, I can have a Dynamic Selector that will filter my pandas to the pr
   name: 'animals',
   defaults: []
 })
+@Injectable()
 export class ZooState {
   static pandas(type: string) {
     return createSelector([ZooState], (state: string[]) => {
@@ -281,9 +285,11 @@ If you do not change the Selector Options (see [above](#selector-options)) then 
 
 ```ts
 @State<PreferencesStateModel>({ ... })
+@Injectable()
 export class PreferencesState { ... }
 
 @State<string[]>({ ... })
+@Injectable()
 export class ZooState {
 
   @Selector([PreferencesState])
@@ -309,9 +315,11 @@ In NGXS v4 and above the default value of the [`injectContainerState`](#injectco
 
 ```ts
 @State<PreferencesStateModel>({ ... })
+@Injectable()
 export class PreferencesState { ... }
 
 @State<string[]>({ ... })
+@Injectable()
 export class ZooState {
 
  @Selector([ZooState, PreferencesState])
@@ -389,6 +397,7 @@ export interface UsersStateModel {
     entities: []
   }
 })
+@Injectable()
 export class UsersState extends EntitiesState {
   //...
 }
@@ -403,6 +412,7 @@ export interface ProductsStateModel {
     entities: []
   }
 })
+@Injectable()
 export class ProductsState extends EntitiesState {
   //...
 }
@@ -446,6 +456,7 @@ This error would be reported for each of the selectors defined below but, as dem
   name: 'animals',
   defaults: ['panda', 'horse', 'bee']
 })
+@Injectable()
 export class ZooState {
   @Selector()
   static pandas(state: string[]) {
@@ -475,6 +486,7 @@ See https://github.com/ng-packagr/ng-packagr/issues/696#issuecomment-387114613
   name: 'animals',
   defaults: ['panda', 'horse', 'bee']
 })
+@Injectable()
 export class ZooState {
   @Selector()
   static pandas(state: string[]) {

--- a/docs/concepts/state.md
+++ b/docs/concepts/state.md
@@ -9,12 +9,14 @@ and action mappings. To define a state container, let's create an
 ES2015 class and decorate it with the `State` decorator.
 
 ```ts
+import { Injectable } from '@angular/core';
 import { State } from '@ngxs/store';
 
 @State<string[]>({
   name: 'animals',
   defaults: []
 })
+@Injectable()
 export class AnimalsState {}
 ```
 
@@ -36,6 +38,7 @@ so all you need to do is inject your dependencies in the constructor.
     feed: false
   }
 })
+@Injectable()
 export class ZooState {
   constructor(private zooService: ZooService) {}
 }
@@ -54,6 +57,7 @@ const ZOO_STATE_TOKEN = new StateToken<ZooStateModel>('zoo');
     feed: false
   }
 })
+@Injectable()
 export class ZooState {
   constructor(private zooService: ZooService) {}
 }
@@ -71,6 +75,7 @@ accepts an action class or an array of action classes.
 Let's define a state that will listen to a `FeedAnimals` action to toggle whether the animals have been fed:
 
 ```ts
+import { Injectable } from '@angular/core';
 import { State, Action, StateContext } from '@ngxs/store';
 
 export class FeedAnimals {
@@ -87,6 +92,7 @@ export interface ZooStateModel {
     feed: false
   }
 })
+@Injectable()
 export class ZooState {
   @Action(FeedAnimals)
   feedAnimals(ctx: StateContext<ZooStateModel>) {
@@ -113,6 +119,7 @@ Actions can also pass along metadata that has to do with the action.
 Say we want to pass along how much hay and carrots each zebra needs.
 
 ```ts
+import { Injectable } from '@angular/core';
 import { State, Action, StateContext } from '@ngxs/store';
 
 // This is an interface that is part of your domain model
@@ -139,6 +146,7 @@ export interface ZooStateModel {
     zebraFood: []
   }
 })
+@Injectable()
 export class ZooState {
   @Action(FeedZebra)
   feedZebra(ctx: StateContext<ZooStateModel>, action: FeedZebra) {
@@ -253,6 +261,7 @@ we give you the flexibility to make that decision yourself based on your require
 Let's take a look at a simple async action:
 
 ```ts
+import { Injectable } from '@angular/core';
 import { State, Action, StateContext } from '@ngxs/store';
 import { tap } from 'rxjs/operators';
 
@@ -271,6 +280,7 @@ export interface ZooStateModel {
     feedAnimals: []
   }
 })
+@Injectable()
 export class ZooState {
   constructor(private animalService: AnimalService) {}
 
@@ -303,6 +313,7 @@ Observables are not a requirement, you can use promises too. We could swap
 that observable chain to look like this:
 
 ```ts
+import { Injectable } from '@angular/core';
 import { State, Action } from '@ngxs/store';
 
 export class FeedAnimals {
@@ -320,6 +331,7 @@ export interface ZooStateModel {
     feedAnimals: []
   }
 })
+@Injectable()
 export class ZooState {
   constructor(private animalService: AnimalService) {}
 
@@ -341,6 +353,7 @@ If you want your action to dispatch another action, you can use the `dispatch` f
 that is contained in the state context object.
 
 ```ts
+import { Injectable } from '@angular/core';
 import { State, Action, StateContext } from '@ngxs/store';
 import { map } from 'rxjs/operators';
 
@@ -354,6 +367,7 @@ export interface ZooStateModel {
     feedAnimals: []
   }
 })
+@Injectable()
 export class ZooState {
   constructor(private animalService: AnimalService) {}
 

--- a/docs/plugins/form.md
+++ b/docs/plugins/form.md
@@ -51,6 +51,7 @@ export class SomeModule {}
 Define your default form state as part of your application state.
 
 ```ts
+import { Injectable } from '@angular/core';
 import { State } from '@ngxs/store';
 
 @State({
@@ -64,6 +65,7 @@ import { State } from '@ngxs/store';
     }
   }
 })
+@Injectable()
 export class NovelsState {}
 ```
 
@@ -153,6 +155,7 @@ interface NovelsStateModel {
     }
   }
 })
+@Injectable()
 export class NovelsState {}
 ```
 

--- a/docs/plugins/hmr.md
+++ b/docs/plugins/hmr.md
@@ -168,6 +168,7 @@ If you want to do some modifications to the state during the hmr lifecycle you c
 import { HmrInitAction, HmrBeforeDestroyAction } from '@ngxs/hmr-plugin';
 
 @State({ ... })
+@Injectable()
 export class MyState {
   @Action(HmrInitAction)
   public hmrInit(ctx: StateContext, { payload }) {

--- a/docs/plugins/storage.md
+++ b/docs/plugins/storage.md
@@ -48,6 +48,7 @@ The `key` option is used to determine what states should be persisted in the sto
   name: 'novels',
   defaults: []
 })
+@Injectable()
 export class NovelsState {}
 
 // detectives.state.ts
@@ -55,6 +56,7 @@ export class NovelsState {}
   name: 'detectives',
   defaults: []
 })
+@Injectable()
 export class DetectivesState {}
 ```
 

--- a/docs/plugins/websocket.md
+++ b/docs/plugins/websocket.md
@@ -73,6 +73,7 @@ export interface Message {
   name: 'messages',
   defaults: []
 })
+@Injectable()
 export class MessagesState {
   @Action(AddMessage)
   addMessage(ctx: StateContext<Message[]>, { from, message }: AddMessage) {

--- a/docs/recipes/cache.md
+++ b/docs/recipes/cache.md
@@ -8,6 +8,7 @@ using the store's current values and returning them instead of calling the HTTP
 service.
 
 ```ts
+import { Injectable } from '@angular/core';
 import { State, Action, StateContext } from '@ngxs/store';
 import { tap } from 'rxjs/operators';
 
@@ -36,6 +37,7 @@ We want to load this information only once. Let's create a state and call it `no
 the object whose keys are the identifiers of the novels:
 
 ```ts
+import { Injectable } from '@angular/core';
 import { State, Action, StateContext, createSelector } from '@ngxs/store';
 import { tap } from 'rxjs/operators';
 
@@ -52,12 +54,10 @@ export class GetNovelById {
   name: 'novelsInfo',
   defaults: {}
 })
+@Injectable()
 export class NovelsInfoState {
   static getNovelById(id: string) {
-    return createSelector(
-      [NovelsInfoState],
-      (state: NovelsInfoStateModel) => state[id]
-    );
+    return createSelector([NovelsInfoState], (state: NovelsInfoStateModel) => state[id]);
   }
 
   constructor(private novelsService: NovelsService) {}

--- a/docs/recipes/style-guide.md
+++ b/docs/recipes/style-guide.md
@@ -63,6 +63,7 @@ export class Todo {
   name: 'todos',
   defaults: []
 })
+@Injectable()
 class TodosState {
   @Action(AddTodo)
   add(ctx: StateContext<Todo[]>, action: AddTodo): void {
@@ -98,6 +99,7 @@ export interface TodoModel {
   name: 'todos',
   defaults: []
 })
+@Injectable()
 class TodosState {
   @Action(AddTodo)
   add(ctx: StateContext<TodoModel[]>, action: AddTodo): void {
@@ -147,6 +149,7 @@ export interface GridCollectionStateModel {
     id: -1
   }
 })
+@Injectable()
 export class RowState {}
 
 @State<GridStateModel>({
@@ -156,6 +159,7 @@ export class RowState {}
     rows: new Map<number, RowState>()
   }
 })
+@Injectable()
 export class GridState {}
 
 @State<GridCollectionStateModel>({
@@ -164,6 +168,7 @@ export class GridState {}
     grids: new Map<number, GridState>()
   }
 })
+@Injectable()
 export class GridCollectionState {}
 ```
 
@@ -195,6 +200,7 @@ export interface GridCollectionStateModel {
     id: -1
   }
 })
+@Injectable()
 export class RowState {}
 
 @State<GridStateModel>({
@@ -204,6 +210,7 @@ export class RowState {}
     rows: {}
   }
 })
+@Injectable()
 export class GridState {}
 
 @State<GridCollectionStateModel>({
@@ -212,5 +219,6 @@ export class GridState {}
     grids: {}
   }
 })
+@Injectable()
 export class GridCollectionState {}
 ```

--- a/docs/recipes/unit-testing.md
+++ b/docs/recipes/unit-testing.md
@@ -97,10 +97,8 @@ In your application you may have selectors created dynamically using the `create
 ```ts
 export class ZooSelectors {
   static animalNames = (type: string) => {
-    return createSelector(
-      [ZooState],
-      (state: ZooStateModel) =>
-        state.animals.filter(animal => animal.type === type).map(animal => animal.name)
+    return createSelector([ZooState], (state: ZooStateModel) =>
+      state.animals.filter(animal => animal.type === type).map(animal => animal.name)
     );
   };
 }
@@ -154,6 +152,7 @@ it('should wait for completion of the asynchronous action', async () => {
     name: 'counter',
     defaults: 0
   })
+  @Injectable()
   class CounterState {
     @Action(IncrementAsync)
     incrementAsync(ctx: StateContext<number>) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

There have been a number of issues reported where users have not read the requirement for classes to be decorated with `@Injectable()` in Ivy. The docs have not included this, but this would is to the detriment of users starting on Ivy and not knowing the difference.
Issue Number: #1223, #1540, #1535

## What is the new behavior?

I added `@Injectable()` to every state class in the docs so that it becomes the new norm.
It should be safe for new and old angular.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
