### PR TITLE
fix(docs): replace controls prop with value

### DIFF
--- a/docs/plugins/form.md
+++ b/docs/plugins/form.md
@@ -173,7 +173,7 @@ import { FormBuilder, FormGroup } from '@angular/forms';
       <input type="text" formControlName="novelName" />
       <div
         formArrayName="authors"
-        *ngFor="let author of newNovelForm.get('authors').controls; index as index"
+        *ngFor="let author of newNovelForm.get('authors').value; index as index"
       >
         <div [formGroupName]="index">
           <input formControlName="name" />


### PR DESCRIPTION
`Controls` prop gives us an object that throws an error when using that prop for the `NgFor` directive, since Object is not iterable.

Fixes #1733

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
