### PR TITLE
fix(store): cancel uncompleted should unsubscribe before next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ $ npm install @ngxs/store@dev
 
 - Fix: Do not re-use the global `Store` instance between different apps [#1740](https://github.com/ngxs/store/pull/1740)
 - Fix: Handle mixed async scenarios for action handlers [#1762](https://github.com/ngxs/store/pull/1762)
+- Fix: An action with cancelUncompleted enabled should unsubscribe before the next action handler is called [#1763](https://github.com/ngxs/store/pull/1763)
 - Fix: Do not run `Promise.then` within synchronous tests when decorating factory [#1753](https://github.com/ngxs/store/pull/1753)
 - Fix: Devtools Plugin - Do not connect to devtools when the plugin is disabled [#1761](https://github.com/ngxs/store/pull/1761)
 - Fix: Router Plugin - Cleanup subscriptions when the root view is destroyed [#1754](https://github.com/ngxs/store/pull/1754)

--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -32,14 +32,14 @@
       "path": "./@ngxs/store/fesm2015/ngxs-store.js",
       "package": "@ngxs/store",
       "target": "es2015",
-      "maxSize": "112.75KB",
+      "maxSize": "113.00KB",
       "compression": "none"
     },
     {
       "path": "./@ngxs/store/fesm5/ngxs-store.js",
       "package": "@ngxs/store",
       "target": "es5",
-      "maxSize": "131.70KB",
+      "maxSize": "131.85KB",
       "compression": "none"
     },
     {

--- a/integrations/hello-world-ng11-ivy/bundlesize.config.json
+++ b/integrations/hello-world-ng11-ivy/bundlesize.config.json
@@ -3,7 +3,7 @@
     {
       "path": "./dist-integration/main.*.js",
       "target": "es2015",
-      "maxSize": "250.95 kB",
+      "maxSize": "251.00 kB",
       "compression": "none"
     }
   ]

--- a/packages/store/src/internal/state-factory.ts
+++ b/packages/store/src/internal/state-factory.ts
@@ -1,5 +1,5 @@
 import { Injectable, Injector, Optional, SkipSelf, Inject, OnDestroy } from '@angular/core';
-import { forkJoin, from, Observable, of, throwError, Subscription } from 'rxjs';
+import { forkJoin, from, Observable, of, throwError, Subscription, Subject } from 'rxjs';
 import {
   catchError,
   defaultIfEmpty,
@@ -203,18 +203,21 @@ export class StateFactory implements OnDestroy {
    */
   connectActionHandlers() {
     if (this._actionsSubscription !== null) return;
+    const dispatched$ = new Subject<ActionContext>();
     this._actionsSubscription = this._actions
       .pipe(
         filter((ctx: ActionContext) => ctx.status === ActionStatus.Dispatched),
-        mergeMap(({ action }) =>
-          this.invokeActions(this._actions, action!).pipe(
+        mergeMap(ctx => {
+          dispatched$.next(ctx);
+          const action = ctx.action;
+          return this.invokeActions(dispatched$, action!).pipe(
             map(() => <ActionContext>{ action, status: ActionStatus.Successful }),
             defaultIfEmpty(<ActionContext>{ action, status: ActionStatus.Canceled }),
             catchError(error =>
               of(<ActionContext>{ action, status: ActionStatus.Errored, error })
             )
-          )
-        )
+          );
+        })
       )
       .subscribe(ctx => this._actionResults.next(ctx));
   }
@@ -222,7 +225,7 @@ export class StateFactory implements OnDestroy {
   /**
    * Invoke actions on the states.
    */
-  invokeActions(actions$: InternalActions, action: any) {
+  invokeActions(dispatched$: Observable<ActionContext>, action: any) {
     const type = getActionTypeFromInstance(action)!;
     const results = [];
 
@@ -264,7 +267,7 @@ export class StateFactory implements OnDestroy {
               if (actionMeta.options.cancelUncompleted) {
                 // todo: ofActionDispatched should be used with action class
                 result = result.pipe(
-                  takeUntil(actions$.pipe(ofActionDispatched(action as any)))
+                  takeUntil(dispatched$.pipe(ofActionDispatched(action as any)))
                 );
               }
             } else {

--- a/packages/store/tests/action.spec.ts
+++ b/packages/store/tests/action.spec.ts
@@ -1,6 +1,6 @@
 import { ErrorHandler, Injectable } from '@angular/core';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { of, Subject, throwError } from 'rxjs';
+import { Observable, of, Subject, throwError } from 'rxjs';
 import { delay, map, tap } from 'rxjs/operators';
 import { Actions } from '../src/actions-stream';
 import { Action } from '../src/decorators/action';
@@ -33,6 +33,7 @@ describe('Action', () => {
 
   class CancelingAction {
     static type = 'CancelingAction';
+    constructor(public readonly id: number) {}
   }
 
   @State({
@@ -202,65 +203,71 @@ describe('Action', () => {
       const { store, actions } = setup();
       const callbacksCalled: string[] = [];
 
-      actions.pipe(ofAction(CancelingAction)).subscribe(() => {
-        callbacksCalled.push('ofAction');
+      actions.pipe(ofAction(CancelingAction)).subscribe(({ id }: CancelingAction) => {
+        callbacksCalled.push('ofAction ' + id);
       });
 
-      actions.pipe(ofActionDispatched(CancelingAction)).subscribe(() => {
-        callbacksCalled.push('ofActionDispatched');
+      actions
+        .pipe(ofActionDispatched(CancelingAction))
+        .subscribe(({ id }: CancelingAction) => {
+          callbacksCalled.push('ofActionDispatched ' + id);
+        });
+
+      actions.pipe(ofActionErrored(CancelingAction)).subscribe(({ id }: CancelingAction) => {
+        callbacksCalled.push('ofActionErrored ' + id);
       });
 
-      actions.pipe(ofActionErrored(CancelingAction)).subscribe(() => {
-        callbacksCalled.push('ofActionErrored');
-      });
+      actions
+        .pipe(ofActionSuccessful(CancelingAction))
+        .subscribe(({ id }: CancelingAction) => {
+          callbacksCalled.push('ofActionSuccessful ' + id);
+          expect(callbacksCalled).toEqual([
+            'ofAction 1',
+            'ofActionDispatched 1',
+            'ofAction 2',
+            'ofActionDispatched 2',
+            'ofAction 1',
+            'ofActionCanceled 1',
+            'ofAction 2',
+            'ofActionSuccessful 2'
+          ]);
+        });
 
-      actions.pipe(ofActionSuccessful(CancelingAction)).subscribe(() => {
-        callbacksCalled.push('ofActionSuccessful');
+      actions.pipe(ofActionCanceled(CancelingAction)).subscribe(({ id }: CancelingAction) => {
+        callbacksCalled.push('ofActionCanceled ' + id);
         expect(callbacksCalled).toEqual([
-          'ofAction',
-          'ofActionDispatched',
-          'ofAction',
-          'ofActionDispatched',
-          'ofAction',
-          'ofActionCanceled',
-          'ofAction',
-          'ofActionSuccessful'
-        ]);
-      });
-
-      actions.pipe(ofActionCanceled(CancelingAction)).subscribe(() => {
-        callbacksCalled.push('ofActionCanceled');
-        expect(callbacksCalled).toEqual([
-          'ofAction',
-          'ofActionDispatched',
-          'ofAction',
-          'ofActionDispatched',
-          'ofAction',
-          'ofActionCanceled'
+          'ofAction 1',
+          'ofActionDispatched 1',
+          'ofAction 2',
+          'ofActionDispatched 2',
+          'ofAction 1',
+          'ofActionCanceled 1'
         ]);
       });
 
       // Act
-      store.dispatch([new CancelingAction(), new CancelingAction()]).subscribe(() => {
+      store.dispatch([new CancelingAction(1), new CancelingAction(2)]).subscribe(() => {
         expect(callbacksCalled).toEqual([
-          'ofAction',
-          'ofActionDispatched',
-          'ofAction',
-          'ofActionDispatched'
+          'ofAction 1',
+          'ofActionDispatched 1',
+          'ofAction 2',
+          'ofActionDispatched 2',
+          'ofAction 1',
+          'ofActionCanceled 1'
         ]);
       });
 
       tick(1);
       // Assert
       expect(callbacksCalled).toEqual([
-        'ofAction',
-        'ofActionDispatched',
-        'ofAction',
-        'ofActionDispatched',
-        'ofAction',
-        'ofActionCanceled',
-        'ofAction',
-        'ofActionSuccessful'
+        'ofAction 1',
+        'ofActionDispatched 1',
+        'ofAction 2',
+        'ofActionDispatched 2',
+        'ofAction 1',
+        'ofActionCanceled 1',
+        'ofAction 2',
+        'ofActionSuccessful 2'
       ]);
     }));
 
@@ -633,5 +640,119 @@ describe('Action', () => {
         ]);
       }));
     });
+  });
+
+  describe('Cancellable Action Scenario', () => {
+    class CancellableAction {
+      static type = 'Cancellable';
+      constructor(
+        public readonly id: number,
+        public readonly observable: Observable<string>
+      ) {}
+    }
+
+    function setup() {
+      const recorder: string[] = [];
+      const record = (message: string) => recorder.push(message);
+
+      @State({
+        name: 'cancellable_action_state'
+      })
+      @Injectable()
+      class AsyncState {
+        @Action(CancellableAction, { cancelUncompleted: true })
+        cancellableAction(_: StateContext<any>, action: CancellableAction) {
+          record(`cancellableAction(${action.id}) - start`);
+          return action.observable.pipe(
+            tap(() => record(`cancellableAction(${action.id}) - observable tap`))
+          );
+        }
+      }
+
+      TestBed.configureTestingModule({
+        imports: [NgxsModule.forRoot([AsyncState])],
+        providers: [{ provide: ErrorHandler, useClass: NoopErrorHandler }]
+      });
+
+      const store = TestBed.inject(Store);
+      const actions = TestBed.inject(Actions);
+      return {
+        store,
+        actions,
+        recorder,
+        record
+      };
+    }
+
+    function recordStream<TValue>(record: (phase: string, value?: TValue) => void) {
+      return function(source: Observable<TValue>): Observable<TValue> {
+        return new Observable(subscriber => {
+          record('subscribe');
+          const subscription = source.subscribe({
+            next(value) {
+              record('next', value);
+              subscriber.next(value);
+            },
+            error(error) {
+              record('next', error);
+              subscriber.error(error);
+            },
+            complete() {
+              record('complete');
+              subscriber.complete();
+            }
+          });
+          return () => {
+            record('unsubscribe');
+            subscription.unsubscribe();
+          };
+        });
+      };
+    }
+
+    function recordedObservable(
+      observable1: Subject<string>,
+      prefix: string,
+      record: (message: string) => number
+    ): Observable<string> {
+      return observable1.pipe(
+        recordStream((phase, value) =>
+          record(prefix + ' - ' + phase + (value ? ' ' + value : ''))
+        )
+      );
+    }
+
+    it('unsubscribes to first action observable before starting second action', fakeAsync(() => {
+      // Arrange
+      const { store, recorder, record } = setup();
+
+      const observable1 = new Subject<string>();
+      const action1 = new CancellableAction(
+        1,
+        recordedObservable(observable1, 'action1 obs', record)
+      );
+      const observable2 = new Subject<string>();
+      const action2 = new CancellableAction(
+        2,
+        recordedObservable(observable2, 'action2 obs', record)
+      );
+
+      record('Action 1 - dispatching');
+      store.dispatch(action1).subscribe(() => record('Action 1 - dispatch complete'));
+      // Act
+      record('Action 2 - dispatching');
+      store.dispatch(action2).subscribe(() => record('Action 2 - dispatch complete'));
+
+      // Assert
+      expect(recorder).toEqual([
+        'Action 1 - dispatching',
+        'cancellableAction(1) - start',
+        'action1 obs - subscribe',
+        'Action 2 - dispatching',
+        'cancellableAction(2) - start',
+        'action2 obs - subscribe',
+        'action1 obs - unsubscribe'
+      ]);
+    }));
   });
 });

--- a/packages/store/tests/action.spec.ts
+++ b/packages/store/tests/action.spec.ts
@@ -749,9 +749,9 @@ describe('Action', () => {
         'cancellableAction(1) - start',
         'action1 obs - subscribe',
         'Action 2 - dispatching',
+        'action1 obs - unsubscribe',
         'cancellableAction(2) - start',
-        'action2 obs - subscribe',
-        'action1 obs - unsubscribe'
+        'action2 obs - subscribe'
       ]);
     }));
   });

--- a/packages/store/tests/dispatch.spec.ts
+++ b/packages/store/tests/dispatch.spec.ts
@@ -721,6 +721,7 @@ describe('Dispatch', () => {
     describe('when the action is canceled by a subsequent action', () => {
       it('should not trigger observer, but should complete observable stream', fakeAsync(() => {
         const resolvers: (() => void)[] = [];
+        const subscriptionsCalled: string[] = [];
 
         @State<number>({
           name: 'counter',
@@ -729,6 +730,7 @@ describe('Dispatch', () => {
         class MyState {
           @Action(Increment, { cancelUncompleted: true })
           increment() {
+            subscriptionsCalled.push('increment');
             return new Promise<void>(resolve => resolvers.push(resolve));
           }
         }
@@ -739,7 +741,6 @@ describe('Dispatch', () => {
 
         const store: Store = TestBed.inject(Store);
 
-        const subscriptionsCalled: string[] = [];
         store.dispatch(new Increment()).subscribe(
           () => subscriptionsCalled.push('previous'),
           () => subscriptionsCalled.push('previous error'),
@@ -749,11 +750,12 @@ describe('Dispatch', () => {
         resolvers[0]();
         resolvers[1]();
         tick(0);
-        expect(subscriptionsCalled).toEqual(['previous complete']);
+        expect(subscriptionsCalled).toEqual(['increment', 'increment', 'previous complete']);
       }));
 
       it('should trigger next and completion for latest but only completion for previous', fakeAsync(() => {
         const resolvers: (() => void)[] = [];
+        const subscriptionsCalled: string[] = [];
 
         @State<number>({
           name: 'counter',
@@ -762,6 +764,7 @@ describe('Dispatch', () => {
         class MyState {
           @Action(Increment, { cancelUncompleted: true })
           increment() {
+            subscriptionsCalled.push('increment');
             return new Promise<void>(resolve => resolvers.push(resolve));
           }
         }
@@ -772,7 +775,6 @@ describe('Dispatch', () => {
 
         const store: Store = TestBed.inject(Store);
 
-        const subscriptionsCalled: string[] = [];
         store.dispatch(new Increment()).subscribe(
           () => subscriptionsCalled.push('previous'),
           () => subscriptionsCalled.push('previous error'),
@@ -787,6 +789,8 @@ describe('Dispatch', () => {
         resolvers[1]();
         tick(0);
         expect(subscriptionsCalled).toEqual([
+          'increment',
+          'increment',
           'previous complete',
           'latest',
           'latest complete'

--- a/packages/store/tests/dispatch.spec.ts
+++ b/packages/store/tests/dispatch.spec.ts
@@ -750,7 +750,7 @@ describe('Dispatch', () => {
         resolvers[0]();
         resolvers[1]();
         tick(0);
-        expect(subscriptionsCalled).toEqual(['increment', 'increment', 'previous complete']);
+        expect(subscriptionsCalled).toEqual(['increment', 'previous complete', 'increment']);
       }));
 
       it('should trigger next and completion for latest but only completion for previous', fakeAsync(() => {
@@ -790,8 +790,8 @@ describe('Dispatch', () => {
         tick(0);
         expect(subscriptionsCalled).toEqual([
           'increment',
-          'increment',
           'previous complete',
+          'increment',
           'latest',
           'latest complete'
         ]);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently there is a slightly unexpected order of events when one in-process action is cancelled in favor of another.
The handler for the second action is executed before the observable for the first actions is unsubscribed.
This can lead to subtle issues, especially when implementing an optimistic update strategy.

Issue Number: N/A

## What is the new behavior?
After this PR, the first action's observable will be unsubscribed (and cancelled) before the second action starts executing its handlers.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
