### PR TITLE
fix(form-plugin): prevent actions infinite loop with multiple `ngxsForm` directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ $ npm install @ngxs/store@dev
 - Fix: Storage Plugin - Ensure the deserialization is not skipped for master key [#1887](https://github.com/ngxs/store/pull/1887)
 - Fix: Storage Plugin - Do not re-hydrate the whole state when the feature state is added [#1887](https://github.com/ngxs/store/pull/1887)
 - Fix: Devtools Plugin - Enable time-traveling for navigation actions [#1868](https://github.com/ngxs/store/pull/1868)
+- Fix: Form Plugin - Prevent actions infinite loop with multiple `ngxsForm` directives [#1890](https://github.com/ngxs/store/pull/1890)
 - Fix: Do not check if the state class is injectable within the decorator since the `ɵprov` will not exist in JIT mode [#1867](https://github.com/ngxs/store/pull/1867)
 - Revert: revert select decorator changes and add deprecation note [#1871](https://github.com/ngxs/store/pull/1871)
 

--- a/packages/form-plugin/src/directive.ts
+++ b/packages/form-plugin/src/directive.ts
@@ -111,9 +111,14 @@ export class FormDirective implements OnInit, OnDestroy {
       this._cd.markForCheck();
     });
 
-    this._formGroupDirective.valueChanges!.pipe(this.debounceChange()).subscribe(() => {
-      this.updateFormStateWithRawValue();
-    });
+    this._formGroupDirective
+      .valueChanges!.pipe(
+        distinctUntilChanged((a, b) => JSON.stringify(a) === JSON.stringify(b)),
+        this.debounceChange()
+      )
+      .subscribe(() => {
+        this.updateFormStateWithRawValue();
+      });
 
     this._formGroupDirective
       .statusChanges!.pipe(distinctUntilChanged(), this.debounceChange())

--- a/packages/form-plugin/tests/issues/issue-1822-multiple-ngxs-form-bindings.spec.ts
+++ b/packages/form-plugin/tests/issues/issue-1822-multiple-ngxs-form-bindings.spec.ts
@@ -1,0 +1,105 @@
+import { TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { FormGroup, FormControl, ReactiveFormsModule } from '@angular/forms';
+import { NgxsModule, State, Actions, ofActionDispatched, Store, Selector } from '@ngxs/store';
+
+import { NgxsFormPluginModule, UpdateFormValue } from '../../';
+
+describe('Multiple `ngxsForm` bindings (https://github.com/ngxs/store/issues/1822)', () => {
+  interface UserStateModel {
+    userForm: {
+      model: {
+        name: string;
+        surname: string;
+      };
+    };
+  }
+
+  @State<UserStateModel>({
+    name: 'user',
+    defaults: {
+      userForm: {
+        model: {
+          name: 'John',
+          surname: 'Doe'
+        }
+      }
+    }
+  })
+  class UserState {
+    @Selector()
+    static getModel(state: UserStateModel) {
+      return state.userForm.model;
+    }
+  }
+
+  @Component({
+    template: `
+      <form [formGroup]="form" ngxsForm="user.userForm">
+        <input id="name" formControlName="name" />
+      </form>
+
+      <form [formGroup]="form" ngxsForm="user.userForm">
+        <input id="surname" formControlName="surname" />
+      </form>
+    `
+  })
+  class TestComponent {
+    form = new FormGroup({
+      name: new FormControl(),
+      surname: new FormControl()
+    });
+  }
+
+  const testSetup = () => {
+    TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        NgxsModule.forRoot([UserState]),
+        NgxsFormPluginModule.forRoot()
+      ],
+      declarations: [TestComponent]
+    });
+    const store = TestBed.inject(Store);
+    const actions$ = TestBed.inject(Actions);
+    const fixture = TestBed.createComponent(TestComponent);
+    return { store, actions$, fixture };
+  };
+
+  it('should not get into an infinite loop when `ngxsForm` is bound multiple times', async () => {
+    // Arrange
+    let updateFormValueDispatchedTimes = 0;
+    const { store, actions$, fixture } = testSetup();
+    const subscription = actions$.pipe(ofActionDispatched(UpdateFormValue)).subscribe(() => {
+      updateFormValueDispatchedTimes++;
+    });
+    fixture.detectChanges();
+    const nameInput = document.querySelector<HTMLInputElement>('#name')!;
+    const surnameInput = document.querySelector<HTMLInputElement>('#surname')!;
+    // Assert
+    expect(nameInput.value).toEqual('John');
+    expect(surnameInput.value).toEqual('Doe');
+    // Act
+    nameInput.value = 'Artur';
+    nameInput.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+    // Assert
+    expect(store.selectSnapshot(UserState.getModel)).toEqual({
+      name: 'Artur',
+      surname: 'Doe'
+    });
+    // Act
+    surnameInput.value = 'Daniels';
+    surnameInput.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+    await fixture.whenStable();
+    // Assert
+    expect(store.selectSnapshot(UserState.getModel)).toEqual({
+      name: 'Artur',
+      surname: 'Daniels'
+    });
+    expect(updateFormValueDispatchedTimes).toEqual(6);
+    subscription.unsubscribe();
+  });
+});


### PR DESCRIPTION
Issue: #1822 

I'm unsure if there's another way to fix this issue because `valueChanges` continuously emits a new object (with a new reference), which means just adding `distinctUntilChanged()` isn't enough.

I've been thinking of potential breaking changes with this change. Since binding 2 `ngxsForm` is impossible for now, we can imagine that people are binding `ngxsForm` only once. So if the form value is updated outside with the same value and we're not dispatching any actions - this probably might not break anything.