### PR TITLE
feat(devtools-plugin): add new options to the `NgxsDevtoolsOptions` interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Feature: Expose `ActionContext` and `ActionStatus` [#1766](https://github.com/ngxs/store/pull/1766)
 - Feature: `ofAction*` methods should have strong types [#1808](https://github.com/ngxs/store/pull/1808)
 - Feature: Improve contextual type inference for state operators [#1806](https://github.com/ngxs/store/pull/1806)
+- Feature: Devtools Plugin - Add new options to the `NgxsDevtoolsOptions` interface [#1879](https://github.com/ngxs/store/pull/1879)
 
 ### To become next patch version
 

--- a/docs/plugins/devtools.md
+++ b/docs/plugins/devtools.md
@@ -39,7 +39,11 @@ The plugin supports the following options passed via the `forRoot` method:
 - `name`: Set the name by which this store instance is referenced in devtools (Default: 'NGXS')
 - `disabled`: Disable the devtools during production
 - `maxAge`: Max number of entries to keep.
-- `actionSanitizer`: Reformat actions before sending to dev tools
+- `maxAge`: Max number of entries to keep.
+- `latency`: If more than one action is dispatched in the indicated interval, all new actions will be collected and sent at once. It is the joint between performance and speed. When set to 0, all actions will be sent instantly. Set it to a higher value when experiencing perf issues (also maxAge to a lower value). Default is 500 ms.
+- `actionsBlacklist`: string or array of strings as regex - actions types to be hidden in the monitors (while passed to the reducers). If actionsWhitelist specified, actionsBlacklist is ignored.
+- `actionsWhitelist`: string or array of strings as regex - actions types to be shown in the monitors (while passed to the reducers). If actionsWhitelist specified, actionsBlacklist is ignored.
+- `predicate`: called for every action before sending, takes state and action object, and returns true in case it allows sending the current data to the monitor. Use it as a more advanced version of actionsBlacklist/actionsWhitelist parameters
 - `stateSanitizer`: Reformat state before sending to devtools
 
 ### Notes

--- a/docs/plugins/devtools.md
+++ b/docs/plugins/devtools.md
@@ -39,10 +39,12 @@ The plugin supports the following options passed via the `forRoot` method:
 - `name`: Set the name by which this store instance is referenced in devtools (Default: 'NGXS')
 - `disabled`: Disable the devtools during production
 - `maxAge`: Max number of entries to keep.
+
 - `latency`: If more than one action is dispatched in the indicated interval, all new actions will be collected and sent at once. It is the joint between performance and speed. When set to 0, all actions will be sent instantly. Set it to a higher value when experiencing perf issues (also maxAge to a lower value). Default is 500 ms.
 - `actionsBlacklist`: string or array of strings as regex - actions types to be hidden in the monitors (while passed to the reducers). If actionsWhitelist specified, actionsBlacklist is ignored.
 - `actionsWhitelist`: string or array of strings as regex - actions types to be shown in the monitors (while passed to the reducers). If actionsWhitelist specified, actionsBlacklist is ignored.
 - `predicate`: called for every action before sending, takes state and action object, and returns true in case it allows sending the current data to the monitor. Use it as a more advanced version of actionsBlacklist/actionsWhitelist parameters
+- `actionSanitizer`: Reformat actions before sending to dev tools
 - `stateSanitizer`: Reformat state before sending to devtools
 
 ### Notes

--- a/docs/plugins/devtools.md
+++ b/docs/plugins/devtools.md
@@ -39,10 +39,16 @@ The plugin supports the following options passed via the `forRoot` method:
 - `name`: Set the name by which this store instance is referenced in devtools (Default: 'NGXS')
 - `disabled`: Disable the devtools during production
 - `maxAge`: Max number of entries to keep.
-- `latency`: If more than one action is dispatched in the indicated interval, all new actions will be collected and sent at once. It is the joint between performance and speed. When set to 0, all actions will be sent instantly. Set it to a higher value when experiencing perf issues (also maxAge to a lower value). Default is 500 ms.
-- `actionsBlacklist`: string or array of strings as regex - actions types to be hidden in the monitors (while passed to the reducers). If actionsWhitelist specified, actionsBlacklist is ignored.
-- `actionsWhitelist`: string or array of strings as regex - actions types to be shown in the monitors (while passed to the reducers). If actionsWhitelist specified, actionsBlacklist is ignored.
-- `predicate`: called for every action before sending, takes state and action object, and returns true in case it allows sending the current data to the monitor. Use it as a more advanced version of actionsBlacklist/actionsWhitelist parameters
+- `latency`: If more than one action is dispatched in the indicated interval, all new actions will be collected and sent at once.
+  It is the joint between performance and speed. When set to 0, all actions will be sent instantly. 
+  Set it to a higher value when experiencing perf issues (also maxAge to a lower value). Default is 500 ms.
+- `actionsBlacklist`: string or array of strings as regex - actions types to be hidden in the monitors (while passed to the reducers).
+  If actionsWhitelist specified, actionsBlacklist is ignored.
+- `actionsWhitelist`: string or array of strings as regex - actions types to be shown in the monitors (while passed to the reducers).
+  If actionsWhitelist specified, actionsBlacklist is ignored.
+- `predicate`: called for every action before sending, takes state and action object, and 
+  returns true in case it allows sending the current data to the monitor.
+Use it as a more advanced version of actionsBlacklist/actionsWhitelist parameters
 - `actionSanitizer`: Reformat actions before sending to dev tools
 - `stateSanitizer`: Reformat state before sending to devtools
 

--- a/docs/plugins/devtools.md
+++ b/docs/plugins/devtools.md
@@ -39,7 +39,6 @@ The plugin supports the following options passed via the `forRoot` method:
 - `name`: Set the name by which this store instance is referenced in devtools (Default: 'NGXS')
 - `disabled`: Disable the devtools during production
 - `maxAge`: Max number of entries to keep.
-
 - `latency`: If more than one action is dispatched in the indicated interval, all new actions will be collected and sent at once. It is the joint between performance and speed. When set to 0, all actions will be sent instantly. Set it to a higher value when experiencing perf issues (also maxAge to a lower value). Default is 500 ms.
 - `actionsBlacklist`: string or array of strings as regex - actions types to be hidden in the monitors (while passed to the reducers). If actionsWhitelist specified, actionsBlacklist is ignored.
 - `actionsWhitelist`: string or array of strings as regex - actions types to be shown in the monitors (while passed to the reducers). If actionsWhitelist specified, actionsBlacklist is ignored.

--- a/docs/plugins/devtools.md
+++ b/docs/plugins/devtools.md
@@ -39,7 +39,6 @@ The plugin supports the following options passed via the `forRoot` method:
 - `name`: Set the name by which this store instance is referenced in devtools (Default: 'NGXS')
 - `disabled`: Disable the devtools during production
 - `maxAge`: Max number of entries to keep.
-- `maxAge`: Max number of entries to keep.
 - `latency`: If more than one action is dispatched in the indicated interval, all new actions will be collected and sent at once. It is the joint between performance and speed. When set to 0, all actions will be sent instantly. Set it to a higher value when experiencing perf issues (also maxAge to a lower value). Default is 500 ms.
 - `actionsBlacklist`: string or array of strings as regex - actions types to be hidden in the monitors (while passed to the reducers). If actionsWhitelist specified, actionsBlacklist is ignored.
 - `actionsWhitelist`: string or array of strings as regex - actions types to be shown in the monitors (while passed to the reducers). If actionsWhitelist specified, actionsBlacklist is ignored.

--- a/packages/devtools-plugin/src/symbols.ts
+++ b/packages/devtools-plugin/src/symbols.ts
@@ -34,23 +34,30 @@ export interface NgxsDevtoolsOptions {
   maxAge?: number;
 
   /**
-   * If more than one action is dispatched in the indicated interval, all new actions will be collected and sent at once. It is the joint between performance and speed. When set to 0, all actions will be sent instantly. Set it to a higher value when experiencing perf issues (also maxAge to a lower value). Default is 500 ms.
+   * If more than one action is dispatched in the indicated interval, all new actions will be collected
+   * and sent at once. It is the joint between performance and speed. When set to 0, all actions will be
+   * sent instantly. Set it to a higher value when experiencing perf issues (also maxAge to a lower value).
+   * Default is 500 ms.
    */
   latency?: number;
 
   /**
-   * string or array of strings as regex - actions types to be hidden in the monitors (while passed to the reducers). If actionsWhitelist specified, actionsBlacklist is ignored.
+   * string or array of strings as regex - actions types to be hidden in the monitors (while passed to the reducers).
+   * If actionsWhitelist specified, actionsBlacklist is ignored.
    */
   actionsBlacklist?: string | string[];
 
   /**
-   * string or array of strings as regex - actions types to be shown in the monitors (while passed to the reducers). If actionsWhitelist specified, actionsBlacklist is ignored.
+   * string or array of strings as regex - actions types to be shown in the monitors (while passed to the reducers).
+   * If actionsWhitelist specified, actionsBlacklist is ignored.
    */
   actionsWhitelist?: string | string[];
 
 
   /**
-   * called for every action before sending, takes state and action object, and returns true in case it allows sending the current data to the monitor. Use it as a more advanced version of actionsBlacklist/actionsWhitelist parameters
+   * called for every action before sending, takes state and action object, and returns true in case it allows
+   * sending the current data to the monitor. Use it as a more advanced version of
+   * actionsBlacklist/actionsWhitelist parameters
    */
   predicate?: (state: any, action: any) => boolean;
 

--- a/packages/devtools-plugin/src/symbols.ts
+++ b/packages/devtools-plugin/src/symbols.ts
@@ -34,6 +34,27 @@ export interface NgxsDevtoolsOptions {
   maxAge?: number;
 
   /**
+   * If more than one action is dispatched in the indicated interval, all new actions will be collected and sent at once. It is the joint between performance and speed. When set to 0, all actions will be sent instantly. Set it to a higher value when experiencing perf issues (also maxAge to a lower value). Default is 500 ms.
+   */
+  latency?: number;
+
+  /**
+   * string or array of strings as regex - actions types to be hidden in the monitors (while passed to the reducers). If actionsWhitelist specified, actionsBlacklist is ignored.
+   */
+  actionsBlacklist?: string | string[];
+
+  /**
+   * string or array of strings as regex - actions types to be shown in the monitors (while passed to the reducers). If actionsWhitelist specified, actionsBlacklist is ignored.
+   */
+  actionsWhitelist?: string | string[];
+
+
+  /**
+   * called for every action before sending, takes state and action object, and returns true in case it allows sending the current data to the monitor. Use it as a more advanced version of actionsBlacklist/actionsWhitelist parameters
+   */
+  predicate?: (state: any, action: any) => boolean;
+
+  /**
    * Reformat actions before sending to dev tools
    */
   actionSanitizer?: (action: any) => void;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

User unable to pass options to the redux dev tools because we don't have all options described in NgxsDevtoolsOptions interface

Issue Number: N/A

## What is the new behavior?
Added new [option types](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md) that allow filtering actions in dev mode
- latency
- actionsBlacklist
- actionsWhitelist
- predicate

## Does this PR introduce a breaking change?

```
[ ] Yes
[x ] No
```


## Other information
