### PR TITLE
fix(store): avoid incorrectly ordered state observable events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ $ npm install @ngxs/store@dev
 - Fix: Give back control to `developmentMode` config property [#1878](https://github.com/ngxs/store/pull/1878)
 - Fix: Do not use `refCount()` since it makes selectable stream cold [#1883](https://github.com/ngxs/store/pull/1883)
 - Fix: Remove `?` from `ctx` parameter of lifecycle hooks since they are never undefined [#1889](https://github.com/ngxs/store/pull/1889)
+- Fix: Do not emit old values from the state [#1908](https://github.com/ngxs/store/pull/1908)
 - Fix: Router Plugin - Prevent router overriding valid navigation [#1907](https://github.com/ngxs/store/pull/1907)
 - Fix: Storage Plugin - Provide more meaningful error message when the storage quota exceeds [#1863](https://github.com/ngxs/store/pull/1863)
 - Fix: Storage Plugin - Ensure the deserialization is not skipped for master key [#1887](https://github.com/ngxs/store/pull/1887)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ $ npm install @ngxs/store@dev
 - Fix: Give back control to `developmentMode` config property [#1878](https://github.com/ngxs/store/pull/1878)
 - Fix: Do not use `refCount()` since it makes selectable stream cold [#1883](https://github.com/ngxs/store/pull/1883)
 - Fix: Remove `?` from `ctx` parameter of lifecycle hooks since they are never undefined [#1889](https://github.com/ngxs/store/pull/1889)
-- Fix: Do not emit old values from the state [#1908](https://github.com/ngxs/store/pull/1908)
+- Fix: Avoid incorrectly ordered events from state observable [#1908](https://github.com/ngxs/store/pull/1908)
 - Fix: Router Plugin - Prevent router overriding valid navigation [#1907](https://github.com/ngxs/store/pull/1907)
 - Fix: Storage Plugin - Provide more meaningful error message when the storage quota exceeds [#1863](https://github.com/ngxs/store/pull/1863)
 - Fix: Storage Plugin - Ensure the deserialization is not skipped for master key [#1887](https://github.com/ngxs/store/pull/1887)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ $ npm install @ngxs/store@dev
 - Fix: Give back control to `developmentMode` config property [#1878](https://github.com/ngxs/store/pull/1878)
 - Fix: Do not use `refCount()` since it makes selectable stream cold [#1883](https://github.com/ngxs/store/pull/1883)
 - Fix: Remove `?` from `ctx` parameter of lifecycle hooks since they are never undefined [#1889](https://github.com/ngxs/store/pull/1889)
-- Fix: Avoid incorrectly ordered events from state observable [#1908](https://github.com/ngxs/store/pull/1908)
+- Fix: Avoid incorrectly ordered state observable events [#1908](https://github.com/ngxs/store/pull/1908)
 - Fix: Router Plugin - Prevent router overriding valid navigation [#1907](https://github.com/ngxs/store/pull/1907)
 - Fix: Storage Plugin - Provide more meaningful error message when the storage quota exceeds [#1863](https://github.com/ngxs/store/pull/1863)
 - Fix: Storage Plugin - Ensure the deserialization is not skipped for master key [#1887](https://github.com/ngxs/store/pull/1887)

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -1,7 +1,14 @@
 // tslint:disable:unified-signatures
 import { Inject, Injectable, Optional, Type } from '@angular/core';
-import { Observable, of, Subscription, throwError } from 'rxjs';
-import { catchError, distinctUntilChanged, map, shareReplay, take } from 'rxjs/operators';
+import { Observable, of, Subscription, throwError, queueScheduler } from 'rxjs';
+import {
+  catchError,
+  distinctUntilChanged,
+  map,
+  shareReplay,
+  take,
+  observeOn
+} from 'rxjs/operators';
 import { INITIAL_STATE_TOKEN, PlainObject } from '@ngxs/store/internals';
 
 import { InternalNgxsExecutionStrategy } from './execution/internal-ngxs-execution-strategy';
@@ -21,6 +28,7 @@ export class Store {
    * All selects would use this stream, and it would call leave only once for any state change across all active selectors.
    */
   private _selectableStateStream = this._stateStream.pipe(
+    observeOn(queueScheduler),
     leaveNgxs(this._internalExecutionStrategy),
     shareReplay({ bufferSize: 1, refCount: true })
   );

--- a/packages/store/tests/issues/issue-1728-dispatch-from-select-subscriber.spec.ts
+++ b/packages/store/tests/issues/issue-1728-dispatch-from-select-subscriber.spec.ts
@@ -1,0 +1,130 @@
+import { Action, StateContext, Selector, State, NgxsModule, Store } from '@ngxs/store';
+import { Injectable } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+interface DataStateModel {
+  data: string;
+}
+
+class SetDataState {
+  static readonly type = '[DataState] Set Data';
+  constructor(public dataRequest: string) {}
+}
+
+class FixDataState {
+  static readonly type = '[DataState] Fix Data';
+  constructor(public newState: DataStateModel) {}
+}
+
+@State<DataStateModel>({
+  name: 'DataState',
+  defaults: {
+    data: ''
+  }
+})
+@Injectable()
+class DataState {
+  @Selector()
+  static getData(state: DataStateModel) {
+    return state.data;
+  }
+
+  @Action(FixDataState)
+  fixData(ctx: StateContext<DataStateModel>, { newState }: FixDataState) {
+    ctx.setState(newState);
+  }
+
+  @Action(SetDataState)
+  getData(ctx: StateContext<DataStateModel>, { dataRequest }: SetDataState) {
+    const fixedData = dataRequest === 'TAKE BROKEN DATA' ? 'BAD-DATA' : 'GOOD-DATA';
+    return new Promise(resolve => {
+      setTimeout(() => {
+        ctx.setState({ data: fixedData });
+        resolve();
+      });
+    });
+  }
+}
+
+interface StatusStateModel {
+  counter: number;
+  status: string;
+}
+
+class SetStatusState {
+  static readonly type = '[StatusState] Set Status';
+  constructor(public status: string) {}
+}
+
+@State<StatusStateModel>({
+  name: 'StatusState',
+  defaults: {
+    counter: 0,
+    status: ''
+  }
+})
+@Injectable()
+class StatusState {
+  @Selector()
+  static getStatus(state: StatusStateModel) {
+    return state.status;
+  }
+
+  @Action(SetStatusState)
+  setState(ctx: StateContext<StatusStateModel>, action: SetStatusState) {
+    const state = ctx.getState();
+    ctx.setState({
+      status: action.status,
+      counter: state.counter + 1
+    });
+  }
+}
+
+describe('Dispatch from select subscriber (https://github.com/ngxs/store/issues/1728)', () => {
+  function setup() {
+    TestBed.configureTestingModule({
+      imports: [NgxsModule.forRoot([DataState, StatusState])]
+    });
+
+    const recorder: string[] = [];
+    const store = TestBed.inject(Store);
+    const record = (message: string) => recorder.push(message);
+    return { store, record, recorder };
+  }
+
+  it('should not receive an old value', async () => {
+    // Arrange
+    const { store, record, recorder } = setup();
+
+    store.select(DataState).subscribe(state => {
+      const isValid = state.data !== 'BAD-DATA';
+      record(`DataState subscription: data = ${state.data}, isValid = ${isValid}`);
+      const action = new SetStatusState(isValid ? 'good' : 'bad');
+      store.dispatch(action);
+    });
+
+    store.select(StatusState).subscribe(state => {
+      record(`StatusState subscription: ${state.status}`);
+    });
+
+    // Act
+    await store.dispatch(new SetDataState('TAKE BROKEN DATA')).toPromise();
+
+    // This is how `recorder` looked like before we added the `observeOn(queueScheduler)` to the `_selectableStateStream`:
+    // [
+    //   'DataState subscription: data = , isValid = true',
+    //   'StatusState subscription: good',
+    //   'DataState subscription: data = BAD-DATA, isValid = false',
+    //   'StatusState subscription: bad',
+    //   'StatusState subscription: good'
+    // ]
+
+    // Assert
+    expect(recorder).toEqual([
+      'DataState subscription: data = , isValid = true',
+      'StatusState subscription: good',
+      'DataState subscription: data = BAD-DATA, isValid = false',
+      'StatusState subscription: bad'
+    ]);
+  });
+});

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -5,7 +5,9 @@
     "baseUrl": "./",
     "module": "commonjs",
     "types": ["jest", "node"],
-    "importHelpers": true
+    "importHelpers": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
   },
   "exclude": ["@ngxs/**", "./packages/store/types/**"],
   "include": ["packages/**/*.ts", "packages/**/*.spec.ts"]


### PR DESCRIPTION
Issue: #1728 

<s>Note: `do not emit old values from the state` is a wrong commit name, I just haven't found anything meaningful, this should be renamed.</s>

I've updated `tsconfig.spec.json` to stop warning on unused locals, because it's a pain writing unit tests with these options enabled.