### PR TITLE
fix(store): merge options with default options

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,5 +32,25 @@
       "internalConsoleOptions": "neverOpen",
       "disableOptimisticBPs": true,
     },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest Current File",
+      "program": "${workspaceFolder}/node_modules/cross-env/dist/bin/cross-env.js",
+      "cwd": "${workspaceFolder}",
+      "args": [
+        "CI=true",
+        "ng",
+        "test",
+        "--project",
+        "ngxs",
+        "--testPathPattern=${fileBasenameNoExtension}",
+        "--colors",
+        "--runInBand"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+    }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,25 @@
       "outFiles": [
         "${workspaceFolder}/**/*.js"
       ]
-    }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest All",
+      "program": "${workspaceFolder}/node_modules/cross-env/dist/bin/cross-env.js",
+      "cwd": "${workspaceFolder}",
+      "args": [
+        "CI=true",
+        "ng",
+        "test",
+        "--project",
+        "ngxs",
+        "--colors",
+        "--runInBand"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+    },
   ]
 }

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -32,14 +32,14 @@
       "path": "./@ngxs/store/fesm2015/ngxs-store.js",
       "package": "@ngxs/store",
       "target": "es2015",
-      "maxSize": "112.12KB",
+      "maxSize": "113.25KB",
       "compression": "none"
     },
     {
       "path": "./@ngxs/store/fesm5/ngxs-store.js",
       "package": "@ngxs/store",
       "target": "es5",
-      "maxSize": "131.77KB",
+      "maxSize": "133.10KB",
       "compression": "none"
     },
     {

--- a/integration/app/app.component.html
+++ b/integration/app/app.component.html
@@ -1,6 +1,7 @@
 <div class="todo-list">
   <div>
     <h3>Reactive Form</h3>
+    <p>{{ injected$ | async }}</p>
     <form [formGroup]="pizzaForm" novalidate (ngSubmit)="onSubmit()" ngxsForm="todos.pizza">
       Toppings: <input type="text" formControlName="toppings" /> <br />
       Crust <input type="text" formControlName="crust" /> <br />

--- a/integration/app/app.component.ts
+++ b/integration/app/app.component.ts
@@ -22,9 +22,11 @@ import { Extras, Pizza, Todo } from '@integration/store/todos/todos.model';
 export class AppComponent implements OnInit {
   public allExtras: Extras[];
   public pizzaForm: FormGroup;
+  public greeting: string;
   @Select(TodoState) public todos$: Observable<Todo[]>;
   @Select(TodoState.pandas) public pandas$: Observable<Todo[]>;
   @Select(TodosState.pizza) public pizza$: Observable<Pizza>;
+  @Select(TodosState.injected) public injected$: Observable<string>;
 
   constructor(private store: Store, private formBuilder: FormBuilder) {}
 

--- a/integration/app/store/store.module.ts
+++ b/integration/app/store/store.module.ts
@@ -17,7 +17,10 @@ import { environment as env } from '../../environments/environment';
     NgxsLoggerPluginModule.forRoot({ logger: console, collapsed: false }),
     NgxsReduxDevtoolsPluginModule.forRoot({ disabled: env.production }),
     NgxsRouterPluginModule.forRoot(),
-    NgxsModule.forRoot([TodosState, TodoState], { developmentMode: !env.production })
+    NgxsModule.forRoot([TodosState, TodoState], {
+      developmentMode: !env.production,
+      selectorOptions: {}
+    })
   ],
   exports: [
     NgxsFormPluginModule,

--- a/integration/app/store/store.module.ts
+++ b/integration/app/store/store.module.ts
@@ -19,7 +19,7 @@ import { environment as env } from '../../environments/environment';
     NgxsRouterPluginModule.forRoot(),
     NgxsModule.forRoot([TodosState, TodoState], {
       developmentMode: !env.production,
-      selectorOptions: {}
+      selectorOptions: {} // empty object to test option merging
     })
   ],
   exports: [

--- a/integration/app/store/todos/todos.state.ts
+++ b/integration/app/store/todos/todos.state.ts
@@ -29,6 +29,9 @@ export class TodosState {
 
   @Selector([ListState.hello])
   public static injected(state: TodoStateModel, hello: string): string {
+    if (state.todo == null || hello == null) {
+      return 'container injection failed or is disabled';
+    }
     return `${hello}! i have ${state.todo.length} todos`;
   }
 

--- a/integration/app/store/todos/todos.state.ts
+++ b/integration/app/store/todos/todos.state.ts
@@ -8,6 +8,7 @@ import { TodoState } from '@integration/store/todos/todo/todo.state';
 import { Pizza, TodoStateModel } from '@integration/store/todos/todos.model';
 import { LoadData, SetPrefix } from '@integration/store/todos/todos.actions';
 import { Injectable } from '@angular/core';
+import { ListState } from '@integration/list/list.state';
 
 const TODOS_TOKEN: StateToken<TodoStateModel> = new StateToken('todos');
 
@@ -24,6 +25,11 @@ export class TodosState {
   @Selector()
   public static pizza(state: TodoStateModel): Pizza {
     return state.pizza;
+  }
+
+  @Selector([ListState.hello])
+  public static injected(state: TodoStateModel, hello: string): string {
+    return `${hello}! i have ${state.todo.length} todos`;
   }
 
   @Action(SetPrefix)

--- a/packages/store/src/module.ts
+++ b/packages/store/src/module.ts
@@ -153,8 +153,7 @@ export class NgxsModule {
   }
 
   private static ngxsConfigFactory(options: NgxsModuleOptions): NgxsConfig {
-    let merged = mergeDeep(new NgxsConfig(), options);
-    return merged;
+    return mergeDeep(new NgxsConfig(), options);
   }
 
   private static appBootstrapListenerFactory(bootstrapper: NgxsBootstrapper): Function {

--- a/packages/store/src/module.ts
+++ b/packages/store/src/module.ts
@@ -41,6 +41,7 @@ import { DispatchOutsideZoneNgxsExecutionStrategy } from './execution/dispatch-o
 import { InternalNgxsExecutionStrategy } from './execution/internal-ngxs-execution-strategy';
 import { HostEnvironment } from './host-environment/host-environment';
 import { ConfigValidator } from './internal/config-validator';
+import { mergeDeep } from './utils/utils';
 
 /**
  * Ngxs Module
@@ -152,7 +153,16 @@ export class NgxsModule {
   }
 
   private static ngxsConfigFactory(options: NgxsModuleOptions): NgxsConfig {
-    return Object.assign(new NgxsConfig(), options);
+    console.log('before');
+    console.log(options);
+
+    let merged = mergeDeep(new NgxsConfig(), options);
+    // let merged = Object.assign(new NgxsConfig(), options);
+
+    console.log('after');
+    console.log(merged);
+
+    return merged;
   }
 
   private static appBootstrapListenerFactory(bootstrapper: NgxsBootstrapper): Function {

--- a/packages/store/src/module.ts
+++ b/packages/store/src/module.ts
@@ -154,7 +154,6 @@ export class NgxsModule {
 
   private static ngxsConfigFactory(options: NgxsModuleOptions): NgxsConfig {
     let merged = mergeDeep(new NgxsConfig(), options);
-    // let merged = Object.assign(new NgxsConfig(), options);
     return merged;
   }
 

--- a/packages/store/src/module.ts
+++ b/packages/store/src/module.ts
@@ -153,15 +153,8 @@ export class NgxsModule {
   }
 
   private static ngxsConfigFactory(options: NgxsModuleOptions): NgxsConfig {
-    console.log('before');
-    console.log(options);
-
     let merged = mergeDeep(new NgxsConfig(), options);
     // let merged = Object.assign(new NgxsConfig(), options);
-
-    console.log('after');
-    console.log(merged);
-
     return merged;
   }
 

--- a/packages/store/src/utils/utils.ts
+++ b/packages/store/src/utils/utils.ts
@@ -80,7 +80,7 @@ export const isObject = (item: any) => {
  *
  * @param base base object onto which `sources` will be applied
  */
-export const mergeDeep = (base: any, ...sources: any): any => {
+export const mergeDeep = (base: any, ...sources: any[]): any => {
   if (!sources.length) return base;
   const source = sources.shift();
 

--- a/packages/store/src/utils/utils.ts
+++ b/packages/store/src/utils/utils.ts
@@ -63,31 +63,37 @@ export const getValue = (obj: any, prop: string): any =>
 
 /**
  * Simple object check.
- * @param item
+ *
+ *    isObject({a:1}) //=> true
+ *    isObject(1) //=> false
+ *
+ * @ignore
  */
-function isObject(item: any) {
+export const isObject = (item: any) => {
   return item && typeof item === 'object' && !Array.isArray(item);
-}
+};
 
 /**
  * Deep merge two objects.
- * @param target
- * @param ...sources
+ *
+ *    mergeDeep({a:1, b:{x: 1, y:2}}, {b:{x: 3}, c:4}) //=> {a:1, b:{x:3, y:2}, c:4}
+ *
+ * @param base base object onto which `sources` will be applied
  */
-export const mergeDeep = (target: any, ...sources: any): any => {
-  if (!sources.length) return target;
+export const mergeDeep = (base: any, ...sources: any): any => {
+  if (!sources.length) return base;
   const source = sources.shift();
 
-  if (isObject(target) && isObject(source)) {
+  if (isObject(base) && isObject(source)) {
     for (const key in source) {
       if (isObject(source[key])) {
-        if (!target[key]) Object.assign(target, { [key]: {} });
-        mergeDeep(target[key], source[key]);
+        if (!base[key]) Object.assign(base, { [key]: {} });
+        mergeDeep(base[key], source[key]);
       } else {
-        Object.assign(target, { [key]: source[key] });
+        Object.assign(base, { [key]: source[key] });
       }
     }
   }
 
-  return mergeDeep(target, ...sources);
+  return mergeDeep(base, ...sources);
 };

--- a/packages/store/src/utils/utils.ts
+++ b/packages/store/src/utils/utils.ts
@@ -60,3 +60,34 @@ export const setValue = (obj: any, prop: string, val: any) => {
  */
 export const getValue = (obj: any, prop: string): any =>
   prop.split('.').reduce((acc: any, part: string) => acc && acc[part], obj);
+
+/**
+ * Simple object check.
+ * @param item
+ */
+function isObject(item: any) {
+  return item && typeof item === 'object' && !Array.isArray(item);
+}
+
+/**
+ * Deep merge two objects.
+ * @param target
+ * @param ...sources
+ */
+export const mergeDeep = (target: any, ...sources: any): any => {
+  if (!sources.length) return target;
+  const source = sources.shift();
+
+  if (isObject(target) && isObject(source)) {
+    for (const key in source) {
+      if (isObject(source[key])) {
+        if (!target[key]) Object.assign(target, { [key]: {} });
+        mergeDeep(target[key], source[key]);
+      } else {
+        Object.assign(target, { [key]: source[key] });
+      }
+    }
+  }
+
+  return mergeDeep(target, ...sources);
+};

--- a/packages/store/tests/selector.spec.ts
+++ b/packages/store/tests/selector.spec.ts
@@ -892,7 +892,7 @@ describe('Selector', () => {
       TestBed.configureTestingModule({
         imports: [
           NgxsModule.forRoot([ContactsState], {
-            selectorOptions: { suppressErrors: false }
+            selectorOptions: { suppressErrors: false, injectContainerState: false }
           })
         ]
       });

--- a/packages/store/tests/utils/utils.spec.ts
+++ b/packages/store/tests/utils/utils.spec.ts
@@ -1,6 +1,6 @@
 import { PlainObject } from '@ngxs/store/internals';
 import { propGetter } from '../../src/internal/internals';
-import { setValue } from '../../src/utils/utils';
+import { setValue, isObject, mergeDeep } from '../../src/utils/utils';
 import { NgxsConfig } from '../../src/symbols';
 
 describe('utils', () => {
@@ -77,6 +77,76 @@ describe('utils', () => {
 
       expect(propGetter(['a', 'b', 'c'], config)(target)).toEqual(100);
       expect(propGetter(['a', 'b'], config)(target)).toEqual({ c: 100 });
+    });
+  });
+
+  describe('isObject', () => {
+    it('should correctly identify objects', () => {
+      const object = { a: 1 };
+      const constructedObject = new Object(1);
+      const array = [1, 2, 3];
+      const string = 'asdasd';
+      const number = 12;
+
+      expect(isObject(object)).toBeTruthy();
+      expect(isObject(constructedObject)).toBeTruthy();
+      expect(isObject(array)).toBeFalsy();
+      expect(isObject(string)).toBeFalsy();
+      expect(isObject(number)).toBeFalsy();
+
+      expect(isObject(null)).toBeFalsy();
+      expect(isObject(undefined)).toBeFalsy();
+    });
+  });
+
+  describe('mergeDeep', () => {
+    it('should merge properties from two objects', () => {
+      const base = { a: 1, b: 2 };
+      const source = { c: 3 };
+
+      expect(mergeDeep(base, source)).toEqual({ a: 1, b: 2, c: 3 });
+    });
+
+    it('should merge properties from multiple objects', () => {
+      const base = { a: 1, b: 2 };
+      const sources = [{ c: 3 }, { d: 4 }, { e: 5 }];
+
+      expect(mergeDeep(base, sources[0], sources[1], sources[2])).toEqual({
+        a: 1,
+        b: 2,
+        c: 3,
+        d: 4,
+        e: 5
+      });
+    });
+
+    it('should merge subproperties from two objects ', () => {
+      const base = { a: 1, b: { x: 2, z: { c: 1 } } };
+      const source = { b: { y: 3, z: { d: 2 }, w: { f: 1 } } };
+
+      expect(mergeDeep(base, source)).toEqual({
+        a: 1,
+        b: { x: 2, y: 3, z: { c: 1, d: 2 }, w: { f: 1 } }
+      });
+    });
+
+    it('should overwrite properties of base object with source object', () => {
+      const base = { a: 1, b: 2 };
+      const source = { c: 3, b: 4 };
+
+      expect(mergeDeep(base, source)).toEqual({ a: 1, b: 4, c: 3 });
+    });
+
+    it('should overwrite properties in the correct order', () => {
+      const base = { a: 1, b: 2 };
+      const sources = [{ c: 3, b: 4, d: 6 }, { c: 5 }, { b: 7 }];
+
+      expect(mergeDeep(base, sources[0], sources[1], sources[2])).toEqual({
+        a: 1,
+        b: 7,
+        c: 5,
+        d: 6
+      });
     });
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:  #1683

## What is the new behavior?

The values that are set in the options object are supplied by the default options. This behaviour was already partially implemented using `Object.assign`, however that function does not merge deeply. This then affected the `selectorOptions` for the `NgxsStoreModule`, as they are a object inside the `options` object. The new util function `mergeDeep` does basically the same thing as `Object.assign` but also deeply.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Not sure if this counts as "breaking", but for example if someone set  the `selectorOptions`, with the intent on disabling the option `injectContainerState` implicitly,

```ts
NgxsModule.forRoot([ContactsState], {
     selectorOptions: { suppressErrors: false }
})

// instead of this

NgxsModule.forRoot([ContactsState], {
    selectorOptions: { suppressErrors: false, injectContainerState: false }
})
```

then this would now result in `injectContainerState` becoming true instead of false (in reality it is "falsy" and not false).

## Other information

I had to fix one selector test by explicitly setting the option to false, as it was making use of this implicit "falsyness".
I also added some code to the example, this see if container injection is on or off.
Since i saw you explicitly allow the launch.json to be commited (in the gitignore) i added my jest debugging launch configurations.