### PR TITLE
docs: update `StorageEngine` section

### DIFF
--- a/docs/plugins/storage.md
+++ b/docs/plugins/storage.md
@@ -165,10 +165,6 @@ export class MyStorageEngine implements StorageEngine {
   clear(): void {
     // Your logic here
   }
-
-  key(val: number): string {
-    // Your logic here
-  }
 }
 
 @NgModule({


### PR DESCRIPTION
Remove outdated `key` method.

Closes #1685

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Documentation content changes