### PR TITLE
refactor(*): replace `get type()` with `type =` in actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ $ npm install @ngxs/store@dev
 - Fix: Storage Plugin - Access local and session storages globals only in browser [#2034](https://github.com/ngxs/store/pull/2034)
 - Fix: Storage Plugin - Require only `getItem` and `setItem` on engines [#2036](https://github.com/ngxs/store/pull/2036)
 - Performance: Tree-shake selectors validation errors [#2020](https://github.com/ngxs/store/pull/2020)
+- Refactor: Replace `get type()` with `type =` in actions [#2035](https://github.com/ngxs/store/pull/2035)
 
 # 3.8.1 2023-05-16
 

--- a/packages/form-plugin/src/actions.ts
+++ b/packages/form-plugin/src/actions.ts
@@ -1,8 +1,6 @@
 export class UpdateFormStatus {
-  static get type() {
-    // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138
-    return '[Forms] Update Form Status';
-  }
+  static readonly type = '[Forms] Update Form Status';
+
   constructor(
     public payload: {
       status: string | null;
@@ -12,18 +10,14 @@ export class UpdateFormStatus {
 }
 
 export class UpdateFormValue {
-  static get type() {
-    // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138
-    return '[Forms] Update Form Value';
-  }
+  static readonly type = '[Forms] Update Form Value';
+
   constructor(public payload: { value: any; path: string; propertyPath?: string }) {}
 }
 
 export class UpdateForm {
-  static get type() {
-    // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138
-    return '[Forms] Update Form';
-  }
+  static readonly type = '[Forms] Update Form';
+
   constructor(
     public payload: {
       value: any;
@@ -36,57 +30,43 @@ export class UpdateForm {
 }
 
 export class UpdateFormDirty {
-  static get type() {
-    // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138
-    return '[Forms] Update Form Dirty';
-  }
+  static readonly type = '[Forms] Update Form Dirty';
+
   constructor(public payload: { dirty: boolean | null; path: string }) {}
 }
 
 export class SetFormDirty {
-  static get type() {
-    // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138
-    return '[Forms] Set Form Dirty';
-  }
+  static readonly type = '[Forms] Set Form Dirty';
+
   constructor(public payload: string) {}
 }
 
 export class SetFormPristine {
-  static get type() {
-    // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138
-    return '[Forms] Set Form Pristine';
-  }
+  static readonly type = '[Forms] Set Form Pristine';
+
   constructor(public payload: string) {}
 }
 
 export class UpdateFormErrors {
-  static get type() {
-    // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138
-    return '[Forms] Update Form Errors';
-  }
+  static readonly type = '[Forms] Update Form Errors';
+
   constructor(public payload: { errors: { [k: string]: string } | null; path: string }) {}
 }
 
 export class SetFormDisabled {
-  static get type() {
-    // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138
-    return '[Forms] Set Form Disabled';
-  }
+  static readonly type = '[Forms] Set Form Disabled';
+
   constructor(public payload: string) {}
 }
 
 export class SetFormEnabled {
-  static get type() {
-    // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138
-    return '[Forms] Set Form Enabled';
-  }
+  static readonly type = '[Forms] Set Form Enabled';
+
   constructor(public payload: string) {}
 }
 
 export class ResetForm {
-  static get type() {
-    // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138
-    return '[Forms] Reset Form';
-  }
+  static readonly type = '[Forms] Reset Form';
+
   constructor(public payload: { path: string; value?: any }) {}
 }

--- a/packages/router-plugin/src/router.actions.ts
+++ b/packages/router-plugin/src/router.actions.ts
@@ -16,10 +16,8 @@ import { RouterTrigger } from './router.state';
  * Public event api of the router
  */
 export class Navigate {
-  static get type() {
-    // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138
-    return '[Router] Navigate';
-  }
+  static readonly type = '[Router] Navigate';
+
   constructor(
     public path: any[],
     public queryParams?: Params,
@@ -37,10 +35,8 @@ export class Navigate {
  * An action dispatched when the router starts the navigation.
  */
 export class RouterRequest<T = RouterStateSnapshot> {
-  static get type() {
-    // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138
-    return '[Router] RouterRequest';
-  }
+  static readonly type = '[Router] RouterRequest';
+
   constructor(
     public routerState: T,
     public event: NavigationStart,
@@ -52,10 +48,8 @@ export class RouterRequest<T = RouterStateSnapshot> {
  * An action dispatched when the router navigates.
  */
 export class RouterNavigation<T = RouterStateSnapshot> {
-  static get type() {
-    // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138
-    return '[Router] RouterNavigation';
-  }
+  static readonly type = '[Router] RouterNavigation';
+
   constructor(
     public routerState: T,
     public event: RoutesRecognized,
@@ -67,10 +61,8 @@ export class RouterNavigation<T = RouterStateSnapshot> {
  * An action dispatched when the router cancel navigation.
  */
 export class RouterCancel<T, V = RouterStateSnapshot> {
-  static get type() {
-    // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138
-    return '[Router] RouterCancel';
-  }
+  static readonly type = '[Router] RouterCancel';
+
   constructor(
     public routerState: V,
     public storeState: T,
@@ -83,10 +75,8 @@ export class RouterCancel<T, V = RouterStateSnapshot> {
  * An action dispatched when the router errors.
  */
 export class RouterError<T, V = RouterStateSnapshot> {
-  static get type() {
-    // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138
-    return '[Router] RouterError';
-  }
+  static readonly type = '[Router] RouterError';
+
   constructor(
     public routerState: V,
     public storeState: T,
@@ -99,10 +89,8 @@ export class RouterError<T, V = RouterStateSnapshot> {
  * An action dispatched when the `ResolveEnd` event is triggered.
  */
 export class RouterDataResolved<T = RouterStateSnapshot> {
-  static get type() {
-    // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138
-    return '[Router] RouterDataResolved';
-  }
+  static readonly type = '[Router] RouterDataResolved';
+
   constructor(
     public routerState: T,
     public event: ResolveEnd,
@@ -114,10 +102,8 @@ export class RouterDataResolved<T = RouterStateSnapshot> {
  * An action dispatched when the router navigation has been finished successfully.
  */
 export class RouterNavigated<T = RouterStateSnapshot> {
-  static get type() {
-    // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138
-    return '[Router] RouterNavigated';
-  }
+  static readonly type = '[Router] RouterNavigated';
+
   constructor(
     public routerState: T,
     public event: NavigationEnd,

--- a/packages/store/src/actions/actions.ts
+++ b/packages/store/src/actions/actions.ts
@@ -4,20 +4,14 @@ import { PlainObject } from '@ngxs/store/internals';
  * Init action
  */
 export class InitState {
-  static get type() {
-    // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138
-    return '@@INIT';
-  }
+  static readonly type = '@@INIT';
 }
 
 /**
  * Update action
  */
 export class UpdateState {
-  static get type() {
-    // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138
-    return '@@UPDATE_STATE';
-  }
+  static readonly type = '@@UPDATE_STATE';
 
   constructor(public addedStates?: PlainObject) {}
 }

--- a/packages/websocket-plugin/src/symbols.ts
+++ b/packages/websocket-plugin/src/symbols.ts
@@ -53,17 +53,15 @@ export interface NgxsWebsocketPluginOptions {
 }
 
 export function noop(..._args: any[]) {
-  return function() {};
+  return function () {};
 }
 
 /**
  * Action to connect to the websocket. Optionally pass a URL.
  */
 export class ConnectWebSocket {
-  static get type() {
-    // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138
-    return '[WebSocket] Connect';
-  }
+  static readonly type = '[WebSocket] Connect';
+
   constructor(public payload?: NgxsWebsocketPluginOptions) {}
 }
 
@@ -71,10 +69,8 @@ export class ConnectWebSocket {
  * Action triggered when a error ocurrs
  */
 export class WebsocketMessageError {
-  static get type() {
-    // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138
-    return '[WebSocket] Message Error';
-  }
+  static readonly type = '[WebSocket] Message Error';
+
   constructor(public payload: any) {}
 }
 
@@ -82,39 +78,29 @@ export class WebsocketMessageError {
  * Action to disconnect the websocket.
  */
 export class DisconnectWebSocket {
-  static get type() {
-    // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138
-    return '[WebSocket] Disconnect';
-  }
+  static readonly type = '[WebSocket] Disconnect';
 }
 
 /**
  * Action triggered when websocket is connected
  */
 export class WebSocketConnected {
-  static get type() {
-    return '[WebSocket] Connected';
-  }
+  static readonly type = '[WebSocket] Connected';
 }
 
 /**
  * Action triggered when websocket is disconnected
  */
 export class WebSocketDisconnected {
-  static get type() {
-    // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138
-    return '[WebSocket] Disconnected';
-  }
+  static readonly type = '[WebSocket] Disconnected';
 }
 
 /**
  * Action to send to the server.
  */
 export class SendWebSocketMessage {
-  static get type() {
-    // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138
-    return '[WebSocket] Send Message';
-  }
+  static readonly type = '[WebSocket] Send Message';
+
   constructor(public payload: any) {}
 }
 
@@ -122,10 +108,7 @@ export class SendWebSocketMessage {
  * Action dispatched when the user tries to connect if the connection already exists.
  */
 export class WebSocketConnectionUpdated {
-  static get type() {
-    // NOTE: Not necessary to declare the type in this way in your code. See https://github.com/ngxs/store/pull/644#issuecomment-436003138
-    return '[WebSocket] Connection Updated';
-  }
+  static readonly type = '[WebSocket] Connection Updated';
 }
 
 /**


### PR DESCRIPTION
This commit replaces type getters with property declarations like
`static type = '...'`. The `get type()` was required a long time ago
to maintain backward compatibility between TypeScript 2 and 3 versions.
However, this is no longer necessary.