### PR TITLE
fix(store): faulty select if requested before state added

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -32,14 +32,14 @@
       "path": "./@ngxs/store/fesm2015/ngxs-store.js",
       "package": "@ngxs/store",
       "target": "es2015",
-      "maxSize": "113.25KB",
+      "maxSize": "114.05KB",
       "compression": "none"
     },
     {
       "path": "./@ngxs/store/fesm5/ngxs-store.js",
       "package": "@ngxs/store",
       "target": "es5",
-      "maxSize": "133.10KB",
+      "maxSize": "134.10KB",
       "compression": "none"
     },
     {

--- a/packages/store/src/internal/state-factory.ts
+++ b/packages/store/src/internal/state-factory.ts
@@ -87,7 +87,6 @@ export class StateFactory implements OnDestroy {
       ? this._parentFactory.getRuntimeSelectorContext()
       : {
           getStateGetter(key: string) {
-            // Note to self: This change was done so that selectors that are connected before the state is available can lazy load
             let getter = resolveGetter(key);
             if (getter) {
               return getter;

--- a/packages/store/tests/store.spec.ts
+++ b/packages/store/tests/store.spec.ts
@@ -1,12 +1,13 @@
 import { async, TestBed } from '@angular/core/testing';
-import { Observable } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 
 import { Store } from '../src/store';
 import { NgxsModule } from '../src/module';
 import { State } from '../src/decorators/state';
 import { Action } from '../src/decorators/action';
 import { StateContext } from '../src/symbols';
-import { Injectable } from '@angular/core';
+import { Injectable, ModuleWithProviders, NgModule, Type } from '@angular/core';
+import { tap } from 'rxjs/operators';
 
 describe('Store', () => {
   interface SubSubStateModel {
@@ -83,18 +84,30 @@ describe('Store', () => {
   @Injectable()
   class MyOtherState {}
 
-  let store: Store;
-
-  beforeEach(() => {
+  function setup(
+    options: {
+      preImports?: (ModuleWithProviders<any> | Type<any>)[];
+    } = {}
+  ) {
     TestBed.configureTestingModule({
-      imports: [NgxsModule.forRoot([MySubState, MySubSubState, MyState, MyOtherState])]
+      imports: [
+        ...(options.preImports || []),
+        NgxsModule.forRoot([MySubState, MySubSubState, MyState, MyOtherState])
+      ]
     });
 
-    store = TestBed.inject(Store);
-  });
+    const store = TestBed.inject(Store);
+    return {
+      store
+    };
+  }
 
   it('should subscribe to the root state', async(() => {
+    // Arrange
+    const { store } = setup();
+    // Act
     store.subscribe((state: any) => {
+      // Assert
       expect(state).toEqual({
         foo: {
           first: 'Hello',
@@ -115,15 +128,78 @@ describe('Store', () => {
   }));
 
   it('should select the correct state use a function', async(() => {
+    // Arrange
+    const { store } = setup();
+    // Act
     store
       .select((state: { foo: StateModel }) => state.foo.first)
       .subscribe(state => {
+        // Assert
         expect(state).toBe('Hello');
       });
   }));
 
-  it('should select the correct state use a state class: Root State', async(() => {
-    store.select(MyState).subscribe(state => {
+  describe('[select]', () => {
+    it('should select the correct state use a state class: Root State', async(() => {
+      // Arrange
+      const { store } = setup();
+      // Act
+      store.select(MyState).subscribe(state => {
+        // Assert
+        expect(state).toEqual({
+          first: 'Hello',
+          second: 'World',
+          bar: {
+            hello: true,
+            world: true,
+            baz: {
+              name: 'Danny'
+            }
+          }
+        });
+      });
+    }));
+
+    it('should select the correct state use a state class: Sub State', async(() => {
+      // Arrange
+      const { store } = setup();
+      // Act
+      // todo: remove any
+      store.select<SubStateModel>(<any>MySubState).subscribe((state: SubStateModel) => {
+        // Assert
+        expect(state).toEqual({
+          hello: true,
+          world: true,
+          baz: {
+            name: 'Danny'
+          }
+        });
+      });
+    }));
+
+    it('should select the correct state use a state class: Sub Sub State', async(() => {
+      // Arrange
+      const { store } = setup();
+      // Act
+      // todo: remove any
+      store
+        .select<SubSubStateModel>(<any>MySubSubState)
+        .subscribe((state: SubSubStateModel) => {
+          // Assert
+          expect(state).toEqual({
+            name: 'Danny'
+          });
+        });
+    }));
+  });
+
+  describe('[selectSnapshot]', () => {
+    it('should select snapshot state use a state class', async(() => {
+      // Arrange
+      const { store } = setup();
+      // Act
+      const state = store.selectSnapshot(MyState);
+      // Assert
       expect(state).toEqual({
         first: 'Hello',
         second: 'World',
@@ -135,52 +211,19 @@ describe('Store', () => {
           }
         }
       });
-    });
-  }));
+    }));
 
-  it('should select the correct state use a state class: Sub State', async(() => {
-    // todo: remove any
-    store.select<SubStateModel>(<any>MySubState).subscribe((state: SubStateModel) => {
+    it('should select state with an underscore in name', async(() => {
+      // Arrange
+      const { store } = setup();
+      // Act
+      const state = store.selectSnapshot(MyOtherState);
+      // Assert
       expect(state).toEqual({
-        hello: true,
-        world: true,
-        baz: {
-          name: 'Danny'
-        }
+        under: 'score'
       });
-    });
-  }));
-
-  it('should select the correct state use a state class: Sub Sub State', async(() => {
-    // todo: remove any
-    store.select<SubSubStateModel>(<any>MySubSubState).subscribe((state: SubSubStateModel) => {
-      expect(state).toEqual({
-        name: 'Danny'
-      });
-    });
-  }));
-
-  it('should select snapshot state use a state class', async(() => {
-    const state = store.selectSnapshot(MyState);
-    expect(state).toEqual({
-      first: 'Hello',
-      second: 'World',
-      bar: {
-        hello: true,
-        world: true,
-        baz: {
-          name: 'Danny'
-        }
-      }
-    });
-  }));
-
-  it('should select state with an underscore in name', async(() => {
-    const state = store.selectSnapshot(MyOtherState);
-    expect(state).toEqual({
-      under: 'score'
-    });
-  }));
+    }));
+  });
 
   // it('should not require you to subscrube in order to dispatch', () => {});
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

If a selector is used to retrieve state from a state that has not yet loaded then, for that specific observable, the value does not get updated once the state is loaded, but it always returns `undefined`.

Issue Number: #1522 

## What is the new behavior?

The selector will return the correct values once the state is loaded.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
