### PR TITLE
fix(router-plugin): update state after route successfully activates

### DIFF
--- a/packages/router-plugin/src/router.state.ts
+++ b/packages/router-plugin/src/router.state.ts
@@ -8,8 +8,7 @@ import {
   ResolveEnd,
   UrlSerializer,
   NavigationStart,
-  NavigationEnd,
-  GuardsCheckEnd
+  NavigationEnd
 } from '@angular/router';
 import { LocationStrategy, Location } from '@angular/common';
 import { Action, Selector, State, StateContext, Store } from '@ngxs/store';
@@ -121,8 +120,6 @@ export class RouterState {
         this.navigationStart();
       } else if (event instanceof RoutesRecognized) {
         this._lastRoutesRecognized = event;
-      } else if (event instanceof GuardsCheckEnd && event.shouldActivate) {
-        this.guardsCheckEnd(event);
       } else if (event instanceof ResolveEnd) {
         this.dispatchRouterDataResolved(event);
       } else if (event instanceof NavigationCancel) {
@@ -132,6 +129,7 @@ export class RouterState {
         this.dispatchRouterError(event);
         this.reset();
       } else if (event instanceof NavigationEnd) {
+        this.navigationEnd();
         this.reset();
       }
     });
@@ -142,6 +140,12 @@ export class RouterState {
 
     if (this._trigger !== 'none') {
       this._storeState = this._store.selectSnapshot(RouterState);
+    }
+  }
+
+  private navigationEnd(): void {
+    if (this.shouldDispatchRouterNavigation()) {
+      this.dispatchRouterNavigation();
     }
   }
 
@@ -189,7 +193,6 @@ export class RouterState {
     this.dispatchRouterAction(
       new RouterCancel(this._routerState!, this._storeState, event, this._trigger)
     );
-    this.reset();
   }
 
   private dispatchRouterError(event: NavigationError): void {
@@ -210,14 +213,6 @@ export class RouterState {
       this._store.dispatch(action);
     } finally {
       this._trigger = 'none';
-    }
-  }
-
-  private guardsCheckEnd(event: GuardsCheckEnd) {
-    this._routerState = this._serializer.serialize(event.state);
-
-    if (this.shouldDispatchRouterNavigation()) {
-      this.dispatchRouterNavigation();
     }
   }
 

--- a/packages/router-plugin/tests/router-navigation.spec.ts
+++ b/packages/router-plugin/tests/router-navigation.spec.ts
@@ -1,0 +1,180 @@
+import { Component, NgModule, ErrorHandler } from '@angular/core';
+import { APP_BASE_HREF } from '@angular/common';
+import { BrowserModule } from '@angular/platform-browser';
+import {
+  Router,
+  RouterModule,
+  Resolve,
+  NavigationError,
+  NavigationEnd
+} from '@angular/router';
+import { freshPlatform } from '@ngxs/store/internals/testing';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { filter } from 'rxjs/operators';
+
+import { NgxsModule, ofActionDispatched, Actions, Store } from '@ngxs/store';
+import { NgxsRouterPluginModule, RouterNavigation, RouterState, Navigate } from '../';
+
+describe('RouterNavigation', () => {
+  class ErrorSupressor implements ErrorHandler {
+    handleError() {}
+  }
+
+  class ErrorResolver implements Resolve<void> {
+    async resolve(): Promise<void> {
+      throw Error();
+    }
+  }
+
+  class SuccessResolver implements Resolve<void> {
+    async resolve(): Promise<void> {
+      return;
+    }
+  }
+
+  @Component({
+    selector: 'app-root',
+    template: '<router-outlet></router-outlet>'
+  })
+  class RootComponent {}
+
+  @Component({
+    selector: 'home',
+    template: ''
+  })
+  class HomeComponent {}
+
+  @Component({
+    selector: 'error',
+    template: ''
+  })
+  class ErrorComponent {}
+
+  @Component({
+    selector: 'success',
+    template: ''
+  })
+  class SuccessComponent {}
+
+  function getTestModule() {
+    @NgModule({
+      imports: [
+        BrowserModule,
+        // Resolvers are not respected if we're using `RouterTestingModule`
+        // see https://github.com/angular/angular/issues/15779
+        // to be sure our data is resolved - we have to use native `RouterModule`
+        RouterModule.forRoot([
+          {
+            path: '',
+            component: HomeComponent
+          },
+          {
+            path: 'error',
+            component: ErrorComponent,
+            resolve: {
+              error: ErrorResolver
+            }
+          },
+          {
+            path: 'success',
+            component: SuccessComponent,
+            resolve: {
+              success: SuccessResolver
+            }
+          }
+        ]),
+        NgxsModule.forRoot([]),
+        NgxsRouterPluginModule.forRoot()
+      ],
+      declarations: [RootComponent, HomeComponent, ErrorComponent, SuccessComponent],
+      bootstrap: [RootComponent],
+      providers: [
+        ErrorResolver,
+        SuccessResolver,
+        { provide: APP_BASE_HREF, useValue: '/' },
+        {
+          provide: ErrorHandler,
+          useClass: ErrorSupressor
+        }
+      ]
+    })
+    class TestModule {}
+    return TestModule;
+  }
+
+  describe('when route guards and resolvers succeed', () => {
+    it(
+      'should wait for `NavigationEnd` and then dispatch the `RouterNavigation` action',
+      freshPlatform(async () => {
+        // Arrange
+        const { injector } = await platformBrowserDynamic().bootstrapModule(getTestModule());
+        const actions$: Actions = injector.get(Actions);
+        const router: Router = injector.get(Router);
+        const store: Store = injector.get(Store);
+
+        let navigationEndEmittedTimes = 0;
+        let routerNavigationDispatchedTimes = 0;
+
+        const subscription = router.events
+          .pipe(filter((event): event is NavigationEnd => event instanceof NavigationEnd))
+          .subscribe(() => {
+            navigationEndEmittedTimes++;
+          });
+
+        actions$.pipe(ofActionDispatched(RouterNavigation)).subscribe(() => {
+          routerNavigationDispatchedTimes++;
+        });
+
+        // Act
+        await store.dispatch(new Navigate(['/success'])).toPromise();
+        subscription.unsubscribe();
+
+        // Assert
+        expect(navigationEndEmittedTimes).toBe(1);
+        expect(routerNavigationDispatchedTimes).toBe(1);
+      })
+    );
+  });
+
+  describe('when route guard succeeds and route resolver fails', () => {
+    it(
+      'should persist previous state and NOT dispatch the `RouterNavigation` action',
+      freshPlatform(async () => {
+        // Arrange
+        const { injector } = await platformBrowserDynamic().bootstrapModule(getTestModule());
+        const actions$: Actions = injector.get(Actions);
+        const store: Store = injector.get(Store);
+        const router: Router = injector.get(Router);
+        const initialUrl = store.selectSnapshot(RouterState.url);
+
+        let navigationErrorEmittedTimes = 0;
+        let routerNavigationDispatchedTimes = 0;
+
+        const subscription = router.events
+          .pipe(filter((event): event is NavigationError => event instanceof NavigationError))
+          .subscribe(() => {
+            navigationErrorEmittedTimes++;
+          });
+
+        actions$.pipe(ofActionDispatched(RouterNavigation)).subscribe(() => {
+          routerNavigationDispatchedTimes++;
+        });
+
+        // Act
+        try {
+          await store.dispatch(new Navigate(['/error'])).toPromise();
+        } catch {
+        } finally {
+          subscription.unsubscribe();
+
+          // Assert
+          const url = store.selectSnapshot(RouterState.url);
+          expect(url).not.toBe('/error');
+          expect(url).toBe(initialUrl);
+          expect(routerNavigationDispatchedTimes).toBe(0);
+          expect(navigationErrorEmittedTimes).toBe(1);
+        }
+      })
+    );
+  });
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: #1605

The router-plugin eagerly updates router state _before_ the route is actually activated.  For example, if a route has both guards and resolvers, if the guards succeed but the resolvers fail, ngxs router state _still_ updates even though the route did not activate.  Please see issue for more details.

Current behavior:
1. User clicks a link to a new route
2. Route guards are checked
3. NGXS Router state updates
4. Wait for route resolvers to complete
5. Angular activates route

## What is the new behavior?

This makes the router plugin wait until _after_ the next route has successfully activated before updating state.

New behavior:
1. User clicks a link to a new route
2. Route guards are checked
3. Wait for route resolvers to complete
4. Angular activates route
5. NGXS Router state updates

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
