### PR TITLE
perf: do not create `new Observable()` every time when subscribing to `ivyEnabledInDevMode$`

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -32,14 +32,14 @@
       "path": "./@ngxs/store/fesm2015/ngxs-store.js",
       "package": "@ngxs/store",
       "target": "es2015",
-      "maxSize": "114.315KB",
+      "maxSize": "111.20KB",
       "compression": "none"
     },
     {
       "path": "./@ngxs/store/fesm5/ngxs-store.js",
       "package": "@ngxs/store",
       "target": "es5",
-      "maxSize": "134.255KB",
+      "maxSize": "130.8KB",
       "compression": "none"
     },
     {

--- a/packages/store/src/ivy/ensure-state-class-is-injectable.ts
+++ b/packages/store/src/ivy/ensure-state-class-is-injectable.ts
@@ -1,4 +1,4 @@
-import { ivyEnabledInDevMode } from './ivy-enabled-in-dev-mode';
+import { ivyEnabledInDevMode$ } from './ivy-enabled-in-dev-mode';
 import { CONFIG_MESSAGES, VALIDATION_CODE } from '../configs/messages.config';
 
 /**
@@ -11,7 +11,7 @@ export function ensureStateClassIsInjectable(target: any): void {
   // AOT mode because this property is added before runtime. If an application is running in
   // JIT mode then this property can be added by the `@Injectable()` decorator. The `@Injectable()`
   // decorator has to go after the `@State()` decorator, thus we prevent users from unwanted DI errors.
-  ivyEnabledInDevMode().subscribe(_ivyEnabledInDevMode => {
+  ivyEnabledInDevMode$.subscribe(_ivyEnabledInDevMode => {
     if (_ivyEnabledInDevMode) {
       const ngInjectableDef = target.ɵprov;
       if (!ngInjectableDef) {

--- a/packages/store/src/ivy/ivy-enabled-in-dev-mode.ts
+++ b/packages/store/src/ivy/ivy-enabled-in-dev-mode.ts
@@ -1,11 +1,7 @@
 import { isDevMode } from '@angular/core';
-import { Observable, ReplaySubject } from 'rxjs';
+import { ReplaySubject } from 'rxjs';
 
-/**
- * Keep it as a single `const` variable since this `ReplaySubject`
- * will be private and accessible only within this file.
- */
-const _ivyEnabledInDevMode$ = new ReplaySubject<boolean>(1);
+export const ivyEnabledInDevMode$ = new ReplaySubject<boolean>(1);
 
 /**
  * Ivy exposes helper functions to the global `window.ng` object.
@@ -25,14 +21,10 @@ export function setIvyEnabledInDevMode(): void {
     const ng = (window as any).ng;
     const _viewEngineEnabled = !!ng.probe && !!ng.coreTokens;
     const _ivyEnabledInDevMode = !_viewEngineEnabled && isDevMode();
-    _ivyEnabledInDevMode$.next(_ivyEnabledInDevMode);
+    ivyEnabledInDevMode$.next(_ivyEnabledInDevMode);
   } catch {
-    _ivyEnabledInDevMode$.next(false);
+    ivyEnabledInDevMode$.next(false);
   } finally {
-    _ivyEnabledInDevMode$.complete();
+    ivyEnabledInDevMode$.complete();
   }
-}
-
-export function ivyEnabledInDevMode(): Observable<boolean> {
-  return _ivyEnabledInDevMode$.asObservable();
 }


### PR DESCRIPTION
I have noticed that I've added `asObservable()` on the replay subject which creates `new Observable` every time the `ivyEnabledInDevMode` is invoked. That shouldn't be like that since it can slow down things on large codebases and dozens of states.