### PR TITLE
fix(store): do not delegate errors to `ErrorHandler` if users catch them manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ $ npm install @ngxs/store@dev
 
 - Fix: Use `isObservable` to test whether actions return an observable [#1925](https://github.com/ngxs/store/pull/1925)
 - Fix: Call `ngxsOnChanges` whenever state changes (even through plugins) [#1926](https://github.com/ngxs/store/pull/1926)
+- Fix: Do not delegate errors to `ErrorHandler` if users catch them manually [#1927](https://github.com/ngxs/store/pull/1927)
 - Fix: Complete `Actions` stream once root view is removed [#1933](https://github.com/ngxs/store/pull/1933)
 - Fix: Storage Plugin - Do not skip deserialization for keys with dot notation [#1924](https://github.com/ngxs/store/pull/1924)
 

--- a/packages/store/src/internal/dispatcher.ts
+++ b/packages/store/src/internal/dispatcher.ts
@@ -1,13 +1,13 @@
-import { ErrorHandler, Injectable, Injector } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { EMPTY, forkJoin, Observable, of, Subject, throwError } from 'rxjs';
 import { exhaustMap, filter, shareReplay, take } from 'rxjs/operators';
 
 import { compose } from '../utils/compose';
+import { InternalErrorReporter, ngxsErrorHandler } from './error-handler';
 import { ActionContext, ActionStatus, InternalActions } from '../actions-stream';
 import { StateStream } from './state-stream';
 import { PluginManager } from '../plugin-manager';
 import { InternalNgxsExecutionStrategy } from '../execution/internal-ngxs-execution-strategy';
-import { leaveNgxs } from '../operators/leave-ngxs';
 import { getActionTypeFromInstance } from '../utils/utils';
 
 /**
@@ -21,15 +21,13 @@ export class InternalDispatchedActionResults extends Subject<ActionContext> {}
 
 @Injectable()
 export class InternalDispatcher {
-  private _errorHandler: ErrorHandler;
-
   constructor(
-    private _injector: Injector,
     private _actions: InternalActions,
     private _actionResults: InternalDispatchedActionResults,
     private _pluginManager: PluginManager,
     private _stateStream: StateStream,
-    private _ngxsExecutionStrategy: InternalNgxsExecutionStrategy
+    private _ngxsExecutionStrategy: InternalNgxsExecutionStrategy,
+    private _internalErrorReporter: InternalErrorReporter
   ) {}
 
   /**
@@ -40,18 +38,9 @@ export class InternalDispatcher {
       this.dispatchByEvents(actionOrActions)
     );
 
-    result.subscribe({
-      error: error =>
-        this._ngxsExecutionStrategy.leave(() => {
-          try {
-            // Retrieve lazily to avoid cyclic dependency exception
-            this._errorHandler = this._errorHandler || this._injector.get(ErrorHandler);
-            this._errorHandler.handleError(error);
-          } catch {}
-        })
-    });
-
-    return result.pipe(leaveNgxs(this._ngxsExecutionStrategy));
+    return result.pipe(
+      ngxsErrorHandler(this._internalErrorReporter, this._ngxsExecutionStrategy)
+    );
   }
 
   private dispatchByEvents(actionOrActions: any | any[]): Observable<any> {

--- a/packages/store/src/internal/error-handler.ts
+++ b/packages/store/src/internal/error-handler.ts
@@ -1,0 +1,69 @@
+import { ErrorHandler, Injectable, Injector } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { leaveNgxs } from '../operators/leave-ngxs';
+import { NgxsExecutionStrategy } from '../execution/symbols';
+
+/**
+ * This operator is used for piping the observable result
+ * from the `dispatch()`. It has a "smart" error handling
+ * strategy that allows us to decide whether we propagate
+ * errors to Angular's `ErrorHandler` or enable users to
+ * handle them manually. We consider following cases:
+ * 1) `store.dispatch()` (no subscribe) -> call `handleError()`
+ * 2) `store.dispatch().subscribe()` (no error callback) -> call `handleError()`
+ * 3) `store.dispatch().subscribe({ error: ... })` -> don't call `handleError()`
+ * 4) `toPromise()` without `catch` -> do `handleError()`
+ * 5) `toPromise()` with `catch` -> don't `handleError()`
+ */
+export function ngxsErrorHandler<T>(
+  internalErrorReporter: InternalErrorReporter,
+  ngxsExecutionStrategy: NgxsExecutionStrategy
+) {
+  return (source: Observable<T>) => {
+    let subscribed = false;
+
+    source.subscribe({
+      error: error => {
+        // Do not trigger change detection for a microtask. This depends on the execution
+        // strategy being used, but the default `DispatchOutsideZoneNgxsExecutionStrategy`
+        // leaves the Angular zone.
+        ngxsExecutionStrategy.enter(() =>
+          Promise.resolve().then(() => {
+            if (!subscribed) {
+              ngxsExecutionStrategy.leave(() =>
+                internalErrorReporter.reportErrorSafely(error)
+              );
+            }
+          })
+        );
+      }
+    });
+
+    return new Observable(subscriber => {
+      subscribed = true;
+      return source.pipe(leaveNgxs(ngxsExecutionStrategy)).subscribe(subscriber);
+    });
+  };
+}
+
+@Injectable({ providedIn: 'root' })
+export class InternalErrorReporter {
+  /** Will be set lazily to be backward compatible. */
+  private _errorHandler: ErrorHandler = null!;
+
+  constructor(private _injector: Injector) {}
+
+  reportErrorSafely(error: any): void {
+    if (this._errorHandler === null) {
+      this._errorHandler = this._injector.get(ErrorHandler);
+    }
+    // The `try-catch` is used to avoid handling the error twice. Suppose we call
+    // `handleError` which re-throws the error internally. The re-thrown error will
+    // be caught by zone.js which will then get to the `zone.onError.emit()` and the
+    // `onError` subscriber will call `handleError` again.
+    try {
+      this._errorHandler.handleError(error);
+    } catch {}
+  }
+}

--- a/packages/store/tests/dispatch.spec.ts
+++ b/packages/store/tests/dispatch.spec.ts
@@ -15,48 +15,6 @@ describe('Dispatch', () => {
     static type = 'DECREMENT';
   }
 
-  it('should throw error', async(() => {
-    const observedCalls: string[] = [];
-
-    @State<number>({
-      name: 'counter',
-      defaults: 0
-    })
-    @Injectable()
-    class MyState {
-      @Action(Increment)
-      increment() {
-        throw new Error();
-      }
-    }
-
-    @Injectable()
-    class CustomErrorHandler implements ErrorHandler {
-      handleError() {
-        observedCalls.push('handleError(...)');
-      }
-    }
-
-    TestBed.configureTestingModule({
-      imports: [NgxsModule.forRoot([MyState])],
-      providers: [
-        {
-          provide: ErrorHandler,
-          useClass: CustomErrorHandler
-        }
-      ]
-    });
-
-    const store: Store = TestBed.inject(Store);
-
-    store.dispatch(new Increment()).subscribe(
-      () => {},
-      () => observedCalls.push('observer.error(...)')
-    );
-
-    expect(observedCalls).toEqual(['handleError(...)', 'observer.error(...)']);
-  }));
-
   it('should not propagate an unhandled exception', () => {
     // Arrange
     const message = 'This is an eval error...';

--- a/packages/store/tests/issues/issue-1687-inject-store-inside-error-handler.spec.ts
+++ b/packages/store/tests/issues/issue-1687-inject-store-inside-error-handler.spec.ts
@@ -4,7 +4,7 @@ import { NgxsModule, State, Action, Store, Actions, ofActionDispatched } from '@
 import { throwError } from 'rxjs';
 
 describe('Allow to inject the Store class into the ErrorHandler (https://github.com/ngxs/store/issues/1687)', () => {
-  it('should allow to inject the Store', () => {
+  it('should allow to inject the Store', async () => {
     // Arrange
     class ProduceError {
       static type = '[Animals] Produce error';
@@ -49,6 +49,7 @@ describe('Allow to inject the Store class into the ErrorHandler (https://github.
     });
 
     TestBed.inject(Store).dispatch(new ProduceError());
+    await Promise.resolve();
 
     // Assert
     expect(handleErrorHasBeenDispatched).toBe(true);

--- a/packages/store/tests/issues/issue-1691-error-handling.spec.ts
+++ b/packages/store/tests/issues/issue-1691-error-handling.spec.ts
@@ -1,0 +1,271 @@
+import { DoBootstrap, ErrorHandler, Injectable, NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { freshPlatform, skipConsoleLogging } from '@ngxs/store/internals/testing';
+import { Action, NgxsModule, State, Store } from '@ngxs/store';
+import { defer, throwError } from 'rxjs';
+import { tap } from 'rxjs/operators';
+
+describe('Error handling (https://github.com/ngxs/store/issues/1691)', () => {
+  class ProduceErrorSynchronously {
+    static readonly type = 'Produce error synchronously';
+  }
+
+  class ProduceErrorSynchronouslyInStream {
+    static readonly type = 'Produce error synchronously in stream';
+  }
+
+  class ProduceErrorAsynchronously {
+    static readonly type = 'Produce error asynchronously';
+  }
+
+  const actionError = new RangeError('Custom NGXS error');
+
+  @State({
+    name: 'app'
+  })
+  class AppState {
+    @Action(ProduceErrorSynchronously)
+    produceErrorSynchronously() {
+      throw actionError;
+    }
+
+    @Action(ProduceErrorSynchronouslyInStream)
+    produceErrorSynchronouslyInStream() {
+      return throwError(actionError);
+    }
+
+    @Action(ProduceErrorAsynchronously)
+    produceErrorAsynchronously() {
+      return defer(() => Promise.resolve()).pipe(
+        tap(() => {
+          throw actionError;
+        })
+      );
+    }
+  }
+
+  @Injectable()
+  class CustomErrorHandler implements ErrorHandler {
+    caughtErrorsByErrorHandler: any[] = [];
+
+    handleError(error: any): void {
+      this.caughtErrorsByErrorHandler.push(error);
+    }
+  }
+
+  @NgModule({
+    imports: [BrowserModule, NgxsModule.forRoot([AppState])],
+    providers: [CustomErrorHandler, { provide: ErrorHandler, useExisting: CustomErrorHandler }]
+  })
+  class TestModule implements DoBootstrap {
+    ngDoBootstrap(): void {
+      // Do not do anything.
+    }
+  }
+
+  describe('observables', () => {
+    it(
+      'errors should be caught by ErrorHandler if there is no subscribe',
+      freshPlatform(async () => {
+        // Arrange
+        const { injector } = await skipConsoleLogging(() =>
+          platformBrowserDynamic().bootstrapModule(TestModule)
+        );
+
+        const store = injector.get(Store);
+        const errorHandler = injector.get(CustomErrorHandler);
+
+        // Act
+        store.dispatch(new ProduceErrorSynchronously());
+        await macrotask();
+        // Assert
+        expect(errorHandler.caughtErrorsByErrorHandler).toEqual([actionError]);
+
+        // Act
+        store.dispatch(new ProduceErrorSynchronouslyInStream());
+        await macrotask();
+        // Assert
+        expect(errorHandler.caughtErrorsByErrorHandler).toEqual([actionError, actionError]);
+
+        // Act
+        store.dispatch(new ProduceErrorAsynchronously());
+        await macrotask();
+        // Assert
+        expect(errorHandler.caughtErrorsByErrorHandler).toEqual([
+          actionError,
+          actionError,
+          actionError
+        ]);
+      })
+    );
+
+    it(
+      'errors should be caught by ErrorHandler if subscribe is empty',
+      freshPlatform(async () => {
+        // Arrange
+        const { injector } = await skipConsoleLogging(() =>
+          platformBrowserDynamic().bootstrapModule(TestModule)
+        );
+
+        const store = injector.get(Store);
+        const errorHandler = injector.get(CustomErrorHandler);
+
+        // Act
+        store.dispatch(new ProduceErrorSynchronously()).subscribe();
+        await macrotask();
+        // Assert
+        expect(errorHandler.caughtErrorsByErrorHandler).toEqual([actionError]);
+
+        // Act
+        store.dispatch(new ProduceErrorSynchronouslyInStream()).subscribe();
+        await macrotask();
+        // Assert
+        expect(errorHandler.caughtErrorsByErrorHandler).toEqual([actionError, actionError]);
+
+        // Act
+        store.dispatch(new ProduceErrorAsynchronously()).subscribe();
+        await macrotask();
+        // Assert
+        expect(errorHandler.caughtErrorsByErrorHandler).toEqual([
+          actionError,
+          actionError,
+          actionError
+        ]);
+      })
+    );
+
+    it(
+      'errors should NOT be caught by ErrorHandler if subscribe has error observer',
+      freshPlatform(async () => {
+        // Arrange
+        const caughtErrors: any[] = [];
+        const { injector } = await skipConsoleLogging(() =>
+          platformBrowserDynamic().bootstrapModule(TestModule)
+        );
+
+        const store = injector.get(Store);
+        const errorHandler = injector.get(CustomErrorHandler);
+
+        // Act
+        store.dispatch(new ProduceErrorSynchronously()).subscribe({
+          error: error => caughtErrors.push(error)
+        });
+        await macrotask();
+        // Assert
+        expect(caughtErrors).toEqual([actionError]);
+        expect(errorHandler.caughtErrorsByErrorHandler).toEqual([]);
+
+        // Act
+        store.dispatch(new ProduceErrorSynchronouslyInStream()).subscribe({
+          error: error => caughtErrors.push(error)
+        });
+        await macrotask();
+        // Assert
+        expect(caughtErrors).toEqual([actionError, actionError]);
+        expect(errorHandler.caughtErrorsByErrorHandler).toEqual([]);
+
+        // Act
+        store.dispatch(new ProduceErrorAsynchronously()).subscribe({
+          error: error => caughtErrors.push(error)
+        });
+        await macrotask();
+        // Assert
+        expect(caughtErrors).toEqual([actionError, actionError, actionError]);
+        expect(errorHandler.caughtErrorsByErrorHandler).toEqual([]);
+      })
+    );
+  });
+
+  describe('toPromise', () => {
+    it(
+      'errors should be caught by ErrorHandler if there is no catch',
+      freshPlatform(async () => {
+        // Arrange
+        const { injector } = await skipConsoleLogging(() =>
+          platformBrowserDynamic().bootstrapModule(TestModule)
+        );
+
+        const store = injector.get(Store);
+        const errorHandler = injector.get(CustomErrorHandler);
+
+        // Act
+        store.dispatch(new ProduceErrorSynchronously()).toPromise();
+        await macrotask();
+        // Assert
+        expect(errorHandler.caughtErrorsByErrorHandler.length).toEqual(1);
+
+        // Act
+        store.dispatch(new ProduceErrorSynchronouslyInStream()).toPromise();
+        await macrotask();
+        // Assert
+        expect(errorHandler.caughtErrorsByErrorHandler.length).toEqual(2);
+
+        // Act
+        store.dispatch(new ProduceErrorAsynchronously()).toPromise();
+        await macrotask();
+        // Assert
+        expect(errorHandler.caughtErrorsByErrorHandler.length).toEqual(3);
+        errorHandler.caughtErrorsByErrorHandler.forEach(error => {
+          expect(error.message).toContain(
+            'Uncaught (in promise): RangeError: Custom NGXS error'
+          );
+        });
+      })
+    );
+
+    it(
+      'errors should NOT be caught by ErrorHandler if there promise catch',
+      freshPlatform(async () => {
+        // Arrange
+        const caughtErrors: any[] = [];
+        const { injector } = await skipConsoleLogging(() =>
+          platformBrowserDynamic().bootstrapModule(TestModule)
+        );
+
+        const store = injector.get(Store);
+        const errorHandler = injector.get(CustomErrorHandler);
+
+        // Act
+        store
+          .dispatch(new ProduceErrorSynchronously())
+          .toPromise()
+          .then(
+            () => {},
+            error => caughtErrors.push(error)
+          );
+        await macrotask();
+        store
+          .dispatch(new ProduceErrorSynchronouslyInStream())
+          .toPromise()
+          .then(
+            () => {},
+            error => caughtErrors.push(error)
+          );
+        await macrotask();
+        store
+          .dispatch(new ProduceErrorAsynchronously())
+          .toPromise()
+          .then(
+            () => {},
+            error => caughtErrors.push(error)
+          );
+        await macrotask();
+
+        // Assert
+        expect(caughtErrors.length).toEqual(3);
+        expect(errorHandler.caughtErrorsByErrorHandler.length).toEqual(0);
+        caughtErrors.forEach(error => {
+          expect(error).toEqual(actionError);
+        });
+      })
+    );
+  });
+});
+
+function macrotask() {
+  // We explicitly provide 10 ms to wait until RxJS `SafeSubscriber`
+  // handles the error. The `SafeSubscriber` re-throws errors asynchronously,
+  // it's the following: `setTimeout(() => { throw error })`.
+  return new Promise(resolve => setTimeout(resolve, 10));
+}


### PR DESCRIPTION
Issue: #1691