### PR TITLE
fix(devtools-plugin): actions with "action" property end up logged with <UNDEFINED>

### DIFF
--- a/packages/devtools-plugin/src/devtools.plugin.ts
+++ b/packages/devtools-plugin/src/devtools.plugin.ts
@@ -65,7 +65,7 @@ export class NgxsReduxDevtoolsPlugin implements NgxsPlugin {
     if (isInitAction) {
       this.devtoolsExtension!.init(state);
     } else {
-      this.devtoolsExtension!.send({ ...action, type }, newState);
+      this.devtoolsExtension!.send({ ...action, action: null, type }, newState);
     }
   }
 

--- a/packages/devtools-plugin/tests/devtools.spec.ts
+++ b/packages/devtools-plugin/tests/devtools.spec.ts
@@ -10,6 +10,11 @@ describe('[TEST]: Devtools', () => {
   let devtools: ReduxDevtoolsMockConnector;
   let store: Store;
 
+  class TestActionPayload {
+    public static readonly type = 'TestActionPayload';
+    constructor(public action: string) {}
+  }
+
   @State({
     name: 'count',
     defaults: 0
@@ -18,6 +23,11 @@ describe('[TEST]: Devtools', () => {
   class CountState {
     @Action({ type: 'increment' })
     increment(ctx: StateContext<number>) {
+      ctx.setState(state => state + 1);
+    }
+
+    @Action(TestActionPayload)
+    actionPayload(ctx: StateContext<number>) {
       ctx.setState(state => state + 1);
     }
   }
@@ -247,5 +257,21 @@ describe('[TEST]: Devtools', () => {
         jumped: false
       }
     ]);
+  });
+
+  describe('Action with "action" payload', () => {
+    it('should call send action with action=null', () => {
+      const spy = spyOn(devtools, 'send');
+      store.dispatch(new TestActionPayload('test'));
+      expect(spy).toHaveBeenCalledWith(
+        {
+          action: null,
+          type: 'TestActionPayload'
+        },
+        {
+          count: 1
+        }
+      );
+    });
   });
 });


### PR DESCRIPTION
make action:null before sending to devtools

## PR Type

What kind of change does this PR introduce?

```
[ X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When dispatching an action which payload includes an `action` property, ReduxDevTools logs it as <UNDEFINED>

Issue Number: N/A

## What is the new behavior?

`action` property will be set to null before sending to devtools to log action correctly

## Does this PR introduce a breaking change?

```
[ ] Yes
[ X ] No
```
![Screen Shot 2020-06-21 at 17 43 17](https://user-images.githubusercontent.com/6530160/85234856-e25fca80-b3e6-11ea-95fa-293c6870998b.png)

## Other information
