### PR TITLE
fix(store): do not use `refCount()` since it makes the stream cold

### DIFF
--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -1,14 +1,7 @@
 // tslint:disable:unified-signatures
 import { Inject, Injectable, Optional, Type } from '@angular/core';
 import { Observable, of, Subscription, throwError } from 'rxjs';
-import {
-  catchError,
-  distinctUntilChanged,
-  map,
-  publishReplay,
-  refCount,
-  take
-} from 'rxjs/operators';
+import { catchError, distinctUntilChanged, map, shareReplay, take } from 'rxjs/operators';
 import { INITIAL_STATE_TOKEN, PlainObject } from '@ngxs/store/internals';
 
 import { InternalNgxsExecutionStrategy } from './execution/internal-ngxs-execution-strategy';
@@ -29,8 +22,7 @@ export class Store {
    */
   private _selectableStateStream = this._stateStream.pipe(
     leaveNgxs(this._internalExecutionStrategy),
-    publishReplay(1),
-    refCount()
+    shareReplay({ bufferSize: 1, refCount: true })
   );
 
   constructor(

--- a/packages/store/tests/execution/dispatch-outside-zone-ngxs-execution-strategy.spec.ts
+++ b/packages/store/tests/execution/dispatch-outside-zone-ngxs-execution-strategy.spec.ts
@@ -110,7 +110,7 @@ describe('DispatchOutsideZoneNgxsExecutionStrategy', () => {
       });
 
       // Assert
-      expect(ticks.count).toEqual(3);
+      expect(ticks.count).toEqual(4);
       zoneCounter.assert({
         inside: 3,
         outside: 0
@@ -178,7 +178,7 @@ describe('DispatchOutsideZoneNgxsExecutionStrategy', () => {
       });
       // Assert
       cleanup();
-      expect(ticks.count).toEqual(4);
+      expect(ticks.count).toEqual(5);
       zoneCounter.assert({
         inside: 3,
         outside: 0
@@ -195,7 +195,7 @@ describe('DispatchOutsideZoneNgxsExecutionStrategy', () => {
       });
       // Assert
       cleanup();
-      expect(ticks.count).toEqual(3);
+      expect(ticks.count).toEqual(4);
       zoneCounter.assert({
         inside: 3,
         outside: 0

--- a/packages/store/tests/issues/issue-1880-last-select-value.spec.ts
+++ b/packages/store/tests/issues/issue-1880-last-select-value.spec.ts
@@ -1,0 +1,33 @@
+import { TestBed } from '@angular/core/testing';
+import { NgxsModule, State, Store } from '@ngxs/store';
+
+describe('Last select value (https://github.com/ngxs/store/issues/1880)', () => {
+  @State<number>({
+    name: 'counter',
+    defaults: 0
+  })
+  class CounterState {}
+
+  it('should receive the latest value (previously it was a bug because of refCount() which made observable cold)', async () => {
+    // Arrange
+    TestBed.configureTestingModule({
+      imports: [NgxsModule.forRoot([CounterState])]
+    });
+
+    const store = TestBed.inject(Store);
+
+    // Act
+    // This is done explicitly to make stream cold.
+    store
+      .select(CounterState)
+      .subscribe()
+      .unsubscribe();
+
+    store.reset({ counter: 3 });
+
+    // Assert
+    expect(store.selectSnapshot(CounterState)).toEqual(3);
+    // Previously, it would've returned `0`, because of `refCount()`.
+    expect(await store.selectOnce(CounterState).toPromise()).toEqual(3);
+  });
+});

--- a/packages/store/tests/zone.spec.ts
+++ b/packages/store/tests/zone.spec.ts
@@ -98,8 +98,8 @@ describe('zone', () => {
       store.dispatch(new Increment());
     });
 
-    // Angular has run change detection 5 times
-    expect(ticks).toBe(5);
+    // Angular has run change detection 6 times
+    expect(ticks).toBe(6);
     expect(selectCalls).toEqual(3);
     expect(selectCallsInAngularZone).toEqual(3);
   });


### PR DESCRIPTION
Issue: #1880 

I don't know if there're other ways to fix that issue since using `refCount()` just makes the stream cold when there're no observers, but `publishReplay` buffers the last received value. See the issue and unit test.

The `shareReplay` increases the number of ticks by 1, but fixes the issue.