### PR TITLE
ci: add process for accepting bundlemon differences

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -122,7 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: premerge-integration-test
     outputs:
-      bundlemon-outcome: steps.run-bundlemon.outcome
+      bundlemon-outcome: ${{ steps.run-bundlemon.outcome }}
 
     strategy:
       matrix:
@@ -153,7 +153,7 @@ jobs:
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
 
   premerge-bundlemon-accept-change:
-    if: ${{ needs.premerge-bundlemon.outputs.bundlemon-outcome == 'failure' }}
+    if: ${{ always() && needs.premerge-bundlemon.outputs.bundlemon-outcome == 'failure' }}
     runs-on: ubuntu-latest
     environment: approve-bundlesize-difference
     needs: [ premerge-bundlemon ]

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -157,5 +157,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: approve-bundlesize-difference
     needs: [ premerge-bundlemon ]
+    
+    steps:
       - name: Reviewer Approved Bundlemon Difference
         run: echo "Reviewer Approved Bundlemon Difference"

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -120,6 +120,8 @@ jobs:
     if: github.repository_owner == 'ngxs'
     runs-on: ubuntu-latest
     needs: premerge-integration-test
+    outputs:
+      bundlemon-failed: ${{ steps.run-bundlemon.outcome == 'failure' }}
 
     strategy:
       matrix:
@@ -143,7 +145,17 @@ jobs:
         uses: ./.github/actions/download-integration-test-artifacts
 
       - name: Run BundleMon
-        run: yarn bundlemon
+        id: run-bundlemon
+        continue-on-error: true
+        run: yarn bundlemon        
         env:
           BUNDLEMON_PROJECT_ID: 62b174ff6619780d8caf79fa
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+
+  premerge-bundlemon-accept-change:
+    if: ${{ failure() && needs.premerge-bundlemon.outputs.bundlemon-failed }}
+    runs-on: ubuntu-latest
+    environment: approve-bundlesize-difference
+    needs: [ premerge-bundlemon ]
+      - name: Reviewer Approved Bundlemon Difference
+        run: echo "Reviewer Approved Bundlemon Difference"

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   NODE_VERSION: 16.x
+  
 defaults:
   run:
     shell: bash

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Run BundleMon
         id: run-bundlemon
         continue-on-error: true
-        run: yarn bundlemon        
+        run: yarn bundlemonaaaaa        
         env:
           BUNDLEMON_PROJECT_ID: 62b174ff6619780d8caf79fa
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -7,6 +7,8 @@ name: pr-validation
 on:
   pull_request:
 
+env:
+  NODE_VERSION: 16.x
 defaults:
   run:
     shell: bash
@@ -29,7 +31,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          node-version: 16.x
+          node-version: ${{ env.NODE_VERSION }}
           github-ref-name: ${{ github.head_ref }}
           github-sha: ${{ github.event.pull_request.head.sha }}
 
@@ -42,7 +44,6 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
         script: [lint, eslint, 'test:ci']
 
     steps:
@@ -55,7 +56,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
           github-ref-name: ${{ github.head_ref }}
           github-sha: ${{ github.event.pull_request.head.sha }}
 
@@ -78,7 +79,6 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
         script:
           - 'integration:ng7'
           - 'integration:ng8'
@@ -103,7 +103,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
           github-ref-name: ${{ github.head_ref }}
           github-sha: ${{ github.event.pull_request.head.sha }}
 
@@ -124,10 +124,6 @@ jobs:
     outputs:
       bundlemon-outcome: ${{ steps.run-bundlemon.outcome }}
 
-    strategy:
-      matrix:
-        node-version: [16.x]
-
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -138,7 +134,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
           github-ref-name: ${{ github.head_ref }}
           github-sha: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -118,10 +118,11 @@ jobs:
 
   premerge-bundlemon:
     if: github.repository_owner == 'ngxs'
+    continue-on-error: true
     runs-on: ubuntu-latest
     needs: premerge-integration-test
     outputs:
-      bundlemon-failed: ${{ steps.run-bundlemon.outcome == 'failure' }}
+      bundlemon-outcome: steps.run-bundlemon.outcome
 
     strategy:
       matrix:
@@ -146,14 +147,13 @@ jobs:
 
       - name: Run BundleMon
         id: run-bundlemon
-        continue-on-error: true
         run: yarn bundlemonaaaaa        
         env:
           BUNDLEMON_PROJECT_ID: 62b174ff6619780d8caf79fa
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
 
   premerge-bundlemon-accept-change:
-    if: ${{ failure() && needs.premerge-bundlemon.outputs.bundlemon-failed }}
+    if: ${{ needs.premerge-bundlemon.outputs.bundlemon-outcome == 'failure' }}
     runs-on: ubuntu-latest
     environment: approve-bundlesize-difference
     needs: [ premerge-bundlemon ]

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -147,7 +147,7 @@ jobs:
 
       - name: Run BundleMon
         id: run-bundlemon
-        run: yarn bundlemonaaaaa        
+        run: yarn bundlemon        
         env:
           BUNDLEMON_PROJECT_ID: 62b174ff6619780d8caf79fa
           CI_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
     types:
       - created
 
+env:
+  NODE_VERSION: 16.x
+
 defaults:
   run:
     shell: bash
@@ -28,7 +31,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          node-version: 16.x
+          node-version: ${{ env.NODE_VERSION }}
           github-ref-name: ${{ github.ref_name }}
           github-sha: ${{ github.sha }}
 
@@ -41,7 +44,6 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
         script: [lint, eslint, 'test:ci']
 
     steps:
@@ -51,7 +53,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
           github-ref-name: ${{ github.ref_name }}
           github-sha: ${{ github.sha }}
 
@@ -74,7 +76,6 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
         script:
           - 'integration:ng7'
           - 'integration:ng8'
@@ -96,7 +97,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
           github-ref-name: ${{ github.ref_name }}
           github-sha: ${{ github.sha }}
 
@@ -114,10 +115,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: release-integration-test
 
-    strategy:
-      matrix:
-        node-version: [16.x]
-
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -125,7 +122,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
           github-ref-name: ${{ github.ref_name }}
           github-sha: ${{ github.sha }}
 
@@ -151,7 +148,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          node-version: 16.x
+          node-version: ${{ env.NODE_VERSION }}
           github-ref-name: ${{ github.ref_name }}
           github-sha: ${{ github.sha }}
 

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -111,8 +111,11 @@ jobs:
 
   trunk-bundlemon:
     if: github.repository_owner == 'ngxs'
+    continue-on-error: true
     runs-on: ubuntu-latest
     needs: trunk-integration-test
+    outputs:
+      bundlemon-outcome: ${{ steps.run-bundlemon.outcome }}
 
     strategy:
       matrix:
@@ -133,10 +136,21 @@ jobs:
         uses: ./.github/actions/download-integration-test-artifacts
 
       - name: Run BundleMon
+        id: run-bundlemon
         run: yarn bundlemon
         env:
           BUNDLEMON_PROJECT_ID: 62b174ff6619780d8caf79fa
           CI_COMMIT_SHA: ${{ github.sha }}
+
+  trunk-bundlemon-accept-change:
+    if: ${{ always() && needs.trunk-bundlemon.outputs.bundlemon-outcome == 'failure' }}
+    runs-on: ubuntu-latest
+    environment: approve-bundlesize-difference
+    needs: [ trunk-bundlemon ]
+    
+    steps:
+      - name: Reviewer Approved Bundlemon Difference
+        run: echo "Reviewer Approved Bundlemon Difference"
 
   trunk-publish:
     if: github.repository_owner == 'ngxs'

--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -9,6 +9,9 @@ on:
     branches: [master]
     tags-ignore: ['*']
 
+env:
+  NODE_VERSION: 16.x
+
 defaults:
   run:
     shell: bash
@@ -28,7 +31,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          node-version: 16.x
+          node-version: ${{ env.NODE_VERSION }}
           github-ref-name: ${{ github.ref_name }}
           github-sha: ${{ github.sha }}
 
@@ -41,7 +44,6 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
         script: [lint, eslint, 'test:ci']
 
     steps:
@@ -51,7 +53,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
           github-ref-name: ${{ github.ref_name }}
           github-sha: ${{ github.sha }}
 
@@ -74,7 +76,6 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
         script:
           - 'integration:ng7'
           - 'integration:ng8'
@@ -96,7 +97,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
           github-ref-name: ${{ github.ref_name }}
           github-sha: ${{ github.sha }}
 
@@ -117,10 +118,6 @@ jobs:
     outputs:
       bundlemon-outcome: ${{ steps.run-bundlemon.outcome }}
 
-    strategy:
-      matrix:
-        node-version: [16.x]
-
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -128,7 +125,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ env.NODE_VERSION }}
           github-ref-name: ${{ github.ref_name }}
           github-sha: ${{ github.sha }}
 
@@ -166,7 +163,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          node-version: 16.x
+          node-version: ${{ env.NODE_VERSION }}
           github-ref-name: ${{ github.ref_name }}
           github-sha: ${{ github.sha }}
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

A Bundlemon failure fails the workflow.

## What is the new behavior?

We should allow for a Bundlemon Failure to be approved by the reviewer, resulting in a successful workflow.
PS. I also took the opportunity to remove the pointless node version dimension of the job matrixes.