### PR TITLE
fix(store): do not check if the state class is injectable within the decorator since the `ɵprov` will not exist in JIT mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ $ npm install @ngxs/store@dev
 - Feature: Improve contextual type inference for state operators [#1806](https://github.com/ngxs/store/pull/1806)
 - Fix: Storage Plugin - Provide more meaningful error message when the storage quota exceeds [#1863](https://github.com/ngxs/store/pull/1863)
 - Fix: Do not try to decorate factory asynchronously [#1861](https://github.com/ngxs/store/pull/1861)
+- Fix: Do not check if the state class is injectable within the decorator since the `ɵprov` will not exist in JIT mode [#1867](https://github.com/ngxs/store/pull/1867)
 
 # 3.7.4 2022-06-09
 

--- a/packages/store/src/decorators/state.ts
+++ b/packages/store/src/decorators/state.ts
@@ -3,7 +3,6 @@ import { StateClass } from '@ngxs/store/internals';
 import { ensureStoreMetadata, MetaDataModel, StateClassInternal } from '../internal/internals';
 import { META_KEY, META_OPTIONS_KEY, StoreOptions } from '../symbols';
 import { StoreValidators } from '../utils/store-validators';
-import { ensureStateClassIsInjectable } from '../ivy/ivy-enabled-in-dev-mode';
 
 interface MutateMetaOptions<T> {
   meta: MetaDataModel;
@@ -44,11 +43,6 @@ export function State<T>(options: StoreOptions<T>) {
   }
 
   return (target: StateClass): void => {
-    // Caretaker note: we have still left the `typeof` condition in order to avoid
-    // creating a breaking change for projects that still use the View Engine.
-    if (typeof ngDevMode === 'undefined' || ngDevMode) {
-      ensureStateClassIsInjectable(target);
-    }
     const stateClass: StateClassInternal = target;
     const meta: MetaDataModel = ensureStoreMetadata(stateClass);
     const inheritedStateClass: StateClassInternal = Object.getPrototypeOf(stateClass);

--- a/packages/store/src/ivy/ivy-enabled-in-dev-mode.ts
+++ b/packages/store/src/ivy/ivy-enabled-in-dev-mode.ts
@@ -7,16 +7,16 @@ import { getUndecoratedStateInIvyWarningMessage } from '../configs/messages.conf
  * (previously, injected tokens without `@Injectable` were allowed
  * if another decorator was used, e.g. pipes).
  */
-export function ensureStateClassIsInjectable(target: any): void {
+export function ensureStateClassIsInjectable(stateClass: any): void {
   // `ɵprov` is a static property added by the NGCC compiler. It always exists in
   // AOT mode because this property is added before runtime. If an application is running in
   // JIT mode then this property can be added by the `@Injectable()` decorator. The `@Injectable()`
   // decorator has to go after the `@State()` decorator, thus we prevent users from unwanted DI errors.
   if (ɵivyEnabled) {
-    const ngInjectableDef = target.ɵprov;
+    const ngInjectableDef = stateClass.ɵprov;
     if (!ngInjectableDef) {
       // Don't warn if Ivy is disabled or `ɵprov` exists on the class
-      console.warn(getUndecoratedStateInIvyWarningMessage(target.name));
+      console.warn(getUndecoratedStateInIvyWarningMessage(stateClass.name));
     }
   }
 }


### PR DESCRIPTION
Issue: #1866 