### PR TITLE
fix(store): be more explicit when checking if Angular is in test mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ $ npm install @ngxs/store@dev
 - Fix: Do not run `Promise.then` within synchronous tests when decorating factory [#1753](https://github.com/ngxs/store/pull/1753)
 - Fix: Provide `NoopNgxsExecutionStrategy` explicitly when the zone is nooped [#1819](https://github.com/ngxs/store/pull/1819)
 - Fix: Complete the state stream once the root view is removed [#1830](https://github.com/ngxs/store/pull/1830)
+- Fix: Be more explicit when checking if Angular is in test mode [#1831](https://github.com/ngxs/store/pull/1831)
 - Fix: Devtools Plugin - Do not connect to devtools when the plugin is disabled [#1761](https://github.com/ngxs/store/pull/1761)
 - Fix: Router Plugin - Cleanup subscriptions when the root view is destroyed [#1754](https://github.com/ngxs/store/pull/1754)
 - Fix: WebSocket Plugin - Cleanup subscriptions and close the connection when the root view is destroyed [#1755](https://github.com/ngxs/store/pull/1755)

--- a/packages/store/internals/src/angular.ts
+++ b/packages/store/internals/src/angular.ts
@@ -1,30 +1,10 @@
-import { getPlatform, COMPILER_OPTIONS, CompilerOptions, PlatformRef } from '@angular/core';
-import { memoize } from './memoize';
+import { ɵglobal } from '@angular/core';
 
-/**
- * @description Will be provided through Terser global definitions by Angular CLI
- * during the production build. This is how Angular does tree-shaking internally.
- */
-declare const ngDevMode: boolean;
-
-function _isAngularInTestMode(): boolean {
-  const platformRef: PlatformRef | null = getPlatform();
-  if (!platformRef) return false;
-  const compilerOptions = platformRef.injector.get(COMPILER_OPTIONS, null);
-  if (!compilerOptions) return false;
-  const isInTestMode = compilerOptions.some((item: CompilerOptions) => {
-    const providers = (item && item.providers) || [];
-    return providers.some((provider: any) => {
-      return (
-        (provider && provider.provide && provider.provide.name === 'MockNgModuleResolver') ||
-        false
-      );
-    });
-  });
-  return isInTestMode;
+export function isAngularInTestMode(): boolean {
+  return (
+    typeof ɵglobal.__karma__ !== 'undefined' ||
+    typeof ɵglobal.jasmine !== 'undefined' ||
+    typeof ɵglobal.jest !== 'undefined' ||
+    typeof ɵglobal.Mocha !== 'undefined'
+  );
 }
-
-export const isAngularInTestMode =
-  // Caretaker note: we have still left the `typeof` condition in order to avoid
-  // creating a breaking change for projects that still use the View Engine.
-  typeof ngDevMode === 'undefined' || ngDevMode ? memoize(_isAngularInTestMode) : () => false;

--- a/packages/store/tests/utils/angular.spec.ts
+++ b/packages/store/tests/utils/angular.spec.ts
@@ -1,82 +1,59 @@
-import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-import { getPlatform, platformCore } from '@angular/core';
-import { platformBrowser } from '@angular/platform-browser';
-import {
-  platformBrowserDynamicTesting,
-  BrowserDynamicTestingModule
-} from '@angular/platform-browser-dynamic/testing';
-import { getTestBed } from '@angular/core/testing';
+import { ɵglobal } from '@angular/core';
+
 import { isAngularInTestMode } from '@ngxs/store/internals';
 
 describe('[utils/angular]', () => {
   describe('isAngularInTestMode', () => {
-    function resetEnv() {
-      const fn = <any>isAngularInTestMode;
-      // Reset the memoization
-      fn && fn.reset && fn.reset();
+    // Just an empty object so `typeof !== undefined` will be truthy.
+    const nonUndefinedValue = {};
 
-      // Reset the angular platform
-      const p = <any>getPlatform();
-      p && p.destroy && p.destroy();
-    }
-
-    beforeEach(() => {
-      resetEnv();
+    it('should return true if `__karma__` is available', () => {
+      // Arrange & act & assert
+      const __karma__ = ɵglobal.__karma__;
+      ɵglobal.__karma__ = nonUndefinedValue;
+      expect(isAngularInTestMode()).toEqual(true);
+      ɵglobal.__karma__ = __karma__;
     });
 
-    afterEach(() => {
-      resetEnv();
-
-      getTestBed().resetTestEnvironment();
-      getTestBed().initTestEnvironment(
-        BrowserDynamicTestingModule,
-        platformBrowserDynamicTesting()
-      );
+    it('should return true if `jasmine` is available', () => {
+      // Arrange & act & assert
+      const jasmine = ɵglobal.jasmine;
+      ɵglobal.jasmine = nonUndefinedValue;
+      expect(isAngularInTestMode()).toEqual(true);
+      ɵglobal.jasmine = jasmine;
     });
 
-    it(`should return true if the Angular Test Module has been bootstrapped`, () => {
-      // Arrange
-      platformBrowserDynamicTesting();
-      // Act
-      const result = isAngularInTestMode();
-      // Assert
-      expect(result).toEqual(true);
+    it('should return true if `jest` is available', () => {
+      // Arrange & act & assert
+      const jest = ɵglobal.jest;
+      ɵglobal.jest = nonUndefinedValue;
+      expect(isAngularInTestMode()).toEqual(true);
+      ɵglobal.jest = jest;
     });
 
-    it(`should return false if Angular has not been bootstrapped`, () => {
-      // Arrange
-
-      // Act
-      const result = isAngularInTestMode();
-      // Assert
-      expect(result).toEqual(false);
+    it('should return true if `Mocha` is available', () => {
+      // Arrange & act & assert
+      const Mocha = ɵglobal.Mocha;
+      ɵglobal.Mocha = nonUndefinedValue;
+      expect(isAngularInTestMode()).toEqual(true);
+      ɵglobal.Mocha = Mocha;
     });
 
-    it(`should return false if the Angular platformBrowserDynamic has been bootstrapped`, async () => {
-      // Arrange
-      platformBrowserDynamic();
-      // Act
-      const result = isAngularInTestMode();
-      // Assert
-      expect(result).toEqual(false);
-    });
-
-    it(`should return false if the Angular platformBrowser has been bootstrapped`, async () => {
-      // Arrange
-      platformBrowser();
-      // Act
-      const result = isAngularInTestMode();
-      // Assert
-      expect(result).toEqual(false);
-    });
-
-    it(`should return false if the Angular platformCore has been bootstrapped`, async () => {
-      // Arrange
-      platformCore();
-      // Act
-      const result = isAngularInTestMode();
-      // Assert
-      expect(result).toEqual(false);
+    it('should return false if any of the values are globally available', () => {
+      // Arrange & act & assert
+      const __karma__ = ɵglobal.__karma__;
+      const jasmine = ɵglobal.jasmine;
+      const jest = ɵglobal.jest;
+      const Mocha = ɵglobal.Mocha;
+      delete ɵglobal.__karma__;
+      delete ɵglobal.jasmine;
+      delete ɵglobal.jest;
+      delete ɵglobal.Mocha;
+      expect(isAngularInTestMode()).toEqual(false);
+      ɵglobal.__karma__ = __karma__;
+      ɵglobal.jasmine = jasmine;
+      ɵglobal.jest = jest;
+      ɵglobal.Mocha = Mocha;
     });
   });
 });


### PR DESCRIPTION
@markwhitfeld I've noticed that this function doesn't work in ESP app because there's no `MockNgModuleResolver` anymore (the `@angular/compiler/testing`) just doesn't export anything now. Thee `MockNgModuleResolver` was available before the VE support has been removed.

We couldn't see that in NGXS repository since our packages are version 9.