### PR TITLE
test(store): fix jest and linter configs - update ignored patterns

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 **/*.spec.ts
+**/__name__*.ts
 **/*.lint.ts

--- a/angular.json
+++ b/angular.json
@@ -26,7 +26,14 @@
           "options": {
             "tsConfig": ["tsconfig.lib.json", "tsconfig.spec.json"],
             "tslintConfig": "tslint.json",
-            "exclude": ["**/node_modules/**", "./integrations/**", "./packages/store/types/**"]
+            "exclude": [
+              "**/node_modules/**",
+              "./integrations/**",
+              "./packages/store/types/**",
+              "./packages/store/schematics/templates/actions/__name__*",
+              "./packages/store/schematics/templates/store/__name__*",
+              "./packages/store/schematics/templates/state/__name__*"
+            ]
           }
         }
       }

--- a/jest.config.js
+++ b/jest.config.js
@@ -105,7 +105,7 @@ module.exports = {
    * project's root directory to prevent it from accidentally ignoring all of
    * your files in different environments that may have different root directories.
    */
-  testPathIgnorePatterns: ['/node_modules/', '/types/', '/helpers/'],
+  testPathIgnorePatterns: ['/node_modules/', '/types/', '/helpers/', '__name__'],
 
   /**
    * Indicates whether each individual test should be reported during the run.


### PR DESCRIPTION
## PR Checklist

- [x] exclude template files with 'spec' in file name when executing unit tests;
- [x] exclude template files from eslint check;
- [x] exclude template files form tslint check;

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

`__name__.spec.ts` are included when jest executes unit tests which leads to failures.
`__name__.spec.ts` are checked by eslint an tslint.

Issue Number: N/A

## What is the new behavior?

`__name__.spec.ts` are excluded when jest executes unit tests.
`__name__.spec.ts` are excluded from eslint and tslint checks.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
