### PR TITLE
build: bump RxJS version to repair Cypress postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "mock-socket": "^8.1.0",
     "ng-packagr": "^9.1.5",
     "prettier": "1.19.1",
-    "rxjs": "^6.5.5",
+    "rxjs": "6.6.7",
     "start-server-and-test": "^1.11.0",
     "ts-loader": "^6.2.1",
     "ts-node": "^8.10.2",

--- a/packages/store/tests/execution/dispatch-outside-zone-ngxs-execution-strategy.spec.ts
+++ b/packages/store/tests/execution/dispatch-outside-zone-ngxs-execution-strategy.spec.ts
@@ -110,7 +110,7 @@ describe('DispatchOutsideZoneNgxsExecutionStrategy', () => {
       });
 
       // Assert
-      expect(ticks.count).toEqual(4);
+      expect(ticks.count).toEqual(3);
       zoneCounter.assert({
         inside: 3,
         outside: 0
@@ -178,7 +178,7 @@ describe('DispatchOutsideZoneNgxsExecutionStrategy', () => {
       });
       // Assert
       cleanup();
-      expect(ticks.count).toEqual(5);
+      expect(ticks.count).toEqual(4);
       zoneCounter.assert({
         inside: 3,
         outside: 0
@@ -195,7 +195,7 @@ describe('DispatchOutsideZoneNgxsExecutionStrategy', () => {
       });
       // Assert
       cleanup();
-      expect(ticks.count).toEqual(4);
+      expect(ticks.count).toEqual(3);
       zoneCounter.assert({
         inside: 3,
         outside: 0

--- a/packages/store/tests/zone.spec.ts
+++ b/packages/store/tests/zone.spec.ts
@@ -98,8 +98,8 @@ describe('zone', () => {
       store.dispatch(new Increment());
     });
 
-    // Angular has run change detection 6 times
-    expect(ticks).toBe(6);
+    // Angular has run change detection 5 times
+    expect(ticks).toBe(5);
     expect(selectCalls).toEqual(3);
     expect(selectCallsInAngularZone).toEqual(3);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10755,7 +10755,14 @@ rxjs@6.5.4:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^6.3.3, rxjs@^6.5.0, rxjs@^6.5.3, rxjs@^6.5.4, rxjs@^6.5.5:
+rxjs@6.6.7:
+  version "6.6.7"
+  resolved "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
+  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.3.3, rxjs@^6.5.0, rxjs@^6.5.3, rxjs@^6.5.4:
   version "6.5.5"
   resolved "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz#c5c884e3094c8cfee31bf27eb87e54ccfc87f9ec"
   integrity sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==


### PR DESCRIPTION
Fixes cypress postinstall error "Cannot find any-observable implementation nor global.Observable".