### PR TITLE
fix(storage-plugin): do not skip deserialization for keys with dot notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Feature: Expose `ActionContext` and `ActionStatus` [#1766](https://github.com/ngxs/store/pull/1766)
 - Feature: `ofAction*` methods should have strong types [#1808](https://github.com/ngxs/store/pull/1808)
 - Feature: Improve contextual type inference for state operators [#1806](https://github.com/ngxs/store/pull/1806)
+- Fix: Storage Plugin - Do not skip deserialization for keys with dot notation [#1924](https://github.com/ngxs/store/pull/1924)
 
 ### To become next patch version
 

--- a/packages/storage-plugin/src/storage.plugin.ts
+++ b/packages/storage-plugin/src/storage.plugin.ts
@@ -60,8 +60,17 @@ export class NgxsStoragePlugin implements NgxsPlugin {
         // the storage plugin. For instance, we only want to deserialize the `auth` state, NGXS has added
         // the `user` state, the storage plugin will be rerun and will do redundant deserialization.
         // `usesDefaultStateKey` is necessary to check since `event.addedStates` never contains `@@STATE`.
-        if (!this._usesDefaultStateKey && addedStates && !addedStates.hasOwnProperty(key)) {
-          continue;
+        if (!this._usesDefaultStateKey && addedStates) {
+          // We support providing keys that can be deeply nested via dot notation, for instance,
+          // `keys: ['myState.myProperty']` is a valid key.
+          // The state name should always go first. The below code checks if the `key` includes dot
+          // notation and extracts the state name out of the key.
+          // Given the `key` is `myState.myProperty`, the `addedStates` will only contain `myState`.
+          const dotNotationIndex = key.indexOf(DOT);
+          const stateName = dotNotationIndex > -1 ? key.slice(0, dotNotationIndex) : key;
+          if (!addedStates.hasOwnProperty(stateName)) {
+            continue;
+          }
         }
 
         let storedValue: any = this._engine.getItem(key!);
@@ -169,3 +178,5 @@ export class NgxsStoragePlugin implements NgxsPlugin {
     );
   }
 }
+
+const DOT = '.';

--- a/packages/storage-plugin/tests/issues/issue-1916-key-state-notation.spec.ts
+++ b/packages/storage-plugin/tests/issues/issue-1916-key-state-notation.spec.ts
@@ -1,0 +1,74 @@
+import { Component, NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { NgxsModule, State, Store } from '@ngxs/store';
+import { freshPlatform, skipConsoleLogging } from '@ngxs/store/internals/testing';
+
+import { NgxsStoragePluginModule } from '../../';
+
+describe('State deserialization for keys with dot notation (https://github.com/ngxs/store/issues/1916)', () => {
+  afterEach(() => localStorage.clear());
+
+  @State({
+    name: 'blog',
+    defaults: {
+      name: null
+    }
+  })
+  class BlogState {}
+
+  @State({
+    name: 'home',
+    defaults: {
+      name: null
+    }
+  })
+  class HomeState {}
+
+  @State({
+    name: 'about',
+    defaults: {
+      description: null
+    }
+  })
+  class AboutState {}
+
+  @Component({ selector: 'app-root', template: '' })
+  class TestComponent {}
+
+  @NgModule({
+    imports: [
+      BrowserModule,
+      NgxsModule.forRoot([BlogState, HomeState, AboutState]),
+      NgxsStoragePluginModule.forRoot({
+        key: ['blog.name', HomeState, 'about.description']
+      })
+    ],
+    declarations: [TestComponent],
+    bootstrap: [TestComponent]
+  })
+  class TestModule {}
+
+  it(
+    'should deserialize states from the storage when keys are provided with dot notation',
+    freshPlatform(async () => {
+      // Arrange
+      localStorage.setItem('blog.name', JSON.stringify('Artur'));
+      localStorage.setItem('home', JSON.stringify({ name: 'Mark' }));
+      localStorage.setItem(
+        'about.description',
+        JSON.stringify('This is some cool description')
+      );
+      const { injector } = await skipConsoleLogging(() =>
+        platformBrowserDynamic().bootstrapModule(TestModule)
+      );
+      const store = injector.get(Store);
+      // Assert
+      expect(store.snapshot()).toEqual({
+        blog: { name: 'Artur' },
+        home: { name: 'Mark' },
+        about: { description: 'This is some cool description' }
+      });
+    })
+  );
+});


### PR DESCRIPTION
Issue: #1916 

This initially was the issue since I didn't even remember that we allow having dot notation in keys, e.g., `key: ['myState.myProp']`. The current fix handles this case when `key` contains dot notation.