### PR TITLE
fix(store): use `isObservable` to test whether actions return an observable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Feature: Expose `ActionContext` and `ActionStatus` [#1766](https://github.com/ngxs/store/pull/1766)
 - Feature: `ofAction*` methods should have strong types [#1808](https://github.com/ngxs/store/pull/1808)
 - Feature: Improve contextual type inference for state operators [#1806](https://github.com/ngxs/store/pull/1806)
+- Fix: Use `isObservable` to test whether actions return an observable [#1925](https://github.com/ngxs/store/pull/1925)
 
 ### To become next patch version
 

--- a/packages/store/src/internal/state-factory.ts
+++ b/packages/store/src/internal/state-factory.ts
@@ -1,5 +1,14 @@
 import { Injectable, Injector, Optional, SkipSelf, Inject, OnDestroy } from '@angular/core';
-import { forkJoin, from, Observable, of, throwError, Subscription, Subject } from 'rxjs';
+import {
+  forkJoin,
+  from,
+  Observable,
+  of,
+  throwError,
+  Subscription,
+  Subject,
+  isObservable
+} from 'rxjs';
 import {
   catchError,
   defaultIfEmpty,
@@ -251,7 +260,7 @@ export class StateFactory implements OnDestroy {
               result = from(result);
             }
 
-            if (result instanceof Observable) {
+            if (isObservable(result)) {
               // If this observable has been completed w/o emitting
               // any value then we wouldn't want to complete the whole chain
               // of actions. Since if any observable completes then
@@ -265,7 +274,7 @@ export class StateFactory implements OnDestroy {
                   if (value instanceof Promise) {
                     return from(value);
                   }
-                  if (value instanceof Observable) {
+                  if (isObservable(value)) {
                     return value;
                   }
                   return of(value);


### PR DESCRIPTION
Issue: #1921 

We can safely use `isObservable` since it already does `instanceof Observable`, but also checks for `obj.lift && obj.subscribe` to be functions.