### PR TITLE
refactor(websocket-plugin): get rid off `rxjs/webSocket` and use `WebSocket` directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ $ npm install @ngxs/store@dev
 - Fix: Devtools Plugin - Do not re-enter Angular zone when resetting state [#2038](https://github.com/ngxs/store/pull/2038)
 - Performance: Tree-shake selectors validation errors [#2020](https://github.com/ngxs/store/pull/2020)
 - Refactor: Replace `get type()` with `type =` in actions [#2035](https://github.com/ngxs/store/pull/2035)
+- Refactor: WebSocket Plugin - Get rid off `rxjs/webSocket` and use `WebSocket` directly [#2033](https://github.com/ngxs/store/pull/2033)
 
 # 3.8.1 2023-05-16
 

--- a/packages/websocket-plugin/src/providers.ts
+++ b/packages/websocket-plugin/src/providers.ts
@@ -1,0 +1,36 @@
+import { APP_INITIALIZER } from '@angular/core';
+
+import { WebSocketHandler } from './websocket-handler';
+import { USER_OPTIONS, NGXS_WEBSOCKET_OPTIONS, NgxsWebsocketPluginOptions } from './symbols';
+
+export function ɵwebsocketOptionsFactory(options: NgxsWebsocketPluginOptions) {
+  return {
+    reconnectInterval: 5000,
+    reconnectAttempts: 10,
+    typeKey: 'type',
+    deserializer(e: MessageEvent) {
+      return JSON.parse(e.data);
+    },
+    serializer(value: any) {
+      return JSON.stringify(value);
+    },
+    ...options
+  };
+}
+
+export function ɵgetProviders(options?: NgxsWebsocketPluginOptions) {
+  return [
+    { provide: USER_OPTIONS, useValue: options },
+    {
+      provide: NGXS_WEBSOCKET_OPTIONS,
+      useFactory: ɵwebsocketOptionsFactory,
+      deps: [USER_OPTIONS]
+    },
+    {
+      provide: APP_INITIALIZER,
+      useFactory: () => () => {},
+      deps: [WebSocketHandler],
+      multi: true
+    }
+  ];
+}

--- a/packages/websocket-plugin/src/symbols.ts
+++ b/packages/websocket-plugin/src/symbols.ts
@@ -1,6 +1,14 @@
 import { InjectionToken } from '@angular/core';
 
-export const NGXS_WEBSOCKET_OPTIONS = new InjectionToken('NGXS_WEBSOCKET_OPTIONS');
+declare const ngDevMode: boolean;
+
+const NG_DEV_MODE = typeof ngDevMode === 'undefined' || ngDevMode;
+
+export const NGXS_WEBSOCKET_OPTIONS = new InjectionToken<NgxsWebsocketPluginOptions>(
+  NG_DEV_MODE ? 'NGXS_WEBSOCKET_OPTIONS' : ''
+);
+
+export const USER_OPTIONS = new InjectionToken(NG_DEV_MODE ? 'USER_OPTIONS' : '');
 
 export interface NgxsWebsocketPluginOptions {
   /**
@@ -50,10 +58,6 @@ export interface NgxsWebsocketPluginOptions {
    * Deseralizer before publishing the message.
    */
   deserializer?: (e: MessageEvent) => any;
-}
-
-export function noop(..._args: any[]) {
-  return function () {};
 }
 
 /**

--- a/packages/websocket-plugin/src/websocket.module.ts
+++ b/packages/websocket-plugin/src/websocket.module.ts
@@ -1,31 +1,12 @@
 import {
   NgModule,
   ModuleWithProviders,
-  APP_INITIALIZER,
-  InjectionToken,
   EnvironmentProviders,
   makeEnvironmentProviders
 } from '@angular/core';
 
-import { WebSocketHandler } from './websocket-handler';
-import { NgxsWebsocketPluginOptions, NGXS_WEBSOCKET_OPTIONS, noop } from './symbols';
-
-export function websocketOptionsFactory(options: NgxsWebsocketPluginOptions) {
-  return {
-    reconnectInterval: 5000,
-    reconnectAttempts: 10,
-    typeKey: 'type',
-    deserializer(e: MessageEvent) {
-      return JSON.parse(e.data);
-    },
-    serializer(value: any) {
-      return JSON.stringify(value);
-    },
-    ...options
-  };
-}
-
-export const USER_OPTIONS = new InjectionToken('USER_OPTIONS');
+import { ɵgetProviders } from './providers';
+import { NgxsWebsocketPluginOptions } from './symbols';
 
 @NgModule()
 export class NgxsWebsocketPluginModule {
@@ -34,24 +15,7 @@ export class NgxsWebsocketPluginModule {
   ): ModuleWithProviders<NgxsWebsocketPluginModule> {
     return {
       ngModule: NgxsWebsocketPluginModule,
-      providers: [
-        WebSocketHandler,
-        {
-          provide: USER_OPTIONS,
-          useValue: options
-        },
-        {
-          provide: NGXS_WEBSOCKET_OPTIONS,
-          useFactory: websocketOptionsFactory,
-          deps: [USER_OPTIONS]
-        },
-        {
-          provide: APP_INITIALIZER,
-          useFactory: noop,
-          deps: [WebSocketHandler],
-          multi: true
-        }
-      ]
+      providers: ɵgetProviders(options)
     };
   }
 }
@@ -59,18 +23,5 @@ export class NgxsWebsocketPluginModule {
 export function withNgxsWebSocketPlugin(
   options?: NgxsWebsocketPluginOptions
 ): EnvironmentProviders {
-  return makeEnvironmentProviders([
-    { provide: USER_OPTIONS, useValue: options },
-    {
-      provide: NGXS_WEBSOCKET_OPTIONS,
-      useFactory: websocketOptionsFactory,
-      deps: [USER_OPTIONS]
-    },
-    {
-      provide: APP_INITIALIZER,
-      useFactory: noop,
-      deps: [WebSocketHandler],
-      multi: true
-    }
-  ]);
+  return makeEnvironmentProviders(ɵgetProviders(options));
 }


### PR DESCRIPTION
This commit updated the WebSocket handler implementation and switched to
using the native `WebSocket` directly, instead of relying on `rxjs/webSocket`.
The RxJS WebSocket implementation can be cumbersome when it comes to handling
socket events and lacks simplicity. By handling socket events manually, we avoid
the need to use the RxJS implementation.