### PR TITLE
fix: ofAction* methods should prevent passing anything except of `ActionType`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ $ npm install @ngxs/store@dev
 - Feature: Storage Plugin - Add before and after serialize hooks [#1513](https://github.com/ngxs/store/pull/1513)
 - Feature: Logger Plugin - Add filter for Logger Plugin [#1571](https://github.com/ngxs/store/pull/1571)
 - Performance: Logger Plugin - Plugin should lazy inject the store once [#1550](https://github.com/ngxs/store/pull/1550)
+- Fix: `ofAction*` methods should prevent passing anything except of `ActionType` [#1616](https://github.com/ngxs/store/pull/1616)
 - Fix: Actions are not canceled when any `Observable` returned by any handler is completed without emitting [#1615](https://github.com/ngxs/store/pull/1615)
 - Fix: Router Plugin - Update state after route successfully activates [#1606](https://github.com/ngxs/store/pull/1606)
 - Fix: HMR Plugin - Show error when use Angular Ivy with JIT mode [#1607](https://github.com/ngxs/store/pull/1607)

--- a/packages/store/types/tests/issues/issue-1561.lint.ts
+++ b/packages/store/types/tests/issues/issue-1561.lint.ts
@@ -1,0 +1,111 @@
+import {
+  Actions,
+  ofAction,
+  ofActionDispatched,
+  ofActionSuccessful,
+  ofActionCanceled,
+  ofActionErrored,
+  ofActionCompleted
+} from '@ngxs/store';
+
+describe('[TEST]: https://github.com/ngxs/store/issues/1561', () => {
+  let actions$: Actions;
+
+  class ActionOne {
+    static type = 'Action one'
+  }
+
+  class ActionTwo {
+    static type = 'Action two';
+  }
+
+  it('ofAction()', () => {
+    // Arrange & act & assert
+    actions$.pipe(
+      ofAction(ActionOne) // $ExpectType OperatorFunction<ActionContext<any>, any>
+    );
+
+    actions$.pipe(
+      ofAction(ActionOne, ActionTwo) // $ExpectType OperatorFunction<ActionContext<any>, any>
+    );
+
+    actions$.pipe(
+      ofAction([ActionOne, ActionTwo]) // $ExpectError
+    );
+  });
+
+  it('ofActionDispatched()', () => {
+    // Arrange & act & assert
+    actions$.pipe(
+      ofActionDispatched(ActionOne) // $ExpectType OperatorFunction<ActionContext<any>, any>
+    );
+
+    actions$.pipe(
+      ofActionDispatched(ActionOne, ActionTwo) // $ExpectType OperatorFunction<ActionContext<any>, any>
+    );
+
+    actions$.pipe(
+      ofActionDispatched([ActionOne, ActionTwo]) // $ExpectError
+    );
+  });
+
+  it('ofActionSuccessful()', () => {
+    // Arrange & act & assert
+    actions$.pipe(
+      ofActionSuccessful(ActionOne) // $ExpectType OperatorFunction<ActionContext<any>, any>
+    );
+
+    actions$.pipe(
+      ofActionSuccessful(ActionOne, ActionTwo) // $ExpectType OperatorFunction<ActionContext<any>, any>
+    );
+
+    actions$.pipe(
+      ofActionSuccessful([ActionOne, ActionTwo]) // $ExpectError
+    );
+  });
+
+  it('ofActionCanceled()', () => {
+    // Arrange & act & assert
+    actions$.pipe(
+      ofActionCanceled(ActionOne) // $ExpectType OperatorFunction<ActionContext<any>, any>
+    );
+
+    actions$.pipe(
+      ofActionCanceled(ActionOne, ActionTwo) // $ExpectType OperatorFunction<ActionContext<any>, any>
+    );
+
+    actions$.pipe(
+      ofActionCanceled([ActionOne, ActionTwo]) // $ExpectError
+    );
+  });
+
+  it('ofActionErrored()', () => {
+    // Arrange & act & assert
+    actions$.pipe(
+      ofActionErrored(ActionOne) // $ExpectType OperatorFunction<ActionContext<any>, any>
+    );
+
+    actions$.pipe(
+      ofActionErrored(ActionOne, ActionTwo) // $ExpectType OperatorFunction<ActionContext<any>, any>
+    );
+
+    actions$.pipe(
+      ofActionErrored([ActionOne, ActionTwo]) // $ExpectError
+    );
+  });
+
+  it('ofActionCompleted()', () => {
+    // Arrange & act & assert
+    actions$.pipe(
+      ofActionCompleted(ActionOne) // $ExpectType OperatorFunction<ActionContext<any>, ActionCompletion<any, Error>>
+    );
+
+    actions$.pipe(
+      ofActionCompleted(ActionOne, ActionTwo) // $ExpectType OperatorFunction<ActionContext<any>, ActionCompletion<any, Error>>
+    );
+
+    actions$.pipe(
+      ofActionCompleted([ActionOne, ActionTwo]) // $ExpectError
+    );
+  });
+})


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1561 

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
