### PR TITLE
fix: release NGXS resources when the root module gets destroyed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 $ npm install @ngxs/store@dev
 ```
 
-- ...
+- Fix: Release NGXS resources when the root module gets destroyed [#1669](https://github.com/ngxs/store/pull/1669)
 
 # 3.7.0 2020-09-09
 

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -32,14 +32,14 @@
       "path": "./@ngxs/store/fesm2015/ngxs-store.js",
       "package": "@ngxs/store",
       "target": "es2015",
-      "maxSize": "112.1KB",
+      "maxSize": "112.12KB",
       "compression": "none"
     },
     {
       "path": "./@ngxs/store/fesm5/ngxs-store.js",
       "package": "@ngxs/store",
       "target": "es5",
-      "maxSize": "131.75KB",
+      "maxSize": "131.77KB",
       "compression": "none"
     },
     {

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -32,14 +32,14 @@
       "path": "./@ngxs/store/fesm2015/ngxs-store.js",
       "package": "@ngxs/store",
       "target": "es2015",
-      "maxSize": "111.56KB",
+      "maxSize": "112.1KB",
       "compression": "none"
     },
     {
       "path": "./@ngxs/store/fesm5/ngxs-store.js",
       "package": "@ngxs/store",
       "target": "es5",
-      "maxSize": "131.07KB",
+      "maxSize": "131.75KB",
       "compression": "none"
     },
     {

--- a/packages/store/src/decorators/select/select-factory.ts
+++ b/packages/store/src/decorators/select/select-factory.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, OnDestroy } from '@angular/core';
 
 import { Store } from '../../store';
 import { NgxsConfig } from '../../symbols';
@@ -9,12 +9,16 @@ import { NgxsConfig } from '../../symbols';
  * @ignore
  */
 @Injectable()
-export class SelectFactory {
+export class SelectFactory implements OnDestroy {
   public static store: Store | null = null;
   public static config: NgxsConfig | null = null;
 
   constructor(store: Store, config: NgxsConfig) {
     SelectFactory.store = store;
     SelectFactory.config = config;
+  }
+
+  ngOnDestroy(): void {
+    SelectFactory.store = SelectFactory.config = null;
   }
 }

--- a/packages/store/src/decorators/select/select-factory.ts
+++ b/packages/store/src/decorators/select/select-factory.ts
@@ -19,6 +19,7 @@ export class SelectFactory implements OnDestroy {
   }
 
   ngOnDestroy(): void {
-    SelectFactory.store = SelectFactory.config = null;
+    SelectFactory.store = null;
+    SelectFactory.config = null;
   }
 }

--- a/packages/store/src/internal/state-factory.ts
+++ b/packages/store/src/internal/state-factory.ts
@@ -1,5 +1,5 @@
-import { Injectable, Injector, Optional, SkipSelf, Inject } from '@angular/core';
-import { forkJoin, from, Observable, of, throwError } from 'rxjs';
+import { Injectable, Injector, Optional, SkipSelf, Inject, OnDestroy } from '@angular/core';
+import { forkJoin, from, Observable, of, throwError, Subscription } from 'rxjs';
 import {
   catchError,
   defaultIfEmpty,
@@ -40,8 +40,8 @@ import { INITIAL_STATE_TOKEN, PlainObjectOf, memoize } from '@ngxs/store/interna
  * @ignore
  */
 @Injectable()
-export class StateFactory {
-  private _connected = false;
+export class StateFactory implements OnDestroy {
+  private _actionsSubscription: Subscription | null = null;
 
   constructor(
     private _injector: Injector,
@@ -57,15 +57,23 @@ export class StateFactory {
     private _initialState: any
   ) {}
 
+  ngOnDestroy(): void {
+    // I'm using non-null assertion here since `_actionsSubscrition` will
+    // be 100% defined. This is because `ngOnDestroy()` cannot be invoked
+    // on the `StateFactory` until its initialized :) An it's initialized
+    // for the first time along with the `NgxsRootModule`.
+    this._actionsSubscription!.unsubscribe();
+  }
+
   private _states: MappedStore[] = [];
 
-  public get states(): MappedStore[] {
+  get states(): MappedStore[] {
     return this._parentFactory ? this._parentFactory.states : this._states;
   }
 
   private _statesByName: StatesByName = {};
 
-  public get statesByName(): StatesByName {
+  get statesByName(): StatesByName {
     return this._parentFactory ? this._parentFactory.statesByName : this._statesByName;
   }
 
@@ -75,7 +83,7 @@ export class StateFactory {
     return this._parentFactory ? this._parentFactory.statePaths : this._statePaths;
   }
 
-  public getRuntimeSelectorContext = memoize(() => {
+  getRuntimeSelectorContext = memoize(() => {
     const stateFactory = this;
     const context: RuntimeSelectorContext = this._parentFactory
       ? this._parentFactory.getRuntimeSelectorContext()
@@ -177,8 +185,8 @@ export class StateFactory {
    * Bind the actions to the handlers
    */
   connectActionHandlers() {
-    if (this._connected) return;
-    this._actions
+    if (this._actionsSubscription !== null) return;
+    this._actionsSubscription = this._actions
       .pipe(
         filter((ctx: ActionContext) => ctx.status === ActionStatus.Dispatched),
         mergeMap(({ action }) =>
@@ -192,7 +200,6 @@ export class StateFactory {
         )
       )
       .subscribe(ctx => this._actionResults.next(ctx));
-    this._connected = true;
   }
 
   /**

--- a/packages/store/src/internal/state-factory.ts
+++ b/packages/store/src/internal/state-factory.ts
@@ -57,14 +57,6 @@ export class StateFactory implements OnDestroy {
     private _initialState: any
   ) {}
 
-  ngOnDestroy(): void {
-    // I'm using non-null assertion here since `_actionsSubscrition` will
-    // be 100% defined. This is because `ngOnDestroy()` cannot be invoked
-    // on the `StateFactory` until its initialized :) An it's initialized
-    // for the first time along with the `NgxsRootModule`.
-    this._actionsSubscription!.unsubscribe();
-  }
-
   private _states: MappedStore[] = [];
 
   get states(): MappedStore[] {
@@ -121,6 +113,14 @@ export class StateFactory implements OnDestroy {
 
   private static checkStatesAreValid(stateClasses: StateClassInternal[]): void {
     stateClasses.forEach(StoreValidators.getValidStateMeta);
+  }
+
+  ngOnDestroy(): void {
+    // I'm using non-null assertion here since `_actionsSubscrition` will
+    // be 100% defined. This is because `ngOnDestroy()` cannot be invoked
+    // on the `StateFactory` until its initialized :) An it's initialized
+    // for the first time along with the `NgxsRootModule`.
+    this._actionsSubscription!.unsubscribe();
   }
 
   /**

--- a/packages/store/tests/release-resources.spec.ts
+++ b/packages/store/tests/release-resources.spec.ts
@@ -1,0 +1,41 @@
+import { BrowserModule } from '@angular/platform-browser';
+import { NgModule, ErrorHandler, DoBootstrap } from '@angular/core';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { NgxsModule, Store } from '@ngxs/store';
+import { freshPlatform } from '@ngxs/store/internals/testing';
+
+import { NgxsConfig } from '../src/symbols';
+import { NoopErrorHandler } from './helpers/utils';
+import { SelectFactory } from '../src/decorators/select/select-factory';
+
+describe('Release NGXS resources', () => {
+  it(
+    'should invoke ngOnDestroy() on the SelectFactory and properties should become null',
+    freshPlatform(async () => {
+      // Arrange
+      @NgModule({
+        imports: [BrowserModule, NgxsModule.forRoot([])],
+        providers: [{ provide: ErrorHandler, useClass: NoopErrorHandler }]
+      })
+      class TestModule implements DoBootstrap {
+        ngDoBootstrap(): void {}
+      }
+
+      // Act
+      const ngModuleRef = await platformBrowserDynamic().bootstrapModule(TestModule);
+
+      const onDestroyFn = jest.fn();
+      ngModuleRef.onDestroy(onDestroyFn);
+
+      // Assert
+      expect(SelectFactory.store).toBeInstanceOf(Store);
+      expect(SelectFactory.config).toBeInstanceOf(NgxsConfig);
+
+      ngModuleRef.destroy();
+
+      expect(onDestroyFn).toHaveBeenCalled();
+      expect(SelectFactory.store).toEqual(null);
+      expect(SelectFactory.config).toEqual(null);
+    })
+  );
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

#1675 

## What is the new behavior?

This is the new behavior after the root module has been destroyed:

![image](https://user-images.githubusercontent.com/7337691/92978208-caed2680-f497-11ea-9a1c-09875e917b07.png)


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
