### PR TITLE
perf(router-plugin): tree-shake `isAngularInTestMode()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ $ npm install @ngxs/store@dev
 
 - Fix: Allow to inject the `Store` into the custom error handler [#1708](https://github.com/ngxs/store/pull/1708)
 - Performance: Tree-shake errors and warnings [#1732](https://github.com/ngxs/store/pull/1732)
+- Performance: Router Plugin - Tree-shake `isAngularInTestMode()` [#1733](https://github.com/ngxs/store/pull/1733)
 - Performance: Storage Plugin - Tree-shake `console.*` calls and expand error messages [#1727](https://github.com/ngxs/store/pull/1727)
 - CI: Add bundlesize check for the latest integration app [#1710](https://github.com/ngxs/store/pull/1710)
 

--- a/integrations/hello-world-ng11-ivy/bundlesize.config.json
+++ b/integrations/hello-world-ng11-ivy/bundlesize.config.json
@@ -3,7 +3,7 @@
     {
       "path": "./dist-integration/main.*.js",
       "target": "es2015",
-      "maxSize": "251.70 kB",
+      "maxSize": "251.35 kB",
       "compression": "none"
     }
   ]

--- a/packages/router-plugin/src/router.state.ts
+++ b/packages/router-plugin/src/router.state.ts
@@ -33,6 +33,12 @@ export interface RouterStateModel<T = RouterStateSnapshot> {
 
 export type RouterTrigger = 'none' | 'router' | 'store';
 
+/**
+ * @description Will be provided through Terser global definitions by Angular CLI
+ * during the production build. This is how Angular does tree-shaking internally.
+ */
+declare const ngDevMode: boolean;
+
 @State<RouterStateModel>({
   name: 'router',
   defaults: {
@@ -233,7 +239,14 @@ export class RouterState {
    * is triggered
    */
   private checkInitialNavigationOnce(): void {
-    if (isAngularInTestMode()) {
+    // Caretaker note: we have still left the `typeof` condition in order to avoid
+    // creating a breaking change for projects that still use the View Engine.
+    if (
+      (typeof ngDevMode === 'undefined' || ngDevMode) &&
+      // Angular is running tests in development mode thus we can be sure that this method will be
+      // skipped in tests.
+      isAngularInTestMode()
+    ) {
       return;
     }
 


### PR DESCRIPTION
Removing `isAngularInTestMode()` from the router plugin will allow us to tree-shake this function completely.