### PR TITLE
ci(publish): check the repo owner before executing publish steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup
-        if: ${{ github.repository_owner == 'ngxs' }}
+        if: github.repository_owner == 'ngxs'
         uses: ./.github/actions/setup
         with:
           node-version: 16.x
@@ -153,11 +153,11 @@ jobs:
           github-sha: ${{ github.sha }}
 
       - name: Check @ngxs build artifacts
-        if: ${{ github.repository_owner == 'ngxs' }}
+        if: github.repository_owner == 'ngxs'
         uses: ./.github/actions/check-build-artifacts
 
       - name: Production release - publish tagged builds to all @ngxs packages
-        if: ${{ github.repository_owner == 'ngxs' }}
+        if: github.repository_owner == 'ngxs'
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
           yarn publish:tagged

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,7 @@ jobs:
         run: yarn ${{ matrix.script }}
 
   release-publish:
+    if: github.repository_owner == 'ngxs'
     runs-on: ubuntu-latest
     environment: npm-publish
     needs: [release-build, release-test, release-integration-test, release-bundlesize]
@@ -145,7 +146,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup
-        if: github.repository_owner == 'ngxs'
         uses: ./.github/actions/setup
         with:
           node-version: 16.x
@@ -153,11 +153,9 @@ jobs:
           github-sha: ${{ github.sha }}
 
       - name: Check @ngxs build artifacts
-        if: github.repository_owner == 'ngxs'
         uses: ./.github/actions/check-build-artifacts
 
       - name: Production release - publish tagged builds to all @ngxs packages
-        if: github.repository_owner == 'ngxs'
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
           yarn publish:tagged

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,6 +145,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup
+        if: ${{ github.repository_owner == 'ngxs' }}
         uses: ./.github/actions/setup
         with:
           node-version: 16.x
@@ -152,9 +153,11 @@ jobs:
           github-sha: ${{ github.sha }}
 
       - name: Check @ngxs build artifacts
+        if: ${{ github.repository_owner == 'ngxs' }}
         uses: ./.github/actions/check-build-artifacts
 
       - name: Production release - publish tagged builds to all @ngxs packages
+        if: ${{ github.repository_owner == 'ngxs' }}
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
           yarn publish:tagged

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -145,6 +145,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup
+        if: ${{ github.repository_owner == 'ngxs' }}
         uses: ./.github/actions/setup
         with:
           node-version: 16.x
@@ -152,9 +153,11 @@ jobs:
           github-sha: ${{ github.sha }}
 
       - name: Check @ngxs build artifacts
+        if: ${{ github.repository_owner == 'ngxs' }}
         uses: ./.github/actions/check-build-artifacts
 
       - name: Development release - publish development builds to all @ngxs packages
+        if: ${{ github.repository_owner == 'ngxs' }}
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
           yarn publish:dev

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -136,6 +136,7 @@ jobs:
         run: yarn ${{ matrix.script }}
 
   trunk-publish:
+    if: github.repository_owner == 'ngxs'
     runs-on: ubuntu-latest
     environment: npm-publish
     needs: [trunk-build, trunk-test, trunk-integration-test, trunk-bundlesize]
@@ -145,7 +146,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup
-        if: github.repository_owner == 'ngxs'
         uses: ./.github/actions/setup
         with:
           node-version: 16.x
@@ -153,11 +153,9 @@ jobs:
           github-sha: ${{ github.sha }}
 
       - name: Check @ngxs build artifacts
-        if: github.repository_owner == 'ngxs'
         uses: ./.github/actions/check-build-artifacts
 
       - name: Development release - publish development builds to all @ngxs packages
-        if: github.repository_owner == 'ngxs'
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
           yarn publish:dev

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -145,7 +145,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup
-        if: ${{ github.repository_owner == 'ngxs' }}
+        if: github.repository_owner == 'ngxs'
         uses: ./.github/actions/setup
         with:
           node-version: 16.x
@@ -153,11 +153,11 @@ jobs:
           github-sha: ${{ github.sha }}
 
       - name: Check @ngxs build artifacts
-        if: ${{ github.repository_owner == 'ngxs' }}
+        if: github.repository_owner == 'ngxs'
         uses: ./.github/actions/check-build-artifacts
 
       - name: Development release - publish development builds to all @ngxs packages
-        if: ${{ github.repository_owner == 'ngxs' }}
+        if: github.repository_owner == 'ngxs'
         run: |
           echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
           yarn publish:dev


### PR DESCRIPTION
- [x] publish packages only if the repo owner is 'ngxs';

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently the publish jobs are triggered always, in forked repos as well.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

The publish jobs are triggered only if the repo owner is `ngxs`.
The publish jobs are not triggered from forks.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
