### PR TITLE
test(form-plugin): clean up ngxsFormClearOnDestroy tests

### DIFF
--- a/packages/form-plugin/tests/form.plugin.spec.ts
+++ b/packages/form-plugin/tests/form.plugin.spec.ts
@@ -1,10 +1,8 @@
-import { Component, Injectable } from '@angular/core';
+import { Component, Injectable, Type } from '@angular/core';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-
 import { Actions, NgxsModule, ofActionDispatched, Selector, State, Store } from '@ngxs/store';
-
 import {
   NgxsFormPluginModule,
   ResetForm,
@@ -305,230 +303,224 @@ describe('NgxsFormPlugin', () => {
       expect(input.value).toBe('Buy some coffee');
     });
 
-    it('should update the state if ngxsFormClearOnDestroy option is provided', () => {
-      @State({
-        name: 'todos',
-        defaults: {
-          todosForm: {
-            model: undefined,
-            dirty: false,
-            status: '',
-            errors: {}
+    describe(`with ngxsFormClearOnDestroy`, () => {
+      function setup(ComponentType: Type<unknown>) {
+        @State({
+          name: 'todos',
+          defaults: {
+            todosForm: {
+              model: undefined,
+              dirty: false,
+              status: '',
+              errors: {}
+            }
           }
-        }
-      })
-      class TodosState {}
+        })
+        class TodosState {}
 
-      @Component({
-        template: `
-          <form [formGroup]="form" ngxsForm="todos.todosForm" ngxsFormClearOnDestroy>
-            <input type="text" formControlName="text" /><button type="submit">Add todo</button>
-          </form>
-        `
-      })
-      class MockComponent {
-        public form = new FormGroup({
-          text: new FormControl()
+        TestBed.configureTestingModule({
+          imports: [
+            ReactiveFormsModule,
+            NgxsModule.forRoot([TodosState]),
+            NgxsFormPluginModule.forRoot()
+          ],
+          declarations: [ComponentType]
         });
+        const store: Store = TestBed.get(Store);
+        const fixture = TestBed.createComponent(ComponentType);
+        const getTodosFormState = () => store.selectSnapshot(({ todos }) => todos.todosForm);
+        return { store, fixture, getTodosFormState };
       }
 
-      TestBed.configureTestingModule({
-        imports: [
-          ReactiveFormsModule,
-          NgxsModule.forRoot([TodosState]),
-          NgxsFormPluginModule.forRoot()
-        ],
-        declarations: [MockComponent]
-      });
-      const store: Store = TestBed.get(Store);
-      const fixture = TestBed.createComponent(MockComponent);
-      expect(store.selectSnapshot(({ todos }) => todos.todosForm)).toEqual({
-        model: undefined,
-        dirty: false,
-        status: '',
-        errors: {}
-      });
-
-      fixture.detectChanges();
-      fixture.destroy();
-      expect(store.selectSnapshot(({ todos }) => todos.todosForm)).toEqual({
-        model: {},
-        dirty: null,
-        status: null,
-        errors: {}
-      });
-    });
-
-    it('should not update the state if ngxsFormClearOnDestroy="false" option is provided', () => {
-      @State({
-        name: 'todos',
-        defaults: {
-          todosForm: {
-            model: undefined,
-            dirty: false,
-            status: '',
-            errors: {}
-          }
+      it('should clear the state if ngxsFormClearOnDestroy option is provided', () => {
+        // Arrange
+        @Component({
+          template: `
+            <form [formGroup]="form" ngxsForm="todos.todosForm" ngxsFormClearOnDestroy>
+              <input type="text" formControlName="text" /><button type="submit">
+                Add todo
+              </button>
+            </form>
+          `
+        })
+        class MockComponent {
+          public form = new FormGroup({ text: new FormControl() });
         }
-      })
-      class TodosState {}
 
-      @Component({
-        template: `
-          <form [formGroup]="form" ngxsForm="todos.todosForm" ngxsFormClearOnDestroy="false">
-            <input type="text" formControlName="text" /><button type="submit">Add todo</button>
-          </form>
-        `
-      })
-      class MockComponent {
-        public form = new FormGroup({
-          text: new FormControl()
+        const { fixture, getTodosFormState } = setup(MockComponent);
+        expect(getTodosFormState()).toEqual({
+          model: undefined,
+          dirty: false,
+          status: '',
+          errors: {}
         });
-      }
 
-      TestBed.configureTestingModule({
-        imports: [
-          ReactiveFormsModule,
-          NgxsModule.forRoot([TodosState]),
-          NgxsFormPluginModule.forRoot()
-        ],
-        declarations: [MockComponent]
-      });
-      const store: Store = TestBed.get(Store);
-      const fixture = TestBed.createComponent(MockComponent);
-      expect(store.selectSnapshot(({ todos }) => todos.todosForm)).toEqual({
-        model: undefined,
-        dirty: false,
-        status: '',
-        errors: {}
+        fixture.detectChanges();
+
+        // Act
+        fixture.destroy();
+
+        // Assert
+        expect(getTodosFormState()).toEqual({
+          model: {},
+          dirty: null,
+          status: null,
+          errors: {}
+        });
       });
 
-      fixture.detectChanges();
-      fixture.destroy();
-      expect(store.selectSnapshot(({ todos }) => todos.todosForm)).toEqual({
-        model: {
-          text: null
-        },
-        dirty: false,
-        status: 'VALID',
-        errors: {}
-      });
-    });
-
-    it('should update the state if ngxsFormClearOnDestroy="true" option is provided', () => {
-      @State({
-        name: 'todos',
-        defaults: {
-          todosForm: {
-            model: undefined,
-            dirty: false,
-            status: '',
-            errors: {}
-          }
+      it('should not clear the state if ngxsFormClearOnDestroy="false" option is provided', () => {
+        // Arrange
+        @Component({
+          template: `
+            <form [formGroup]="form" ngxsForm="todos.todosForm" ngxsFormClearOnDestroy="false">
+              <input type="text" formControlName="text" /><button type="submit">
+                Add todo
+              </button>
+            </form>
+          `
+        })
+        class MockComponent {
+          public form = new FormGroup({ text: new FormControl() });
         }
-      })
-      class TodosState {}
 
-      @Component({
-        template: `
-          <form [formGroup]="form" ngxsForm="todos.todosForm" ngxsFormClearOnDestroy="true">
-            <input formControlName="text" /> <button type="submit">Add todo</button>
-          </form>
-        `
-      })
-      class MockComponent {
-        public form = new FormGroup({
-          text: new FormControl()
+        const { fixture, getTodosFormState } = setup(MockComponent);
+        expect(getTodosFormState()).toEqual({
+          model: undefined,
+          dirty: false,
+          status: '',
+          errors: {}
         });
-      }
 
-      TestBed.configureTestingModule({
-        imports: [
-          ReactiveFormsModule,
-          NgxsModule.forRoot([TodosState]),
-          NgxsFormPluginModule.forRoot()
-        ],
-        declarations: [MockComponent]
+        fixture.detectChanges();
+
+        // Act
+        fixture.destroy();
+
+        // Assert
+        expect(getTodosFormState()).toEqual({
+          model: {
+            text: null
+          },
+          dirty: false,
+          status: 'VALID',
+          errors: {}
+        });
       });
 
-      const store: Store = TestBed.get(Store);
-      const fixture = TestBed.createComponent(MockComponent);
-
-      expect(store.selectSnapshot(({ todos }) => todos).todosForm).toEqual({
-        model: undefined,
-        dirty: false,
-        status: '',
-        errors: {}
-      });
-
-      fixture.detectChanges();
-      fixture.destroy();
-
-      expect(store.selectSnapshot(({ todos }) => todos).todosForm).toEqual({
-        model: {},
-        dirty: null,
-        status: null,
-        errors: {}
-      });
-    });
-    it('should update the state if [ngxsFormClearOnDestroy]="true" option is provided', () => {
-      // Arrange
-      @State({
-        name: 'todos',
-        defaults: {
-          todosForm: {
-            model: undefined,
-            dirty: false,
-            status: '',
-            errors: {}
-          }
+      it('should not clear the state if ngxsFormClearOnDestroy option is not provided', () => {
+        // Arrange
+        @Component({
+          template: `
+            <form [formGroup]="form" ngxsForm="todos.todosForm">
+              <input type="text" formControlName="text" /><button type="submit">
+                Add todo
+              </button>
+            </form>
+          `
+        })
+        class MockComponent {
+          public form = new FormGroup({ text: new FormControl() });
         }
-      })
-      @Injectable()
-      class TodosState {}
 
-      @Component({
-        template: `
-          <form [formGroup]="form" ngxsForm="todos.todosForm" [ngxsFormClearOnDestroy]="true">
-            <input formControlName="text" /> <button type="submit">Add todo</button>
-          </form>
-        `
-      })
-      class MockComponent {
-        public form = new FormGroup({
-          text: new FormControl()
+        const { fixture, getTodosFormState } = setup(MockComponent);
+        expect(getTodosFormState()).toEqual({
+          model: undefined,
+          dirty: false,
+          status: '',
+          errors: {}
         });
-      }
 
-      // Act
-      TestBed.configureTestingModule({
-        imports: [
-          ReactiveFormsModule,
-          NgxsModule.forRoot([TodosState]),
-          NgxsFormPluginModule.forRoot()
-        ],
-        declarations: [MockComponent]
+        fixture.detectChanges();
+
+        // Act
+        fixture.destroy();
+
+        // Assert
+        expect(getTodosFormState()).toEqual({
+          model: {
+            text: null
+          },
+          dirty: false,
+          status: 'VALID',
+          errors: {}
+        });
       });
 
-      const store = getStore();
-      const fixture = TestBed.createComponent(MockComponent);
+      it('should clear the state if ngxsFormClearOnDestroy="true" option is provided', () => {
+        // Arrange
+        @Component({
+          template: `
+            <form [formGroup]="form" ngxsForm="todos.todosForm" ngxsFormClearOnDestroy="true">
+              <input formControlName="text" /> <button type="submit">Add todo</button>
+            </form>
+          `
+        })
+        class MockComponent {
+          public form = new FormGroup({ text: new FormControl() });
+        }
 
-      // Assert
-      expect(store.selectSnapshot(({ todos }) => todos).todosForm).toEqual({
-        model: undefined,
-        dirty: false,
-        status: '',
-        errors: {}
+        const { fixture, getTodosFormState } = setup(MockComponent);
+        expect(getTodosFormState()).toEqual({
+          model: undefined,
+          dirty: false,
+          status: '',
+          errors: {}
+        });
+
+        fixture.detectChanges();
+
+        // Act
+        fixture.destroy();
+
+        // Assert
+        expect(getTodosFormState()).toEqual({
+          model: {},
+          dirty: null,
+          status: null,
+          errors: {}
+        });
       });
 
-      fixture.detectChanges();
-      fixture.destroy();
+      it('should clear the state if [ngxsFormClearOnDestroy]="true" option is provided', () => {
+        // Arrange
+        @Component({
+          template: `
+            <form
+              [formGroup]="form"
+              ngxsForm="todos.todosForm"
+              [ngxsFormClearOnDestroy]="true"
+            >
+              <input formControlName="text" /> <button type="submit">Add todo</button>
+            </form>
+          `
+        })
+        class MockComponent {
+          public form = new FormGroup({
+            text: new FormControl()
+          });
+        }
 
-      expect(store.selectSnapshot(({ todos }) => todos).todosForm).toEqual({
-        model: {},
-        dirty: null,
-        status: null,
-        errors: {}
+        const { fixture, getTodosFormState } = setup(MockComponent);
+        expect(getTodosFormState()).toEqual({
+          model: undefined,
+          dirty: false,
+          status: '',
+          errors: {}
+        });
+
+        fixture.detectChanges();
+
+        // Act
+        fixture.destroy();
+
+        // Assert
+        expect(getTodosFormState()).toEqual({
+          model: {},
+          dirty: null,
+          status: null,
+          errors: {}
+        });
       });
     });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[X] Other... Please describe: Tests
```

## What is the current behavior?

There was a test missing from PR #1662 and there was also a bit of cleanup that would improve the tests.

## What is the new behavior?

Added missing test, and cleaned up the tests to use setup method as well as the AAA syntax comment sections.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

## Other information
