### PR TITLE
fix(store): add setting that allows disabling dual error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ $ npm install @ngxs/store@dev
 ### To become next patch version
 
 - Feat: Schematics support a project option and standalone detection [#2089](https://github.com/ngxs/store/pull/2089)
+- Fix: Add setting that allows disabling dual error handling [#1971](https://github.com/ngxs/store/pull/1971)
 - Fix: Ensure features are initialized after root state [#2083](https://github.com/ngxs/store/pull/2083)
 - Fix: Log feature states added before store is initialized [#2067](https://github.com/ngxs/store/pull/2067)
 - Fix: Show error when state initialization order is invalid [#2066](https://github.com/ngxs/store/pull/2066), [#2067](https://github.com/ngxs/store/pull/2067)

--- a/packages/store/src/internal/lifecycle-state-manager.ts
+++ b/packages/store/src/internal/lifecycle-state-manager.ts
@@ -74,7 +74,7 @@ export class LifecycleStateManager implements OnDestroy {
           // errors asynchronously (`setTimeout(() => { throw error })`). This might
           // break existing user's code or unit tests. We catch the error manually to
           // be backward compatible with the old behavior.
-          this._internalErrorReporter.reportErrorSafely(error);
+          this._internalErrorReporter.report(error);
           return EMPTY;
         }),
         takeUntil(this._destroy$)

--- a/packages/store/src/symbols.ts
+++ b/packages/store/src/symbols.ts
@@ -95,6 +95,16 @@ export class NgxsConfig {
     suppressErrors: true // TODO: default is true in v3, will change in v4
   };
 
+  /**
+   * When the `enableDualErrorHandling` flag is set to `true` and the action throws an error,
+   * both the framework's internal error handler and the user's error handler will be called.
+   * This allows the user to handle the error externally while the framework also performs its
+   * internal error handling. However, when the flag is set to `false` and the action throws an error,
+   * the framework checks if the user has implemented an `error` observer. If an `error` observer is implemented,
+   * the framework will propagate the error to the user. Otherwise, it will handle the error internally.
+   */
+  enableDualErrorHandling = true;
+
   constructor() {
     this.compatibility = {
       strictContentSecurityPolicy: false

--- a/packages/store/tests/dev-mode.spec.ts
+++ b/packages/store/tests/dev-mode.spec.ts
@@ -149,7 +149,13 @@ describe('Development Mode', () => {
         }
 
         @NgModule({
-          imports: [BrowserModule, NgxsModule.forRoot([MyStore], { developmentMode: true })],
+          imports: [
+            BrowserModule,
+            NgxsModule.forRoot([MyStore], {
+              developmentMode: true,
+              enableDualErrorHandling: false
+            })
+          ],
           providers: [
             {
               provide: ErrorHandler,
@@ -202,7 +208,10 @@ describe('Development Mode', () => {
         @NgModule({
           imports: [
             BrowserModule,
-            NgxsModule.forRoot([], { developmentMode: true }),
+            NgxsModule.forRoot([], {
+              developmentMode: true,
+              enableDualErrorHandling: false
+            }),
             NgxsModule.forFeature([MyStore])
           ],
           providers: [

--- a/packages/store/tests/dispatch.spec.ts
+++ b/packages/store/tests/dispatch.spec.ts
@@ -1,13 +1,6 @@
 import { ErrorHandler, Injectable, NgZone } from '@angular/core';
 import { fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
-import {
-  State,
-  Action,
-  Store,
-  NgxsModule,
-  StateContext,
-  NgxsExecutionStrategy
-} from '@ngxs/store';
+import { State, Action, Store, NgxsModule, StateContext } from '@ngxs/store';
 import { of, throwError, timer } from 'rxjs';
 import { delay, map, tap } from 'rxjs/operators';
 
@@ -21,76 +14,6 @@ describe('Dispatch', () => {
   class Decrement {
     static type = 'DECREMENT';
   }
-
-  it('should not propagate an unhandled exception', () => {
-    // Arrange
-    const message = 'This is an eval error...';
-
-    @State<number>({
-      name: 'counter',
-      defaults: 0
-    })
-    @Injectable()
-    class CounterState {
-      @Action(Increment)
-      increment() {
-        throw new EvalError(message);
-      }
-    }
-
-    @Injectable({ providedIn: 'root' })
-    class FakeExecutionStrategy implements NgxsExecutionStrategy {
-      enter<T>(func: () => T): T {
-        return func();
-      }
-
-      leave<T>(func: () => T): T {
-        return func();
-      }
-    }
-
-    @Injectable()
-    class CustomErrorHandler implements ErrorHandler {
-      handleError(error: Error): void {
-        throw error;
-      }
-    }
-
-    // Act
-    TestBed.configureTestingModule({
-      imports: [
-        NgxsModule.forRoot([CounterState], {
-          executionStrategy: FakeExecutionStrategy
-        })
-      ],
-      providers: [
-        {
-          provide: ErrorHandler,
-          useClass: CustomErrorHandler
-        }
-      ]
-    });
-
-    const store = TestBed.inject(Store);
-
-    // `typeof message | null` as we don't know will be assigned or not.
-    // Let's test it out at the end
-    let thrownMessage: typeof message | null = null;
-
-    // Start spying after module is initialized, not before
-    jest.spyOn(FakeExecutionStrategy.prototype, 'leave').mockImplementationOnce(func => {
-      try {
-        return func();
-      } catch (e: any) {
-        thrownMessage = e.message;
-      }
-    });
-
-    store.dispatch(new Increment());
-
-    // Assert
-    expect(thrownMessage).toBeNull();
-  });
 
   it('should run outside zone and return back in zone', () => {
     // Arrange

--- a/packages/store/tests/issues/issue-1691-error-handling.spec.ts
+++ b/packages/store/tests/issues/issue-1691-error-handling.spec.ts
@@ -56,7 +56,10 @@ describe('Error handling (https://github.com/ngxs/store/issues/1691)', () => {
   }
 
   @NgModule({
-    imports: [BrowserModule, NgxsModule.forRoot([AppState])],
+    imports: [
+      BrowserModule,
+      NgxsModule.forRoot([AppState], { enableDualErrorHandling: false })
+    ],
     providers: [CustomErrorHandler, { provide: ErrorHandler, useExisting: CustomErrorHandler }]
   })
   class TestModule implements DoBootstrap {


### PR DESCRIPTION
Issue: #1965 

NGXS has had an explicit error-handling mechanism from actions for the last years. However, this caused issues with `ErrorHandler` being called twice with the same error. The explicit error handling mechanism is required because of the NGXS action handling strategy. The default action handling process leaves the Angular zone, so NGXS actions are invoked in the `<root>` zone context. All caught actions must be returned to the Angular error handler.

Angular's default error-handling mechanism requires zone.js to be bundled. The forked Angular zone has an `onHandleError` hook which calls `zone.onError.emit(error)` when any error is being caught in Angular zone. Angular subscribes to `onError` when calls `bootstrapModuleFactory`:
```js
const exceptionHandler = moduleRef.injector.get(ErrorHandler, null);

...

const subscription = ngZone.onError.subscribe({
    next: (error) => {
        exceptionHandler.handleError(error);
    }
});
```

This PR adds "switchers" between explicit and implicit error-handling mechanisms. We either catch them manually and delegate them to `handleError` or allow Angular to catch errors in its zone and delegate them to `handleError`.

We would use the old behavior where we catch errors explicitly to be backward-compatible and allow users to switch to the implicit behavior where zone.js is responsible for catching errors and delegating them to Angular.