### PR TITLE
fix(store): remove `?` from `ctx` parameter of lifecycle hooks since they are never undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ $ npm install @ngxs/store@dev
 - Performance: Tree-shake no type on the action error [#1858](https://github.com/ngxs/store/pull/1858)
 - Fix: Give back control to `developmentMode` config property [#1878](https://github.com/ngxs/store/pull/1878)
 - Fix: Do not use `refCount()` since it makes selectable stream cold [#1883](https://github.com/ngxs/store/pull/1883)
+- Fix: Remove `?` from `ctx` parameter of lifecycle hooks since they are never undefined [#1889](https://github.com/ngxs/store/pull/1889)
 - Fix: Storage Plugin - Provide more meaningful error message when the storage quota exceeds [#1863](https://github.com/ngxs/store/pull/1863)
 - Fix: Storage Plugin - Ensure the deserialization is not skipped for master key [#1887](https://github.com/ngxs/store/pull/1887)
 - Fix: Storage Plugin - Do not re-hydrate the whole state when the feature state is added [#1887](https://github.com/ngxs/store/pull/1887)

--- a/packages/store/src/symbols.ts
+++ b/packages/store/src/symbols.ts
@@ -154,7 +154,7 @@ export class NgxsSimpleChange<T = any> {
  * On init interface
  */
 export interface NgxsOnInit {
-  ngxsOnInit(ctx?: StateContext<any>): void | any;
+  ngxsOnInit(ctx: StateContext<any>): void;
 }
 
 /**
@@ -168,7 +168,7 @@ export interface NgxsOnChanges {
  * After bootstrap interface
  */
 export interface NgxsAfterBootstrap {
-  ngxsAfterBootstrap(ctx?: StateContext<any>): void;
+  ngxsAfterBootstrap(ctx: StateContext<any>): void;
 }
 
 export type NgxsModuleOptions = Partial<NgxsConfig>;


### PR DESCRIPTION
Closes #1689

This commit updates the signature of `NgxsOnInit` and `NgxsAfterBootstrap` interfaces. The `ctx` parameter was marked as optional initially by some reason. But it's never optional since we pass the `ctx` parameter. This isn't a breaking change.