### PR TITLE
fix(store): ofAction* methods should prevent invalid parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 $ npm install @ngxs/store@dev
 ```
 
+- Fix: `ofAction*` methods should error on invalid parameters [#1574](https://github.com/ngxs/store/pull/1574)
 - Feature: Storage Plugin - Add before and after serialize hooks [#1513](https://github.com/ngxs/store/pull/1513)
 - Feature: Logger Plugin - Add filter for Logger Plugin [#1571](https://github.com/ngxs/store/pull/1571)
 - Performance: Logger Plugin - Plugin should lazy inject the store once [#1550](https://github.com/ngxs/store/pull/1550)

--- a/packages/store/src/configs/messages.config.ts
+++ b/packages/store/src/configs/messages.config.ts
@@ -5,6 +5,7 @@ export enum VALIDATION_CODE {
   STATE_DECORATOR = 'STATE_DECORATOR',
   INCORRECT_PRODUCTION = 'INCORRECT_PRODUCTION',
   INCORRECT_DEVELOPMENT = 'INCORRECT_DEVELOPMENT',
+  INCORRECT_OFACTION_PARAMETER = 'INCORRECT_OFACTION_PARAMETER',
   SELECT_FACTORY_NOT_CONNECTED = 'SELECT_FACTORY_NOT_CONNECTED',
   ACTION_DECORATOR = 'ACTION_DECORATOR',
   SELECTOR_DECORATOR = 'SELECTOR_DECORATOR',
@@ -28,6 +29,8 @@ export const CONFIG_MESSAGES = {
   [VALIDATION_CODE.INCORRECT_DEVELOPMENT]: () =>
     'RECOMMENDATION: Set developmentMode to true on the NgxsModule when Angular is running in development mode.\n' +
     'NgxsModule.forRoot(states, { developmentMode: !environment.production })',
+  [VALIDATION_CODE.INCORRECT_OFACTION_PARAMETER]: () =>
+    'The ofAction* operators only accept actions as parameters and not as an array.',
   [VALIDATION_CODE.SELECT_FACTORY_NOT_CONNECTED]: () =>
     'You have forgotten to import the NGXS module!',
   [VALIDATION_CODE.ACTION_DECORATOR]: () =>

--- a/packages/store/src/operators/of-action.ts
+++ b/packages/store/src/operators/of-action.ts
@@ -2,6 +2,7 @@ import { OperatorFunction, Observable } from 'rxjs';
 import { map, filter } from 'rxjs/operators';
 import { getActionTypeFromInstance } from '../utils/utils';
 import { ActionContext, ActionStatus } from '../actions-stream';
+import { CONFIG_MESSAGES, VALIDATION_CODE } from '../configs/messages.config';
 
 export interface ActionCompletion<T = any, E = Error> {
   action: T;
@@ -82,10 +83,7 @@ function ofActionOperator<T = any>(
   const allowedMap = createAllowedActionTypesMap(allowedTypes);
   const allowedStatusMap = statuses && createAllowedStatusesMap(statuses);
   return function(o: Observable<ActionContext>) {
-    return o.pipe(
-      filterStatus(allowedMap, allowedStatusMap),
-      mapOperator()
-    );
+    return o.pipe(filterStatus(allowedMap, allowedStatusMap), mapOperator());
   };
 }
 
@@ -120,21 +118,18 @@ interface FilterMap {
 }
 
 function createAllowedActionTypesMap(types: any[]): FilterMap {
-  return types.reduce(
-    (filterMap: FilterMap, klass: any) => {
-      filterMap[getActionTypeFromInstance(klass)!] = true;
-      return filterMap;
-    },
-    <FilterMap>{}
-  );
+  return types.reduce((filterMap: FilterMap, klass: any) => {
+    if (Array.isArray(klass)) {
+      throw new Error(CONFIG_MESSAGES[VALIDATION_CODE.INCORRECT_OFACTION_PARAMETER]());
+    }
+    filterMap[getActionTypeFromInstance(klass)!] = true;
+    return filterMap;
+  }, <FilterMap>{});
 }
 
 function createAllowedStatusesMap(statuses: ActionStatus[]): FilterMap {
-  return statuses.reduce(
-    (filterMap: FilterMap, status: ActionStatus) => {
-      filterMap[status] = true;
-      return filterMap;
-    },
-    <FilterMap>{}
-  );
+  return statuses.reduce((filterMap: FilterMap, status: ActionStatus) => {
+    filterMap[status] = true;
+    return filterMap;
+  }, <FilterMap>{});
 }

--- a/packages/store/tests/operators/of-action.spec.ts
+++ b/packages/store/tests/operators/of-action.spec.ts
@@ -1,0 +1,54 @@
+import {
+  ofActionDispatched,
+  ofActionCanceled,
+  ofActionErrored,
+  ofActionCompleted,
+  ofActionSuccessful,
+  ofAction
+} from '../../src/operators/of-action';
+
+describe(`ofAction*`, () => {
+  class MyAction {
+    static type = 'My Action';
+  }
+
+  const ofActionTestCases = [
+    {
+      name: 'ofAction',
+      createOperator: (...args: any[]) => ofAction(...args)
+    },
+    {
+      name: 'ofActionDispatched',
+      createOperator: (...args: any[]) => ofActionDispatched(...args)
+    },
+    {
+      name: 'ofActionCanceled',
+      createOperator: (...args: any[]) => ofActionCanceled(...args)
+    },
+    {
+      name: 'ofActionErrored',
+      createOperator: (...args: any[]) => ofActionErrored(...args)
+    },
+    {
+      name: 'ofActionSuccessful',
+      createOperator: (...args: any[]) => ofActionSuccessful(...args)
+    },
+    {
+      name: 'ofActionCompleted',
+      createOperator: (...args: any[]) => ofActionCompleted(...args)
+    }
+  ];
+
+  ofActionTestCases.forEach(({ name, createOperator }) =>
+    it(`should not allow an array to be passed as an action type to ${name}`, () => {
+      // Arrange
+      expect(() => {
+        // Act
+        createOperator([MyAction]);
+        // Assert
+      }).toThrow(
+        'The ofAction* operators only accept actions as parameters and not as an array.'
+      );
+    })
+  );
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, if the user mistakenly passes in an array to on `ofAction*` operator it just fails silently:
```TS
this.actions$.pipe(
  ofActionCompleted( [ ActionOne, ActionTwo ] )
).subscribe(); // Will not fire, but will not throw an error, either.
```
The correct usage is this:
```TS
this.actions$.pipe(
  ofActionCompleted(ActionOne, ActionTwo)
).subscribe(); // Will fire.
```
Issue Number: #1561

## What is the new behavior?
It throws an error if used incorrectly.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
