### PR TITLE
test(router-plugin): silence navigation warnings

### DIFF
--- a/packages/router-plugin/tests/helpers.ts
+++ b/packages/router-plugin/tests/helpers.ts
@@ -1,12 +1,16 @@
 import { Router } from '@angular/router';
 import { Store, Actions } from '@ngxs/store';
-import { Type } from '@angular/core';
+import { Type, NgZone } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { skipConsoleLogging } from '@ngxs/store/internals/testing';
 
 export async function createNgxsRouterPluginTestingPlatform<T>(module: Type<T>) {
-  const { injector } = await platformBrowserDynamic().bootstrapModule(module);
+  const { injector } = await skipConsoleLogging(() =>
+    platformBrowserDynamic().bootstrapModule(module)
+  );
+  const ngZone: NgZone = injector.get(NgZone);
   const store: Store = injector.get(Store);
   const router: Router = injector.get(Router);
   const actions$: Actions = injector.get(Actions);
-  return { store, router, actions$, injector };
+  return { store, router, actions$, injector, ngZone };
 }

--- a/packages/router-plugin/tests/issues/issue-1293.spec.ts
+++ b/packages/router-plugin/tests/issues/issue-1293.spec.ts
@@ -94,12 +94,12 @@ describe('#1293 issue', () => {
     'should not infinitely redirect because of reverted snapshot',
     freshPlatform(async () => {
       // Assert
-      const { router, injector } = await createNgxsRouterPluginTestingPlatform(
+      const { router, injector, ngZone } = await createNgxsRouterPluginTestingPlatform(
         getTestModule()
       );
 
       // Act
-      await router.navigateByUrl('/');
+      await ngZone.run(() => router.navigateByUrl('/'));
 
       const url = router.url;
       const document = injector.get(DOCUMENT);

--- a/packages/router-plugin/tests/issues/issue-1407.spec.ts
+++ b/packages/router-plugin/tests/issues/issue-1407.spec.ts
@@ -85,11 +85,11 @@ describe('#1407 issue', () => {
       }
 
       // Act
-      const { router, store, injector } = await createNgxsRouterPluginTestingPlatform(
+      const { router, store, injector, ngZone } = await createNgxsRouterPluginTestingPlatform(
         getTestModule([QueryParamsState])
       );
 
-      await router.navigateByUrl('/dialed-number?dialedNumber=5555555');
+      await ngZone.run(() => router.navigateByUrl('/dialed-number?dialedNumber=5555555'));
 
       const document = injector.get(DOCUMENT);
       const root = document.querySelector('app-root')!;

--- a/packages/router-plugin/tests/router-cancel.spec.ts
+++ b/packages/router-plugin/tests/router-cancel.spec.ts
@@ -71,7 +71,9 @@ describe('RouterCancel', () => {
     'should persist the previous state if the "RouterCancel" action is dispatched',
     freshPlatform(async () => {
       // Arrange
-      const { router, store } = await createNgxsRouterPluginTestingPlatform(getTestModule());
+      const { router, store, ngZone } = await createNgxsRouterPluginTestingPlatform(
+        getTestModule()
+      );
 
       let navigationCancelEmittedTimes = 0;
 
@@ -82,8 +84,10 @@ describe('RouterCancel', () => {
           navigationCancelEmittedTimes++;
         });
 
-      await router.navigateByUrl('/');
-      await router.navigateByUrl('/blog');
+      await ngZone.run(async () => {
+        await router.navigateByUrl('/');
+        await router.navigateByUrl('/blog');
+      });
 
       const url = store.selectSnapshot(RouterState.url);
 

--- a/packages/router-plugin/tests/router-navigation.spec.ts
+++ b/packages/router-plugin/tests/router-navigation.spec.ts
@@ -8,7 +8,7 @@ import {
   NavigationError,
   NavigationEnd
 } from '@angular/router';
-import { freshPlatform } from '@ngxs/store/internals/testing';
+import { freshPlatform, skipConsoleLogging } from '@ngxs/store/internals/testing';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { filter } from 'rxjs/operators';
 
@@ -107,7 +107,9 @@ describe('RouterNavigation', () => {
       'should wait for `NavigationEnd` and then dispatch the `RouterNavigation` action',
       freshPlatform(async () => {
         // Arrange
-        const { injector } = await platformBrowserDynamic().bootstrapModule(getTestModule());
+        const { injector } = await skipConsoleLogging(() =>
+          platformBrowserDynamic().bootstrapModule(getTestModule())
+        );
         const actions$: Actions = injector.get(Actions);
         const router: Router = injector.get(Router);
         const store: Store = injector.get(Store);
@@ -141,7 +143,9 @@ describe('RouterNavigation', () => {
       'should persist previous state and NOT dispatch the `RouterNavigation` action',
       freshPlatform(async () => {
         // Arrange
-        const { injector } = await platformBrowserDynamic().bootstrapModule(getTestModule());
+        const { injector } = await skipConsoleLogging(() =>
+          platformBrowserDynamic().bootstrapModule(getTestModule())
+        );
         const actions$: Actions = injector.get(Actions);
         const store: Store = injector.get(Store);
         const router: Router = injector.get(Router);

--- a/packages/router-plugin/tests/router-state-cleanup.spec.ts
+++ b/packages/router-plugin/tests/router-state-cleanup.spec.ts
@@ -6,7 +6,7 @@ import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
 import { Subject } from 'rxjs';
 import { NgxsModule } from '@ngxs/store';
-import { freshPlatform } from '@ngxs/store/internals/testing';
+import { freshPlatform, skipConsoleLogging } from '@ngxs/store/internals/testing';
 
 import { NgxsRouterPluginModule, RouterState } from '../';
 
@@ -34,7 +34,9 @@ describe('RouterState cleanup', () => {
     'should cleanup subscriptions when the root view is destroyed',
     freshPlatform(async () => {
       // Arrange & act
-      const ngModuleRef = await platformBrowserDynamic().bootstrapModule(TestModule);
+      const ngModuleRef = await skipConsoleLogging(() =>
+        platformBrowserDynamic().bootstrapModule(TestModule)
+      );
 
       const router = ngModuleRef.injector.get(Router);
       const events = router.events as Subject<RouterEvent>;

--- a/packages/router-plugin/tests/router.plugin.spec.ts
+++ b/packages/router-plugin/tests/router.plugin.spec.ts
@@ -1,4 +1,4 @@
-import { Component, Provider, Type, NgModule, Injectable } from '@angular/core';
+import { Component, Provider, Type, NgModule, Injectable, NgZone } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Router, Params, RouterStateSnapshot } from '@angular/router';
@@ -27,11 +27,12 @@ describe('NgxsRouterPlugin', () => {
   it('should select router state', async () => {
     // Arrange
     createTestModule();
+    const ngZone: NgZone = TestBed.inject(NgZone);
     const router: Router = TestBed.inject(Router);
     const store: Store = TestBed.inject(Store);
 
     // Act
-    await router.navigateByUrl('/testpath');
+    await ngZone.run(() => router.navigateByUrl('/testpath'));
 
     // Assert
     const routerState = store.selectSnapshot(RouterState.state)!;
@@ -155,10 +156,11 @@ describe('NgxsRouterPlugin', () => {
       states: [TestState]
     });
 
+    const ngZone: NgZone = TestBed.inject(NgZone);
     const router: Router = TestBed.inject(Router);
 
     // Act
-    await router.navigateByUrl('/testpath');
+    await ngZone.run(() => router.navigateByUrl('/testpath'));
 
     // Assert
     const state = TestBed.inject(Store).selectSnapshot(TestState);


### PR DESCRIPTION
No functional changes, only cleans up navigation warnings, since it makes a lot of noise in the console.