### PR TITLE
fix(storage-plugin): only restore state if key matches addedStates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ $ npm install @ngxs/store@dev
 - Fix: Devtools Plugin - Do not connect to devtools when the plugin is disabled [#1761](https://github.com/ngxs/store/pull/1761)
 - Fix: Router Plugin - Cleanup subscriptions when the root view is destroyed [#1754](https://github.com/ngxs/store/pull/1754)
 - Fix: WebSocket Plugin - Cleanup subscriptions and close the connection when the root view is destroyed [#1755](https://github.com/ngxs/store/pull/1755)
+- Fix: Storage Plugin - Only restore state if key matches `addedStates` [#1746](https://github.com/ngxs/store/pull/1746)
 - Performance: Tree-shake errors and warnings [#1732](https://github.com/ngxs/store/pull/1732)
 - Performance: Tree-shake `ConfigValidator`, `HostEnvironment` and `isAngularInTestMode` [#1741](https://github.com/ngxs/store/pull/1741)
 - Performance: Tree-shake `SelectFactory` [#1744](https://github.com/ngxs/store/pull/1744)

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -116,14 +116,14 @@
       "path": "./@ngxs/storage-plugin/fesm2015/ngxs-storage-plugin.js",
       "package": "@ngxs/storage-plugin",
       "target": "es2015",
-      "maxSize": "12.56KB",
+      "maxSize": "12.65KB",
       "compression": "none"
     },
     {
       "path": "./@ngxs/storage-plugin/fesm5/ngxs-storage-plugin.js",
       "package": "@ngxs/storage-plugin",
       "target": "es5",
-      "maxSize": "14.20KB",
+      "maxSize": "14.29KB",
       "compression": "none"
     },
     {

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -116,14 +116,14 @@
       "path": "./@ngxs/storage-plugin/fesm2015/ngxs-storage-plugin.js",
       "package": "@ngxs/storage-plugin",
       "target": "es2015",
-      "maxSize": "12.150KB",
+      "maxSize": "12.56KB",
       "compression": "none"
     },
     {
       "path": "./@ngxs/storage-plugin/fesm5/ngxs-storage-plugin.js",
       "package": "@ngxs/storage-plugin",
       "target": "es5",
-      "maxSize": "13.790KB",
+      "maxSize": "14.20KB",
       "compression": "none"
     },
     {

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -116,14 +116,14 @@
       "path": "./@ngxs/storage-plugin/fesm2015/ngxs-storage-plugin.js",
       "package": "@ngxs/storage-plugin",
       "target": "es2015",
-      "maxSize": "12.000KB",
+      "maxSize": "12.150KB",
       "compression": "none"
     },
     {
       "path": "./@ngxs/storage-plugin/fesm5/ngxs-storage-plugin.js",
       "package": "@ngxs/storage-plugin",
       "target": "es5",
-      "maxSize": "13.630KB",
+      "maxSize": "13.790KB",
       "compression": "none"
     },
     {

--- a/integrations/hello-world-ng11-ivy/bundlesize.config.json
+++ b/integrations/hello-world-ng11-ivy/bundlesize.config.json
@@ -3,7 +3,7 @@
     {
       "path": "./dist-integration/main.*.js",
       "target": "es2015",
-      "maxSize": "251.9 kB",
+      "maxSize": "251.05 kB",
       "compression": "none"
     }
   ]

--- a/integrations/hello-world-ng11-ivy/bundlesize.config.json
+++ b/integrations/hello-world-ng11-ivy/bundlesize.config.json
@@ -3,7 +3,7 @@
     {
       "path": "./dist-integration/main.*.js",
       "target": "es2015",
-      "maxSize": "251.00 kB",
+      "maxSize": "251.9 kB",
       "compression": "none"
     }
   ]

--- a/integrations/hello-world-ng12-ivy/bundlesize.config.json
+++ b/integrations/hello-world-ng12-ivy/bundlesize.config.json
@@ -3,7 +3,7 @@
     {
       "path": "./dist-integration/main.*.js",
       "target": "es2015",
-      "maxSize": "236.60 kB",
+      "maxSize": "236.65 kB",
       "compression": "none"
     }
   ]

--- a/packages/storage-plugin/src/storage.plugin.ts
+++ b/packages/storage-plugin/src/storage.plugin.ts
@@ -47,6 +47,10 @@ export class NgxsStoragePlugin implements NgxsPlugin {
 
     if (isInitAction) {
       for (const key of keys) {
+        if (matches(UpdateState) && !(key in ((event as UpdateState).addedStates || {}))) {
+          continue;
+        }
+
         const isMaster = key === DEFAULT_STATE_KEY;
         let val: any = this._engine.getItem(key!);
 

--- a/packages/storage-plugin/src/storage.plugin.ts
+++ b/packages/storage-plugin/src/storage.plugin.ts
@@ -42,7 +42,9 @@ export class NgxsStoragePlugin implements NgxsPlugin {
     // transformed by the `storageOptionsFactory` function that provided token
     const keys = this._options.key as string[];
     const matches = actionMatcher(event);
-    const isInitOrUpdateAction = matches(InitState) || matches(UpdateState);
+    const isInitAction = matches(InitState);
+    const isUpdateAction = matches(UpdateState);
+    const isInitOrUpdateAction = isInitAction || isUpdateAction;
     let hasMigration = false;
 
     if (isInitOrUpdateAction) {
@@ -50,11 +52,7 @@ export class NgxsStoragePlugin implements NgxsPlugin {
         // We're checking what states have been added by NGXS and if any of these states should be handled by
         // the storage plugin. For instance, we only want to deserialize the `auth` state, NGXS has added
         // the `user` state, the storage plugin will be rerun and will do redundant deserialization.
-        if (
-          matches(UpdateState) &&
-          event.addedStates &&
-          !event.addedStates.hasOwnProperty(key)
-        ) {
+        if (isUpdateAction && event.addedStates && !event.addedStates.hasOwnProperty(key)) {
           continue;
         }
 

--- a/packages/storage-plugin/tests/issues/issue-restore-state-only-if-key-matches.spec.ts
+++ b/packages/storage-plugin/tests/issues/issue-restore-state-only-if-key-matches.spec.ts
@@ -1,0 +1,119 @@
+import { APP_BASE_HREF } from '@angular/common';
+import { Router, RouterModule } from '@angular/router';
+import { BrowserModule } from '@angular/platform-browser';
+import { Component, NgModule, NgZone } from '@angular/core';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { freshPlatform } from '@ngxs/store/internals/testing';
+import { State, NgxsModule, Store, StateToken } from '@ngxs/store';
+
+import { NgxsStoragePluginModule } from '../../';
+
+describe('Restore state only if key matches', () => {
+  beforeEach(() => {
+    // Caretaker note: it somehow sets `/@angular-cli-builders` as a default URL, thus when running `initialNavigation()`
+    // it errors that there's no route definition for the `/@angular-cli-builders`.
+    spyOn(Router.prototype, 'initialNavigation').and.returnValue(undefined);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it(
+    'should not deserialize the state twice if the state should not be handled by the storage plugin',
+    freshPlatform(async () => {
+      // Arrange
+      interface AuthStateModel {
+        token: string;
+      }
+
+      const AUTH_STATE_TOKEN = new StateToken<AuthStateModel | null>('auth');
+
+      localStorage.setItem(
+        AUTH_STATE_TOKEN.getName(),
+        JSON.stringify({
+          token: 'initialTokenFromLocalStorage'
+        })
+      );
+
+      @State<AuthStateModel | null>({
+        name: AUTH_STATE_TOKEN,
+        defaults: null
+      })
+      class AuthState {}
+
+      @State({
+        name: 'user',
+        defaults: {}
+      })
+      class UserState {}
+
+      @Component({ template: '' })
+      class UserComponent {}
+
+      @NgModule({
+        imports: [
+          RouterModule.forChild([
+            {
+              path: '',
+              component: UserComponent
+            }
+          ]),
+          NgxsModule.forFeature([UserState])
+        ],
+        declarations: [UserComponent]
+      })
+      class UserModule {}
+
+      @Component({ selector: 'app-root', template: '<router-outlet></router-outlet>' })
+      class TestComponent {}
+
+      @NgModule({
+        imports: [
+          BrowserModule,
+          RouterModule.forRoot([
+            {
+              path: 'user',
+              loadChildren: () => UserModule
+            }
+          ]),
+          NgxsModule.forRoot([AuthState]),
+          NgxsStoragePluginModule.forRoot({
+            key: [AuthState]
+          })
+        ],
+        declarations: [TestComponent],
+        bootstrap: [TestComponent],
+        providers: [{ provide: APP_BASE_HREF, useValue: '/' }]
+      })
+      class TestModule {}
+
+      // Act
+      const { injector } = await platformBrowserDynamic().bootstrapModule(TestModule);
+      const ngZone = injector.get(NgZone);
+      const router = injector.get(Router);
+      const store = injector.get(Store);
+      const subscribeSpy = jest.fn();
+      const subscription = store.select(AuthState).subscribe(subscribeSpy);
+
+      // Well, we're explicitly setting another value for the auth state before going to the `/user` route.
+      // Previously, it would've retrieved the auth state value from the local storage each time the `UpdateState`
+      // action is dispatched. See `storage.plugin.ts` and `!event.addedStates.hasOwnProperty(key)` expression which
+      // runs `continue` if the state, which has been added, shouldn't be handled by the storage plugin.
+      localStorage.setItem(
+        AUTH_STATE_TOKEN.getName(),
+        JSON.stringify({ token: 'manuallySetTokenToEnsureItIsNotRetrievedAgain' })
+      );
+
+      await ngZone.run(() => router.navigateByUrl('/user'));
+
+      // Assert
+      expect(subscribeSpy).toHaveBeenCalledTimes(1);
+      expect(subscribeSpy).toHaveBeenCalledWith({
+        token: 'initialTokenFromLocalStorage'
+      });
+
+      subscription.unsubscribe();
+    })
+  );
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
This plugin is reacting to the `InitState` event as well as any `UpdateState` events.

When state is loaded lazily, it triggers an `UpdateState` event that passes along the states being added `addedStates`.  Each time an `UpdateState` event is triggered, it causes the state to be restored for each key defined in storage-plugin.  In cases where there are multiple lazily loaded state, this causes multiple `setState` actions to be triggered, and any subscriptions of that state, will fire.

Issue Number: N/A

## What is the new behavior?

`InitState` will continue to restore state from storage engine for all defined keys.

`UpdateState` will only restore from storage engine if key matches `addedStates`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
