### PR TITLE
docs(hmr): include workaround using storage-plugin

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -74,14 +74,14 @@
       "path": "./@ngxs/hmr-plugin/fesm2015/ngxs-hmr-plugin.js",
       "package": "@ngxs/hmr-plugin",
       "target": "es2015",
-      "maxSize": "16.550KB",
+      "maxSize": "16.640KB",
       "compression": "none"
     },
     {
       "path": "./@ngxs/hmr-plugin/fesm5/ngxs-hmr-plugin.js",
       "package": "@ngxs/hmr-plugin",
       "target": "es5",
-      "maxSize": "20.135KB",
+      "maxSize": "20.22KB",
       "compression": "none"
     },
     {

--- a/docs/plugins/hmr.md
+++ b/docs/plugins/hmr.md
@@ -3,6 +3,8 @@
 Hot Module Replacement (HMR) is a Webpack feature to update code in a running app without rebuilding it. This results in faster updates and less full page-reloads.
 In order to get HMR working with Angular CLI we first need to add a new environment and enable it.
 
+> As of Angular v10, HMR is no longer supported and will be deprecated
+
 ### Add environment for HMR
 
 In this step we will configure the Angular CLI environments and define in which environment we enable HMR.

--- a/docs/plugins/hmr.md
+++ b/docs/plugins/hmr.md
@@ -3,7 +3,9 @@
 Hot Module Replacement (HMR) is a Webpack feature to update code in a running app without rebuilding it. This results in faster updates and less full page-reloads.
 In order to get HMR working with Angular CLI we first need to add a new environment and enable it.
 
-> As of Angular v10, HMR is no longer supported and will be deprecated
+> As of Angular v10, HMR is no longer supported and will be deprecated.
+>
+> As a workaround to keep store's state on full-page reloads you can use [`@ngxs/storage-plugin`](https://www.ngxs.io/plugins/storage). Here's a [basic implementation example](https://stackblitz.com/edit/ngxs-hmr-workaround-using-storage-plugin)
 
 ### Add environment for HMR
 

--- a/packages/hmr-plugin/src/hmr-bootstrap.ts
+++ b/packages/hmr-plugin/src/hmr-bootstrap.ts
@@ -6,7 +6,8 @@ import { markApplicationAsHmrReloaded, setHmrReloadedTo } from './utils/internal
 
 /**
  * Hot Module Replacement plugin for NGXS
- * @deprecated will be removed
+ * @deprecated As of Angular v10, HMR is no longer supported and will be deprecated.
+ * More information [here](https://www.ngxs.io/plugins/hmr).
  */
 export async function hmr<T>(
   webpackModule: WebpackModule,

--- a/packages/hmr-plugin/src/hmr-bootstrap.ts
+++ b/packages/hmr-plugin/src/hmr-bootstrap.ts
@@ -4,6 +4,10 @@ import { BootstrapModuleFn, NgxsHmrOptions, WebpackModule } from './symbols';
 import { HmrStorage } from './internal/hmr-storage';
 import { markApplicationAsHmrReloaded, setHmrReloadedTo } from './utils/internals';
 
+/**
+ * Hot Module Replacement plugin for NGXS
+ * @deprecated will be removed
+ */
 export async function hmr<T>(
   webpackModule: WebpackModule,
   bootstrapFn: BootstrapModuleFn<T>,


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

```
[ X ] Documentation content changes
```

## Other information

improve deprecation note and include workaround example using `storage/plugin`