### PR TITLE
docs(store): Add state operator link to state docs

### DIFF
--- a/docs/concepts/state.md
+++ b/docs/concepts/state.md
@@ -206,7 +206,7 @@ public addValue(ctx: StateContext, { payload }: MyAction) {
 }
 ```
 
-You may ask _"How is this valuable?"_. Well, it opens the door for refactoring of your immutable updates into `state operators` so that your code can become more declarative as opposed to imperative. We will be adding some standard `state operators` soon that you will be able to use to express your updates to the state. Follow the issue here for updates: https://github.com/ngxs/store/issues/545
+You may ask _"How is this valuable?"_. Well, it opens the door for refactoring of your immutable updates into `state operators` so that your code can become more declarative as opposed to imperative. You can find more details in our [state operators](https://www.ngxs.io/advanced/operators) documentation.
 
 As another example you could use a library like [immer](https://github.com/mweststrate/immer) that can
 handle the immutability updates for you and provide a different way of expressing your immutable update


### PR DESCRIPTION
Currently the docs for state mention state operators being a WIP, with a link to the github issue for that ticket. I removed that content and replaced it with "You can find more details in our state operators documentation", where "state operators" is a link to that documentation page.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
