### PR TITLE
fix(store): allow `@Select()` decorated properties to be accessed within constructors

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -4,14 +4,14 @@
       "path": "./@ngxs/store/fesm2015/ngxs-store-internals.js",
       "package": "@ngxs/store/internals",
       "target": "es2015",
-      "maxSize": "11.75KB",
+      "maxSize": "13.1KB",
       "compression": "none"
     },
     {
       "path": "./@ngxs/store/fesm5/ngxs-store-internals.js",
       "package": "@ngxs/store/internals",
       "target": "es5",
-      "maxSize": "12.70KB",
+      "maxSize": "14.1KB",
       "compression": "none"
     },
     {
@@ -32,14 +32,14 @@
       "path": "./@ngxs/store/fesm2015/ngxs-store.js",
       "package": "@ngxs/store",
       "target": "es2015",
-      "maxSize": "113.00KB",
+      "maxSize": "113.65KB",
       "compression": "none"
     },
     {
       "path": "./@ngxs/store/fesm5/ngxs-store.js",
       "package": "@ngxs/store",
       "target": "es5",
-      "maxSize": "131.85KB",
+      "maxSize": "132.55KB",
       "compression": "none"
     },
     {

--- a/integrations/hello-world-ng11-ivy/bundlesize.config.json
+++ b/integrations/hello-world-ng11-ivy/bundlesize.config.json
@@ -3,7 +3,7 @@
     {
       "path": "./dist-integration/main.*.js",
       "target": "es2015",
-      "maxSize": "251.05 kB",
+      "maxSize": "251.3 kB",
       "compression": "none"
     }
   ]

--- a/integrations/hello-world-ng12-ivy/src/app/__snapshots__/issue-1801-select-within-constructor.spec.ts.snap
+++ b/integrations/hello-world-ng12-ivy/src/app/__snapshots__/issue-1801-select-within-constructor.spec.ts.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`@Select() decorated property is used within a constructor (https://github.com/ngxs/store/issues/1801) should be possible to use @Select() decorated properties within constructors 1`] = `
+Array [
+  "ngModule:constructor:countries$",
+  "ngModule:constructor:lastCountry$",
+  "rootProvider:constructor:countries$",
+  "rootProvider:constructor:lastCountry$",
+  "componentProvider:constructor:countries$",
+  "componentProvider:constructor:lastCountry$",
+  "component:constructor:countries$",
+  "component:constructor:lastCountry$",
+  "directive:constructor:countries$",
+  "directive:constructor:lastCountry$",
+  "pipe:constructor:countries$",
+  "pipe:constructor:lastCountry$",
+  "component:ngOnInit:countries$",
+  "component:ngOnInit:lastCountry$",
+  "directive:ngOnInit:countries$",
+  "directive:ngOnInit:lastCountry$",
+]
+`;

--- a/integrations/hello-world-ng12-ivy/src/app/issue-1801-select-within-constructor.spec.ts
+++ b/integrations/hello-world-ng12-ivy/src/app/issue-1801-select-within-constructor.spec.ts
@@ -1,0 +1,184 @@
+import {
+  Component,
+  Injectable,
+  NgModule,
+  ɵivyEnabled,
+  Directive,
+  Pipe,
+  PipeTransform,
+  OnInit
+} from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { freshPlatform } from '@ngxs/store/internals/testing';
+import { Action, NgxsModule, Select, Selector, State, StateContext } from '@ngxs/store';
+import { Observable } from 'rxjs';
+
+describe('@Select() decorated property is used within a constructor (https://github.com/ngxs/store/issues/1801)', () => {
+  if (!ɵivyEnabled) {
+    throw new Error('This test requires Ivy to be enabled.');
+  }
+
+  class AddCountry {
+    static type = '[Countries] Add country';
+    constructor(public country: string) {}
+  }
+
+  @State({
+    name: 'countries',
+    defaults: ['Mexico', 'USA', 'Canada']
+  })
+  @Injectable()
+  class CountriesState {
+    @Selector()
+    static getLastCountry(countries: string[]): string {
+      return countries[countries.length - 1];
+    }
+
+    @Action(AddCountry)
+    addCountry(ctx: StateContext<string[]>, action: AddCountry) {
+      ctx.setState(state => [...state, action.country]);
+    }
+  }
+
+  it(
+    'should be possible to use @Select() decorated properties within constructors',
+    freshPlatform(async () => {
+      // Arrange
+      const recorder: string[] = [];
+
+      const enum Type {
+        Pipe = 'pipe',
+        Directive = 'directive',
+        Component = 'component',
+        NgModule = 'ngModule',
+        RootProvider = 'rootProvider',
+        ComponentProvider = 'componentProvider'
+      }
+
+      const enum Hook {
+        Constructor = 'constructor',
+        NgOnInit = 'ngOnInit'
+      }
+
+      function record(type: Type, hook: Hook, propertyName: string): void {
+        const value = `${type}:${hook}:${propertyName}`;
+        if (recorder.indexOf(value) === -1) {
+          recorder.push(value);
+        }
+      }
+
+      const countries = 'countries$';
+      const lastCountry = 'lastCountry$';
+
+      interface Recordable {
+        [countries]: Observable<string[]>;
+        [lastCountry]: Observable<string>;
+      }
+
+      function startRecording(ctx: Recordable, type: Type, hook: Hook): void {
+        ctx[countries].subscribe(() => {
+          record(type, hook, countries);
+        });
+
+        ctx[lastCountry].subscribe(() => {
+          record(type, hook, lastCountry);
+        });
+      }
+
+      @Injectable({ providedIn: 'root' })
+      class TestRootProvider implements Recordable {
+        @Select(CountriesState) [countries]!: Observable<string[]>;
+        @Select(CountriesState.getLastCountry) [lastCountry]!: Observable<string>;
+
+        constructor() {
+          startRecording(this, Type.RootProvider, Hook.Constructor);
+        }
+      }
+
+      @Injectable()
+      class TestComponentProvider implements Recordable {
+        @Select(CountriesState) [countries]!: Observable<string[]>;
+        @Select(CountriesState.getLastCountry) [lastCountry]!: Observable<string>;
+
+        constructor() {
+          startRecording(this, Type.ComponentProvider, Hook.Constructor);
+        }
+      }
+
+      @Pipe({ name: 'testPipe' })
+      class TestPipe implements PipeTransform, Recordable {
+        @Select(CountriesState) [countries]!: Observable<string[]>;
+        @Select(CountriesState.getLastCountry) [lastCountry]!: Observable<string>;
+
+        constructor() {
+          startRecording(this, Type.Pipe, Hook.Constructor);
+        }
+
+        transform() {
+          return 'TestPipe';
+        }
+      }
+
+      @Directive({ selector: '[testDirective]' })
+      class TestDirective implements OnInit, Recordable {
+        @Select(CountriesState) [countries]!: Observable<string[]>;
+        @Select(CountriesState.getLastCountry) [lastCountry]!: Observable<string>;
+
+        constructor() {
+          startRecording(this, Type.Directive, Hook.Constructor);
+        }
+
+        ngOnInit(): void {
+          startRecording(this, Type.Directive, Hook.NgOnInit);
+        }
+      }
+
+      @Component({
+        selector: 'app-root',
+        template: `
+          <div testDirective>{{ '' | testPipe }}</div>
+        `,
+        providers: [TestComponentProvider]
+      })
+      class TestComponent implements OnInit, Recordable {
+        @Select(CountriesState) [countries]!: Observable<string[]>;
+        @Select(CountriesState.getLastCountry) [lastCountry]!: Observable<string>;
+
+        constructor(
+          testRootProvider: TestRootProvider,
+          testComponentProvider: TestComponentProvider
+        ) {
+          startRecording(this, Type.Component, Hook.Constructor);
+        }
+
+        ngOnInit(): void {
+          startRecording(this, Type.Component, Hook.NgOnInit);
+        }
+      }
+
+      @NgModule({
+        imports: [
+          BrowserModule,
+          NgxsModule.forRoot([CountriesState], { developmentMode: true })
+        ],
+        declarations: [TestComponent, TestDirective, TestPipe],
+        bootstrap: [TestComponent]
+      })
+      class TestModule {
+        @Select(CountriesState) [countries]!: Observable<string[]>;
+        @Select(CountriesState.getLastCountry) [lastCountry]!: Observable<string>;
+
+        constructor() {
+          startRecording(this, Type.NgModule, Hook.Constructor);
+        }
+      }
+
+      // Act
+      await platformBrowserDynamic().bootstrapModule(TestModule);
+
+      // Assert
+      expect(recorder).toMatchSnapshot();
+    })
+  );
+});

--- a/integrations/hello-world-ng13-ivy/src/app/__snapshots__/issue-1801-select-within-constructor.spec.ts.snap
+++ b/integrations/hello-world-ng13-ivy/src/app/__snapshots__/issue-1801-select-within-constructor.spec.ts.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`@Select() decorated property is used within a constructor (https://github.com/ngxs/store/issues/1801) should be possible to use @Select() decorated properties within constructors 1`] = `
+Array [
+  "ngModule:constructor:countries$",
+  "ngModule:constructor:lastCountry$",
+  "rootProvider:constructor:countries$",
+  "rootProvider:constructor:lastCountry$",
+  "componentProvider:constructor:countries$",
+  "componentProvider:constructor:lastCountry$",
+  "component:constructor:countries$",
+  "component:constructor:lastCountry$",
+  "directive:constructor:countries$",
+  "directive:constructor:lastCountry$",
+  "pipe:constructor:countries$",
+  "pipe:constructor:lastCountry$",
+  "component:ngOnInit:countries$",
+  "component:ngOnInit:lastCountry$",
+  "directive:ngOnInit:countries$",
+  "directive:ngOnInit:lastCountry$",
+]
+`;

--- a/integrations/hello-world-ng13-ivy/src/app/issue-1801-select-within-constructor.spec.ts
+++ b/integrations/hello-world-ng13-ivy/src/app/issue-1801-select-within-constructor.spec.ts
@@ -1,0 +1,184 @@
+import {
+  Component,
+  Injectable,
+  NgModule,
+  ɵivyEnabled,
+  Directive,
+  Pipe,
+  PipeTransform,
+  OnInit
+} from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { freshPlatform } from '@ngxs/store/internals/testing';
+import { Action, NgxsModule, Select, Selector, State, StateContext } from '@ngxs/store';
+import { Observable } from 'rxjs';
+
+describe('@Select() decorated property is used within a constructor (https://github.com/ngxs/store/issues/1801)', () => {
+  if (!ɵivyEnabled) {
+    throw new Error('This test requires Ivy to be enabled.');
+  }
+
+  class AddCountry {
+    static type = '[Countries] Add country';
+    constructor(public country: string) {}
+  }
+
+  @State({
+    name: 'countries',
+    defaults: ['Mexico', 'USA', 'Canada']
+  })
+  @Injectable()
+  class CountriesState {
+    @Selector()
+    static getLastCountry(countries: string[]): string {
+      return countries[countries.length - 1];
+    }
+
+    @Action(AddCountry)
+    addCountry(ctx: StateContext<string[]>, action: AddCountry) {
+      ctx.setState(state => [...state, action.country]);
+    }
+  }
+
+  it(
+    'should be possible to use @Select() decorated properties within constructors',
+    freshPlatform(async () => {
+      // Arrange
+      const recorder: string[] = [];
+
+      const enum Type {
+        Pipe = 'pipe',
+        Directive = 'directive',
+        Component = 'component',
+        NgModule = 'ngModule',
+        RootProvider = 'rootProvider',
+        ComponentProvider = 'componentProvider'
+      }
+
+      const enum Hook {
+        Constructor = 'constructor',
+        NgOnInit = 'ngOnInit'
+      }
+
+      function record(type: Type, hook: Hook, propertyName: string): void {
+        const value = `${type}:${hook}:${propertyName}`;
+        if (recorder.indexOf(value) === -1) {
+          recorder.push(value);
+        }
+      }
+
+      const countries = 'countries$';
+      const lastCountry = 'lastCountry$';
+
+      interface Recordable {
+        [countries]: Observable<string[]>;
+        [lastCountry]: Observable<string>;
+      }
+
+      function startRecording(ctx: Recordable, type: Type, hook: Hook): void {
+        ctx[countries].subscribe(() => {
+          record(type, hook, countries);
+        });
+
+        ctx[lastCountry].subscribe(() => {
+          record(type, hook, lastCountry);
+        });
+      }
+
+      @Injectable({ providedIn: 'root' })
+      class TestRootProvider implements Recordable {
+        @Select(CountriesState) [countries]!: Observable<string[]>;
+        @Select(CountriesState.getLastCountry) [lastCountry]!: Observable<string>;
+
+        constructor() {
+          startRecording(this, Type.RootProvider, Hook.Constructor);
+        }
+      }
+
+      @Injectable()
+      class TestComponentProvider implements Recordable {
+        @Select(CountriesState) [countries]!: Observable<string[]>;
+        @Select(CountriesState.getLastCountry) [lastCountry]!: Observable<string>;
+
+        constructor() {
+          startRecording(this, Type.ComponentProvider, Hook.Constructor);
+        }
+      }
+
+      @Pipe({ name: 'testPipe' })
+      class TestPipe implements PipeTransform, Recordable {
+        @Select(CountriesState) [countries]!: Observable<string[]>;
+        @Select(CountriesState.getLastCountry) [lastCountry]!: Observable<string>;
+
+        constructor() {
+          startRecording(this, Type.Pipe, Hook.Constructor);
+        }
+
+        transform() {
+          return 'TestPipe';
+        }
+      }
+
+      @Directive({ selector: '[testDirective]' })
+      class TestDirective implements OnInit, Recordable {
+        @Select(CountriesState) [countries]!: Observable<string[]>;
+        @Select(CountriesState.getLastCountry) [lastCountry]!: Observable<string>;
+
+        constructor() {
+          startRecording(this, Type.Directive, Hook.Constructor);
+        }
+
+        ngOnInit(): void {
+          startRecording(this, Type.Directive, Hook.NgOnInit);
+        }
+      }
+
+      @Component({
+        selector: 'app-root',
+        template: `
+          <div testDirective>{{ '' | testPipe }}</div>
+        `,
+        providers: [TestComponentProvider]
+      })
+      class TestComponent implements OnInit, Recordable {
+        @Select(CountriesState) [countries]!: Observable<string[]>;
+        @Select(CountriesState.getLastCountry) [lastCountry]!: Observable<string>;
+
+        constructor(
+          testRootProvider: TestRootProvider,
+          testComponentProvider: TestComponentProvider
+        ) {
+          startRecording(this, Type.Component, Hook.Constructor);
+        }
+
+        ngOnInit(): void {
+          startRecording(this, Type.Component, Hook.NgOnInit);
+        }
+      }
+
+      @NgModule({
+        imports: [
+          BrowserModule,
+          NgxsModule.forRoot([CountriesState], { developmentMode: true })
+        ],
+        declarations: [TestComponent, TestDirective, TestPipe],
+        bootstrap: [TestComponent]
+      })
+      class TestModule {
+        @Select(CountriesState) [countries]!: Observable<string[]>;
+        @Select(CountriesState.getLastCountry) [lastCountry]!: Observable<string>;
+
+        constructor() {
+          startRecording(this, Type.NgModule, Hook.Constructor);
+        }
+      }
+
+      // Act
+      await platformBrowserDynamic().bootstrapModule(TestModule);
+
+      // Assert
+      expect(recorder).toMatchSnapshot();
+    })
+  );
+});

--- a/packages/store/internals/src/decorator-injector-adapter.ts
+++ b/packages/store/internals/src/decorator-injector-adapter.ts
@@ -6,6 +6,7 @@ import {
   ɵɵdirectiveInject,
   ɵglobal
 } from '@angular/core';
+import { ReplaySubject } from 'rxjs';
 
 // Will be provided through Terser global definitions by Angular CLI
 // during the production build. This is how Angular does tree-shaking internally.
@@ -19,6 +20,28 @@ const InjectorInstance: unique symbol = Symbol('InjectorInstance');
 
 // A `Symbol` which is used to determine if factory has been decorated previously or not.
 const FactoryHasBeenDecorated: unique symbol = Symbol('FactoryHasBeenDecorated');
+
+// A `Symbol` which is used to save the notifier on the class instance. The `InjectorInstance` cannot
+// be retrieved within the `constructor` since it's set after the `factory()` is called.
+const InjectorNotifier: unique symbol = Symbol('InjectorNotifier');
+
+interface PrototypeWithInjectorNotifier extends Object {
+  [InjectorNotifier]?: ReplaySubject<boolean>;
+}
+
+export function ensureInjectorNotifierIsCaptured(
+  target: PrototypeWithInjectorNotifier | PrivateInstance
+): ReplaySubject<boolean> {
+  if (target[InjectorNotifier]) {
+    return target[InjectorNotifier]!;
+  } else {
+    const injectorNotifier$ = new ReplaySubject<boolean>(1);
+    Object.defineProperty(target, InjectorNotifier, {
+      get: () => injectorNotifier$
+    });
+    return injectorNotifier$;
+  }
+}
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export function ensureLocalInjectorCaptured(target: Object): void {
@@ -76,6 +99,14 @@ function decorateFactory(constructor: ConstructorWithDefinitionAndFactory): void
       // Caretaker note: that this is the same way of getting the injector.
       INJECTOR
     );
+
+    // Caretaker note: the notifier will be available only if consumers call the `ensureInjectorNotifierIsCaptured()`.
+    const injectorNotifier$ = instance[InjectorNotifier];
+    if (injectorNotifier$) {
+      injectorNotifier$.next(true);
+      injectorNotifier$.complete();
+    }
+
     return instance;
   };
 
@@ -136,4 +167,5 @@ interface ConstructorWithDefinitionAndFactory extends Function {
 
 interface PrivateInstance {
   [InjectorInstance]?: Injector;
+  [InjectorNotifier]?: ReplaySubject<boolean>;
 }

--- a/packages/store/internals/src/index.ts
+++ b/packages/store/internals/src/index.ts
@@ -4,4 +4,8 @@ export { memoize } from './memoize';
 export { INITIAL_STATE_TOKEN, InitialState } from './initial-state';
 export { PlainObjectOf, PlainObject, StateClass } from './symbols';
 export { NGXS_STATE_CONTEXT_FACTORY, NGXS_STATE_FACTORY } from './internal-tokens';
-export { ensureLocalInjectorCaptured, localInject } from './decorator-injector-adapter';
+export {
+  localInject,
+  ensureLocalInjectorCaptured,
+  ensureInjectorNotifierIsCaptured
+} from './decorator-injector-adapter';


### PR DESCRIPTION
Hey, this is the fastest solution I came with. I don't have other ideas. I'm opening a PR so we can discuss the implementation and I'm open to other ideas!