### PR TITLE
fix(store): handle mixed async scenarios for action handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ $ npm install @ngxs/store@dev
 ```
 
 - Fix: Do not re-use the global `Store` instance between different apps [#1740](https://github.com/ngxs/store/pull/1740)
+- Fix: Handle mixed async scenarios for action handlers [#1762](https://github.com/ngxs/store/pull/1762)
 - Fix: Do not run `Promise.then` within synchronous tests when decorating factory [#1753](https://github.com/ngxs/store/pull/1753)
 - Fix: Devtools Plugin - Do not connect to devtools when the plugin is disabled [#1761](https://github.com/ngxs/store/pull/1761)
 - Fix: Router Plugin - Cleanup subscriptions when the root view is destroyed [#1754](https://github.com/ngxs/store/pull/1754)

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -32,14 +32,14 @@
       "path": "./@ngxs/store/fesm2015/ngxs-store.js",
       "package": "@ngxs/store",
       "target": "es2015",
-      "maxSize": "112.22KB",
+      "maxSize": "112.75KB",
       "compression": "none"
     },
     {
       "path": "./@ngxs/store/fesm5/ngxs-store.js",
       "package": "@ngxs/store",
       "target": "es5",
-      "maxSize": "131.06KB",
+      "maxSize": "131.70KB",
       "compression": "none"
     },
     {

--- a/integrations/hello-world-ng11-ivy/bundlesize.config.json
+++ b/integrations/hello-world-ng11-ivy/bundlesize.config.json
@@ -3,7 +3,7 @@
     {
       "path": "./dist-integration/main.*.js",
       "target": "es2015",
-      "maxSize": "250.58 kB",
+      "maxSize": "250.95 kB",
       "compression": "none"
     }
   ]

--- a/integrations/hello-world-ng12-ivy/bundlesize.config.json
+++ b/integrations/hello-world-ng12-ivy/bundlesize.config.json
@@ -3,7 +3,7 @@
     {
       "path": "./dist-integration/main.*.js",
       "target": "es2015",
-      "maxSize": "236.18 kB",
+      "maxSize": "236.60 kB",
       "compression": "none"
     }
   ]

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "build:integration:ssr": "yarn build:integration && ng run integration:server:production",
     "// - TESTING": "Test all modules #requires yarn build:packages",
     "test": "ng test",
+    "test:ngxs:watch": "ng test --watch --project ngxs",
     "test:integration": "ng run integration:test --colors --runInBand",
     "test:types": "dtslint packages/store/types --localTs node_modules/typescript/lib",
     "// - E2E": "E2E testing #requires yarn build:integration",

--- a/packages/store/src/internal/state-factory.ts
+++ b/packages/store/src/internal/state-factory.ts
@@ -248,7 +248,18 @@ export class StateFactory implements OnDestroy {
               // `handler(ctx) { return EMPTY; }`
               // then the action will be canceled.
               // See https://github.com/ngxs/store/issues/1568
-              result = result.pipe(defaultIfEmpty({}));
+              result = result.pipe(
+                mergeMap((value: any) => {
+                  if (value instanceof Promise) {
+                    return from(value);
+                  }
+                  if (value instanceof Observable) {
+                    return value;
+                  }
+                  return of(value);
+                }),
+                defaultIfEmpty({})
+              );
 
               if (actionMeta.options.cancelUncompleted) {
                 // todo: ofActionDispatched should be used with action class

--- a/packages/store/tests/action.spec.ts
+++ b/packages/store/tests/action.spec.ts
@@ -1,23 +1,21 @@
 import { ErrorHandler, Injectable } from '@angular/core';
-import { TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { delay, mapTo, tap } from 'rxjs/operators';
-import { throwError, of, Subject } from 'rxjs';
-
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { of, Subject, throwError } from 'rxjs';
+import { delay, map, tap } from 'rxjs/operators';
+import { Actions } from '../src/actions-stream';
 import { Action } from '../src/decorators/action';
 import { State } from '../src/decorators/state';
-import { META_KEY, StateContext } from '../src/symbols';
-
 import { NgxsModule } from '../src/module';
-import { Store } from '../src/store';
-import { Actions } from '../src/actions-stream';
 import {
-  ofActionSuccessful,
-  ofActionDispatched,
   ofAction,
-  ofActionErrored,
   ofActionCanceled,
-  ofActionCompleted
+  ofActionCompleted,
+  ofActionDispatched,
+  ofActionErrored,
+  ofActionSuccessful
 } from '../src/operators/of-action';
+import { Store } from '../src/store';
+import { META_KEY, StateContext } from '../src/symbols';
 import { NoopErrorHandler } from './helpers/utils';
 
 describe('Action', () => {
@@ -341,7 +339,9 @@ describe('Action', () => {
           record('obsThatReturnsPromise - start');
           return observable.pipe(
             tap(() => record('obsThatReturnsPromise - observable tap')),
-            mapTo(promise)
+            map(async () => {
+              return await promise;
+            })
           );
         }
 
@@ -377,7 +377,7 @@ describe('Action', () => {
     }
 
     describe('Promise that returns an observable', () => {
-      it('completes when promise is resolved', fakeAsync(() => {
+      it('completes when observable is resolved', fakeAsync(() => {
         // Arrange
         const {
           store,
@@ -409,9 +409,7 @@ describe('Action', () => {
           '(promiseResolveFn) called',
           'promise resolved',
           'promiseThatReturnsObs - after promise',
-          'observableAction - start',
-          'PromiseThatReturnsObs [Completed]',
-          'dispatch(PromiseThatReturnsObs) - Completed'
+          'observableAction - start'
         ]);
 
         completeObservableFn();
@@ -423,19 +421,20 @@ describe('Action', () => {
           'promise resolved',
           'promiseThatReturnsObs - after promise',
           'observableAction - start',
-          'PromiseThatReturnsObs [Completed]',
-          'dispatch(PromiseThatReturnsObs) - Completed',
           '(completeObservableFn) - next',
           'observableAction - observable tap',
           '(completeObservableFn) - complete',
           'ObservableAction [Completed]',
+          'promiseThatReturnsObs - observable tap',
+          'PromiseThatReturnsObs [Completed]',
+          'dispatch(PromiseThatReturnsObs) - Completed',
           '(completeObservableFn) - end'
         ]);
       }));
     });
 
     describe('Observable that returns a promise', () => {
-      it('completes when observable is completed', fakeAsync(() => {
+      it('completes when promise is completed', fakeAsync(() => {
         // Arrange
         const {
           store,
@@ -467,8 +466,6 @@ describe('Action', () => {
           '(completeObservableFn) - next',
           'obsThatReturnsPromise - observable tap',
           '(completeObservableFn) - complete',
-          'ObsThatReturnsPromise [Completed]',
-          'dispatch(ObsThatReturnsPromise) - Completed',
           '(completeObservableFn) - end'
         ]);
 
@@ -480,12 +477,12 @@ describe('Action', () => {
           '(completeObservableFn) - next',
           'obsThatReturnsPromise - observable tap',
           '(completeObservableFn) - complete',
-          'ObsThatReturnsPromise [Completed]',
-          'dispatch(ObsThatReturnsPromise) - Completed',
           '(completeObservableFn) - end',
           '(promiseResolveFn) called',
           'promise resolved',
-          'promise [resolved]'
+          'promise [resolved]',
+          'ObsThatReturnsPromise [Completed]',
+          'dispatch(ObsThatReturnsPromise) - Completed'
         ]);
       }));
     });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

There currently exists an issue where a user could mistakenly return an observable from an async method and the returned observable will not be subscribed to, and will not determine the completion event of the original action.
A similar situation exists (although not as impactful) where a promise is returned from an observable. For example, if the user used the `map` rxjs pipe, but declared the mapper function as `async (value) => { .....`.

Issue Number: #1660 #1663

## What is the new behavior?

The NGXS engine will inspect the inner values returned by the action handler methods and unwrap any inner observable or promise so that they are now part of the action result observable subscription.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

## Other information
