### PR TITLE
fix: fixed annotation error in docs

### DIFF
--- a/docs/plugins/storage.md
+++ b/docs/plugins/storage.md
@@ -32,7 +32,7 @@ initial state can be picked up by those plugins.
 
 The plugin has the following optional values:
 
-- `key`: State name(s) to be persisted. You can pass a string or array of strings that can be deeply nested via dot notation. If not provided, it defaults to all states using the `@@STATE` key.
+- `key`: State name(s) to be persisted. You can pass a string or array of strings that can be deeply nested via dot notation. If not provided, it defaults to all states using the `@STATE` key.
 - `namespace`: The namespace is used to prefix the key for the state slice. This is necessary when running micro frontend applications which use storage plugin. The namespace will eliminate the conflict between keys that might overlap.
 - `storage`: Storage strategy to use. This defaults to LocalStorage but you can pass SessionStorage or anything that implements the StorageEngine API.
 - `deserialize`: Custom deserializer. Defaults to `JSON.parse`


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
In the data persistence part of the documentation, there is a typo, using the notation `@@State` instead of `@State`.

## What is the new behavior?
Corrected typo.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
I'm not sure if it's really a typo, but I haven't seen anything like `@@State` before.