### PR TITLE
fix(store): expose keys which are used to store metadata privately

### DIFF
--- a/packages/logger-plugin/tests/helpers/setup-with-logger.ts
+++ b/packages/logger-plugin/tests/helpers/setup-with-logger.ts
@@ -1,13 +1,13 @@
 import { ErrorHandler } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { Store, provideStore } from '@ngxs/store';
-import { StateClass } from '@ngxs/store/internals';
+import { ɵStateClass } from '@ngxs/store/internals';
 import { NgxsLoggerPluginOptions, withNgxsLoggerPlugin } from '@ngxs/logger-plugin';
 
 import { LoggerSpy } from './logger-spy';
 import { NoopErrorHandler } from '../../../store/tests/helpers/utils';
 
-export function setupWithLogger(states: StateClass[], opts?: NgxsLoggerPluginOptions) {
+export function setupWithLogger(states: ɵStateClass[], opts?: NgxsLoggerPluginOptions) {
   const logger = new LoggerSpy();
 
   TestBed.configureTestingModule({

--- a/packages/router-plugin/tests/issues/issue-1407.spec.ts
+++ b/packages/router-plugin/tests/issues/issue-1407.spec.ts
@@ -4,7 +4,7 @@ import { Component, Injectable, NgModule } from '@angular/core';
 import { Routes } from '@angular/router';
 import { BrowserModule } from '@angular/platform-browser';
 import { State, Action, StateContext, provideStore, provideStates } from '@ngxs/store';
-import { StateClass } from '@ngxs/store/internals';
+import { ɵStateClass } from '@ngxs/store/internals';
 import { freshPlatform } from '@ngxs/store/internals/testing';
 
 import { Navigate, RouterNavigation, RouterState, withNgxsRouterPlugin } from '../..';
@@ -40,7 +40,7 @@ const routes: Routes = [
   }
 ];
 
-function getTestModule(states: StateClass[] = []) {
+function getTestModule(states: ɵStateClass[] = []) {
   @NgModule({
     imports: [BrowserModule, RouterTestingModule.withRoutes(routes, { enableTracing: true })],
     declarations: [RootComponent, HomeComponent, DialedNumberComponent],

--- a/packages/storage-plugin/internals/src/storage-key.ts
+++ b/packages/storage-plugin/internals/src/storage-key.ts
@@ -1,12 +1,12 @@
 import { InjectionToken, Type } from '@angular/core';
 import { StateToken } from '@ngxs/store';
-import { StateClass } from '@ngxs/store/internals';
+import { ɵMETA_OPTIONS_KEY, ɵStateClass } from '@ngxs/store/internals';
 
 import { StorageEngine } from './symbols';
 
 /** This enables the user to provide a storage engine per individual key. */
 export interface KeyWithExplicitEngine {
-  key: string | StateClass | StateToken<any>;
+  key: string | ɵStateClass | StateToken<any>;
   engine: Type<StorageEngine> | InjectionToken<StorageEngine>;
 }
 
@@ -19,10 +19,8 @@ export function ɵisKeyWithExplicitEngine(key: any): key is KeyWithExplicitEngin
  * This tuples all of the possible types allowed in the `key` property.
  * This is not exposed publicly and used internally only.
  */
-export type StorageKey = string | StateClass | StateToken<any> | KeyWithExplicitEngine;
+export type StorageKey = string | ɵStateClass | StateToken<any> | KeyWithExplicitEngine;
 
-/** This symbol is used to store the metadata on state classes. */
-const META_OPTIONS_KEY = 'NGXS_OPTIONS_META';
 export function ɵextractStringKey(storageKey: StorageKey): string {
   // Extract the actual key out of the `{ key, engine }` structure.
   if (ɵisKeyWithExplicitEngine(storageKey)) {
@@ -32,8 +30,8 @@ export function ɵextractStringKey(storageKey: StorageKey): string {
   // Given the `storageKey` is a class, for instance, `AuthState`.
   // We should retrieve its metadata and the `name` property.
   // The `name` property might be a string (state name) or a state token.
-  if (storageKey.hasOwnProperty(META_OPTIONS_KEY)) {
-    storageKey = (storageKey as any)[META_OPTIONS_KEY].name;
+  if (storageKey.hasOwnProperty(ɵMETA_OPTIONS_KEY)) {
+    storageKey = (storageKey as any)[ɵMETA_OPTIONS_KEY].name;
   }
 
   return storageKey instanceof StateToken ? storageKey.getName() : <string>storageKey;

--- a/packages/store/internals/src/index.ts
+++ b/packages/store/internals/src/index.ts
@@ -1,5 +1,12 @@
 export { NgxsBootstrapper } from './ngxs-bootstrapper';
 export { memoize } from './memoize';
 export { INITIAL_STATE_TOKEN, InitialState } from './initial-state';
-export { PlainObjectOf, PlainObject, StateClass } from './symbols';
+export {
+  PlainObjectOf,
+  PlainObject,
+  ɵStateClass,
+  ɵMETA_KEY,
+  ɵMETA_OPTIONS_KEY,
+  ɵSELECTOR_META_KEY
+} from './symbols';
 export { ɵNGXS_STATE_CONTEXT_FACTORY, ɵNGXS_STATE_FACTORY } from './internal-tokens';

--- a/packages/store/internals/src/symbols.ts
+++ b/packages/store/internals/src/symbols.ts
@@ -6,4 +6,15 @@ export interface PlainObjectOf<T> {
   [key: string]: T;
 }
 
-export type StateClass<T = any> = new (...args: any[]) => T;
+export type ɵStateClass<T = any> = new (...args: any[]) => T;
+
+// This key is used to store metadata on state classes,
+// such as actions and other related information.
+export const ɵMETA_KEY = 'NGXS_META';
+// This key is used to store options on state classes
+// provided through the `@State` decorator.
+export const ɵMETA_OPTIONS_KEY = 'NGXS_OPTIONS_META';
+// This key is used to store selector metadata on selector functions,
+// such as decorated with the `@Selector` or provided through the
+// `createSelector` function.
+export const ɵSELECTOR_META_KEY = 'NGXS_SELECTOR_META';

--- a/packages/store/internals/testing/src/symbol.ts
+++ b/packages/store/internals/testing/src/symbol.ts
@@ -1,10 +1,10 @@
 import { NgxsModuleOptions, Store } from '@ngxs/store';
 import { ModuleWithProviders } from '@angular/core';
 import { TestBedStatic } from '@angular/core/testing';
-import { StateClass } from '@ngxs/store/internals';
+import { ɵStateClass } from '@ngxs/store/internals';
 
 export interface NgxsOptionsTesting {
-  states?: StateClass[];
+  states?: ɵStateClass[];
   ngxsOptions?: NgxsModuleOptions;
   imports?: ModuleWithProviders<any>[];
   before?: () => void;

--- a/packages/store/src/decorators/state.ts
+++ b/packages/store/src/decorators/state.ts
@@ -1,7 +1,7 @@
-import { StateClass } from '@ngxs/store/internals';
+import { ɵStateClass, ɵMETA_KEY, ɵMETA_OPTIONS_KEY } from '@ngxs/store/internals';
 
+import { StoreOptions } from '../symbols';
 import { ensureStateNameIsValid } from '../utils/store-validators';
-import { META_KEY, META_OPTIONS_KEY, StoreOptions } from '../symbols';
 import { ensureStoreMetadata, MetaDataModel, StateClassInternal } from '../internal/internals';
 
 interface MutateMetaOptions<T> {
@@ -14,7 +14,7 @@ interface MutateMetaOptions<T> {
  * Decorates a class with ngxs state information.
  */
 export function State<T>(options: StoreOptions<T>) {
-  return (target: StateClass): void => {
+  return (target: ɵStateClass): void => {
     const stateClass: StateClassInternal = target;
     const meta: MetaDataModel = ensureStoreMetadata(stateClass);
     const inheritedStateClass: StateClassInternal = Object.getPrototypeOf(stateClass);
@@ -23,7 +23,7 @@ export function State<T>(options: StoreOptions<T>) {
       options
     );
     mutateMetaData<T>({ meta, inheritedStateClass, optionsWithInheritance });
-    stateClass[META_OPTIONS_KEY] = optionsWithInheritance;
+    stateClass[ɵMETA_OPTIONS_KEY] = optionsWithInheritance;
   };
 }
 
@@ -32,7 +32,7 @@ function getStateOptions<T>(
   options: StoreOptions<T>
 ): StoreOptions<T> {
   const inheritanceOptions: Partial<StoreOptions<T>> =
-    inheritedStateClass[META_OPTIONS_KEY] || {};
+    inheritedStateClass[ɵMETA_OPTIONS_KEY] || {};
   return { ...inheritanceOptions, ...options } as StoreOptions<T>;
 }
 
@@ -46,8 +46,8 @@ function mutateMetaData<T>(params: MutateMetaOptions<T>): void {
     ensureStateNameIsValid(stateName);
   }
 
-  if (inheritedStateClass.hasOwnProperty(META_KEY)) {
-    const inheritedMeta: Partial<MetaDataModel> = inheritedStateClass[META_KEY] || {};
+  if (inheritedStateClass.hasOwnProperty(ɵMETA_KEY)) {
+    const inheritedMeta: Partial<MetaDataModel> = inheritedStateClass[ɵMETA_KEY] || {};
     meta.actions = { ...meta.actions, ...inheritedMeta.actions };
   }
 

--- a/packages/store/src/internal/internals.ts
+++ b/packages/store/src/internal/internals.ts
@@ -1,19 +1,19 @@
-import { PlainObjectOf, StateClass } from '@ngxs/store/internals';
+import {
+  PlainObjectOf,
+  ɵStateClass,
+  ɵMETA_KEY,
+  ɵMETA_OPTIONS_KEY,
+  ɵSELECTOR_META_KEY
+} from '@ngxs/store/internals';
 import { Observable } from 'rxjs';
 
-import {
-  META_KEY,
-  META_OPTIONS_KEY,
-  NgxsConfig,
-  SELECTOR_META_KEY,
-  StoreOptions
-} from '../symbols';
+import { NgxsConfig, StoreOptions } from '../symbols';
 import { ActionHandlerMetaData } from '../actions/symbols';
 
 // inspired from https://stackoverflow.com/a/43674389
-export interface StateClassInternal<T = any, U = any> extends StateClass<T> {
-  [META_KEY]?: MetaDataModel;
-  [META_OPTIONS_KEY]?: StoreOptions<U>;
+export interface StateClassInternal<T = any, U = any> extends ɵStateClass<T> {
+  [ɵMETA_KEY]?: MetaDataModel;
+  [ɵMETA_OPTIONS_KEY]?: StoreOptions<U>;
 }
 
 export type StateKeyGraph = PlainObjectOf<string[]>;
@@ -77,7 +77,7 @@ export interface StatesAndDefaults {
  * @ignore
  */
 export function ensureStoreMetadata(target: StateClassInternal): MetaDataModel {
-  if (!target.hasOwnProperty(META_KEY)) {
+  if (!target.hasOwnProperty(ɵMETA_KEY)) {
     const defaultMetadata: MetaDataModel = {
       name: null,
       actions: {},
@@ -89,7 +89,7 @@ export function ensureStoreMetadata(target: StateClassInternal): MetaDataModel {
       children: []
     };
 
-    Object.defineProperty(target, META_KEY, { value: defaultMetadata });
+    Object.defineProperty(target, ɵMETA_KEY, { value: defaultMetadata });
   }
   return getStoreMetadata(target);
 }
@@ -100,7 +100,7 @@ export function ensureStoreMetadata(target: StateClassInternal): MetaDataModel {
  * @ignore
  */
 export function getStoreMetadata(target: StateClassInternal): MetaDataModel {
-  return target[META_KEY]!;
+  return target[ɵMETA_KEY]!;
 }
 
 /**
@@ -109,7 +109,7 @@ export function getStoreMetadata(target: StateClassInternal): MetaDataModel {
  * @ignore
  */
 export function ensureSelectorMetadata(target: Function): SelectorMetaDataModel {
-  if (!target.hasOwnProperty(SELECTOR_META_KEY)) {
+  if (!target.hasOwnProperty(ɵSELECTOR_META_KEY)) {
     const defaultMetadata: SelectorMetaDataModel = {
       makeRootSelector: null,
       originalFn: null,
@@ -118,7 +118,7 @@ export function ensureSelectorMetadata(target: Function): SelectorMetaDataModel 
       getSelectorOptions: () => ({})
     };
 
-    Object.defineProperty(target, SELECTOR_META_KEY, { value: defaultMetadata });
+    Object.defineProperty(target, ɵSELECTOR_META_KEY, { value: defaultMetadata });
   }
 
   return getSelectorMetadata(target);
@@ -130,7 +130,7 @@ export function ensureSelectorMetadata(target: Function): SelectorMetaDataModel 
  * @ignore
  */
 export function getSelectorMetadata(target: any): SelectorMetaDataModel {
-  return target[SELECTOR_META_KEY];
+  return target[ɵSELECTOR_META_KEY];
 }
 
 /**
@@ -216,12 +216,12 @@ export function buildGraph(stateClasses: StateClassInternal[]): StateKeyGraph {
       );
     }
 
-    return meta![META_KEY]!.name!;
+    return meta![ɵMETA_KEY]!.name!;
   };
 
   return stateClasses.reduce<StateKeyGraph>(
     (result: StateKeyGraph, stateClass: StateClassInternal) => {
-      const { name, children } = stateClass[META_KEY]!;
+      const { name, children } = stateClass[ɵMETA_KEY]!;
       result[name!] = (children || []).map(findName);
       return result;
     },
@@ -242,7 +242,7 @@ export function buildGraph(stateClasses: StateClassInternal[]): StateKeyGraph {
 export function nameToState(states: StateClassInternal[]): PlainObjectOf<StateClassInternal> {
   return states.reduce<PlainObjectOf<StateClassInternal>>(
     (result: PlainObjectOf<StateClassInternal>, stateClass: StateClassInternal) => {
-      const meta = stateClass[META_KEY]!;
+      const meta = stateClass[ɵMETA_KEY]!;
       result[meta.name!] = stateClass;
       return result;
     },

--- a/packages/store/src/internal/state-factory.ts
+++ b/packages/store/src/internal/state-factory.ts
@@ -18,9 +18,9 @@ import {
   shareReplay,
   takeUntil
 } from 'rxjs/operators';
-import { INITIAL_STATE_TOKEN, PlainObjectOf, memoize } from '@ngxs/store/internals';
+import { INITIAL_STATE_TOKEN, PlainObjectOf, memoize, ɵMETA_KEY } from '@ngxs/store/internals';
 
-import { META_KEY, NgxsConfig } from '../symbols';
+import { NgxsConfig } from '../symbols';
 import {
   buildGraph,
   findFullParentPath,
@@ -174,7 +174,7 @@ export class StateFactory implements OnDestroy {
     for (const name of sortedStates) {
       const stateClass: StateClassInternal = nameGraph[name];
       const path: string = paths[name];
-      const meta: MetaDataModel = stateClass[META_KEY]!;
+      const meta: MetaDataModel = stateClass[ɵMETA_KEY]!;
 
       this.addRuntimeInfoToMeta(meta, path);
 

--- a/packages/store/src/module.ts
+++ b/packages/store/src/module.ts
@@ -1,5 +1,5 @@
 import { ModuleWithProviders, NgModule } from '@angular/core';
-import { StateClass } from '@ngxs/store/internals';
+import { ɵStateClass } from '@ngxs/store/internals';
 
 import { NgxsModuleOptions } from './symbols';
 import { NgxsRootModule } from './modules/ngxs-root.module';
@@ -10,7 +10,7 @@ import { getFeatureProviders } from './standalone-features/feature-providers';
 @NgModule()
 export class NgxsModule {
   static forRoot(
-    states: StateClass[] = [],
+    states: ɵStateClass[] = [],
     options: NgxsModuleOptions = {}
   ): ModuleWithProviders<NgxsRootModule> {
     return {
@@ -19,7 +19,7 @@ export class NgxsModule {
     };
   }
 
-  static forFeature(states: StateClass[] = []): ModuleWithProviders<NgxsFeatureModule> {
+  static forFeature(states: ɵStateClass[] = []): ModuleWithProviders<NgxsFeatureModule> {
     return {
       ngModule: NgxsFeatureModule,
       providers: getFeatureProviders(states)

--- a/packages/store/src/selectors/selector-types.util.ts
+++ b/packages/store/src/selectors/selector-types.util.ts
@@ -1,4 +1,4 @@
-import { StateClass } from '@ngxs/store/internals';
+import { ɵStateClass } from '@ngxs/store/internals';
 
 import { StateToken } from '../state-token/state-token';
 
@@ -6,7 +6,7 @@ export type SelectorFunc<TModel> = (...arg: any[]) => TModel;
 
 export type TypedSelector<TModel> = StateToken<TModel> | SelectorFunc<TModel>;
 
-export type StateSelector = StateClass<any>;
+export type StateSelector = ɵStateClass<any>;
 
 export type SelectorDef<TModel> = StateSelector | TypedSelector<TModel>;
 
@@ -14,7 +14,7 @@ export type SelectorReturnType<T extends SelectorDef<any>> = T extends StateToke
   ? R1
   : T extends SelectorFunc<infer R2>
   ? R2
-  : T extends StateClass<any>
+  : T extends ɵStateClass<any>
   ? any /* (Block comment to stop prettier breaking the comment below)
   // If the state selector is a class then we should infer its return type to `any`, and not to `unknown`.
   // Since we'll get an error that `Type 'unknown' is not assignable to type 'AuthStateModel'.`

--- a/packages/store/src/standalone-features/feature-providers.ts
+++ b/packages/store/src/standalone-features/feature-providers.ts
@@ -1,5 +1,5 @@
 import { Provider } from '@angular/core';
-import { StateClass } from '@ngxs/store/internals';
+import { ɵStateClass } from '@ngxs/store/internals';
 
 import { FEATURE_STATE_TOKEN } from '../symbols';
 import { PluginManager } from '../plugin-manager';
@@ -9,7 +9,7 @@ import { StateFactory } from '../internal/state-factory';
  * This function provides the required providers when calling `NgxsModule.forFeature`
  * or `provideStates`. It is shared between the NgModule and standalone APIs.
  */
-export function getFeatureProviders(states: StateClass[]): Provider[] {
+export function getFeatureProviders(states: ɵStateClass[]): Provider[] {
   return [
     StateFactory,
     PluginManager,

--- a/packages/store/src/standalone-features/provide-states.ts
+++ b/packages/store/src/standalone-features/provide-states.ts
@@ -1,5 +1,5 @@
 import { EnvironmentProviders, makeEnvironmentProviders } from '@angular/core';
-import { StateClass } from '@ngxs/store/internals';
+import { ɵStateClass } from '@ngxs/store/internals';
 
 import { getFeatureProviders } from './feature-providers';
 import { NGXS_FEATURE_ENVIRONMENT_INITIALIZER } from './initializers';
@@ -20,7 +20,7 @@ import { NGXS_FEATURE_ENVIRONMENT_INITIALIZER } from './initializers';
  * ```
  */
 export function provideStates(
-  states: StateClass[],
+  states: ɵStateClass[],
   ...features: EnvironmentProviders[]
 ): EnvironmentProviders {
   return makeEnvironmentProviders([

--- a/packages/store/src/standalone-features/provide-store.ts
+++ b/packages/store/src/standalone-features/provide-store.ts
@@ -1,5 +1,5 @@
 import { EnvironmentProviders, makeEnvironmentProviders } from '@angular/core';
-import { StateClass } from '@ngxs/store/internals';
+import { ɵStateClass } from '@ngxs/store/internals';
 
 import { NgxsModuleOptions } from '../symbols';
 import { getRootProviders } from './root-providers';
@@ -23,18 +23,18 @@ import { NGXS_ROOT_ENVIRONMENT_INITIALIZER } from './initializers';
  * ```
  */
 export function provideStore(
-  states?: StateClass[],
+  states?: ɵStateClass[],
   ...features: EnvironmentProviders[]
 ): EnvironmentProviders;
 
 export function provideStore(
-  states?: StateClass[],
+  states?: ɵStateClass[],
   options?: NgxsModuleOptions,
   ...features: EnvironmentProviders[]
 ): EnvironmentProviders;
 
 export function provideStore(
-  states: StateClass[] = [],
+  states: ɵStateClass[] = [],
   ...optionsAndFeatures: any[]
 ): EnvironmentProviders {
   const features: EnvironmentProviders[] = [];

--- a/packages/store/src/standalone-features/root-providers.ts
+++ b/packages/store/src/standalone-features/root-providers.ts
@@ -1,7 +1,7 @@
 import { APP_BOOTSTRAP_LISTENER, Provider, inject } from '@angular/core';
 import {
   NgxsBootstrapper,
-  StateClass,
+  ɵStateClass,
   ɵNGXS_STATE_CONTEXT_FACTORY,
   ɵNGXS_STATE_FACTORY
 } from '@ngxs/store/internals';
@@ -17,7 +17,7 @@ import { NgxsModuleOptions, ROOT_STATE_TOKEN, NGXS_OPTIONS } from '../symbols';
  * or `provideStore`. It is shared between the NgModule and standalone APIs.
  */
 export function getRootProviders(
-  states: StateClass[],
+  states: ɵStateClass[],
   options: NgxsModuleOptions
 ): Provider[] {
   return [

--- a/packages/store/src/symbols.ts
+++ b/packages/store/src/symbols.ts
@@ -1,7 +1,7 @@
 import { Injectable, InjectionToken, Type, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 
-import { PlainObject, StateClass } from '@ngxs/store/internals';
+import { PlainObject, ɵStateClass } from '@ngxs/store/internals';
 import { StateOperator } from '@ngxs/store/operators';
 
 import { mergeDeep } from './utils/utils';
@@ -14,7 +14,7 @@ const NG_DEV_MODE = typeof ngDevMode === 'undefined' || ngDevMode;
 
 // The injection token is used to resolve a list of states provided at
 // the root level through either `NgxsModule.forRoot` or `provideStore`.
-export const ROOT_STATE_TOKEN = new InjectionToken<Array<StateClass>>(
+export const ROOT_STATE_TOKEN = new InjectionToken<Array<ɵStateClass>>(
   NG_DEV_MODE ? 'ROOT_STATE_TOKEN' : ''
 );
 
@@ -22,7 +22,7 @@ export const ROOT_STATE_TOKEN = new InjectionToken<Array<StateClass>>(
 // the feature level through either `NgxsModule.forFeature` or `provideStates`.
 // The Array<Array> is used to overload the resolved value of the token because
 // it is a multi-provider token.
-export const FEATURE_STATE_TOKEN = new InjectionToken<Array<Array<StateClass>>>(
+export const FEATURE_STATE_TOKEN = new InjectionToken<Array<Array<ɵStateClass>>>(
   NG_DEV_MODE ? 'FEATURE_STATE_TOKEN' : ''
 );
 
@@ -35,10 +35,6 @@ export const NGXS_PLUGINS = new InjectionToken(NG_DEV_MODE ? 'NGXS_PLUGINS' : ''
 export const NGXS_OPTIONS = new InjectionToken<NgxsModuleOptions>(
   NG_DEV_MODE ? 'NGXS_OPTIONS' : ''
 );
-
-export const META_KEY = 'NGXS_META';
-export const META_OPTIONS_KEY = 'NGXS_OPTIONS_META';
-export const SELECTOR_META_KEY = 'NGXS_SELECTOR_META';
 
 export type NgxsLifeCycle = Partial<NgxsOnChanges> &
   Partial<NgxsOnInit> &
@@ -163,7 +159,7 @@ export interface StoreOptions<T> {
   /**
    * Sub states for the given state.
    */
-  children?: StateClass[];
+  children?: ɵStateClass[];
 }
 
 /**

--- a/packages/store/tests/action-handler.spec.ts
+++ b/packages/store/tests/action-handler.spec.ts
@@ -1,7 +1,7 @@
 import { ErrorHandler, Injectable } from '@angular/core';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { Action, State, StateContext, NgxsModule, Store, Actions } from '@ngxs/store';
-import { StateClass } from '@ngxs/store/internals';
+import { ɵStateClass } from '@ngxs/store/internals';
 import { timer } from 'rxjs';
 import { tap } from 'rxjs/operators';
 
@@ -16,7 +16,7 @@ describe('Action handlers', () => {
 
   type IFooStateModel = { name: string; age?: number; updated?: boolean };
 
-  function setup(config: { stores: StateClass[] }) {
+  function setup(config: { stores: ɵStateClass[] }) {
     config = config || {
       stores: []
     };

--- a/packages/store/tests/action.spec.ts
+++ b/packages/store/tests/action.spec.ts
@@ -14,10 +14,10 @@ import {
   ofActionErrored,
   ofActionSuccessful
 } from '@ngxs/store';
+import { ɵMETA_KEY } from '@ngxs/store/internals';
 import { Observable, of, Subject, throwError } from 'rxjs';
 import { delay, map, tap } from 'rxjs/operators';
 
-import { META_KEY } from '../src/symbols';
 import { NoopErrorHandler } from './helpers/utils';
 
 describe('Action', () => {
@@ -81,7 +81,7 @@ describe('Action', () => {
       // Arrange
       setup();
       // Act
-      const meta = (<any>BarStore)[META_KEY];
+      const meta = (<any>BarStore)[ɵMETA_KEY];
       // Assert
       expect(meta.actions[Action1.type]).toBeDefined();
       expect(meta.actions[Action2.type]).toBeDefined();

--- a/packages/store/tests/selector.spec.ts
+++ b/packages/store/tests/selector.spec.ts
@@ -8,7 +8,7 @@ import {
   Selector,
   SelectorOptions
 } from '@ngxs/store';
-import { StateClass } from '@ngxs/store/internals';
+import { ɵStateClass } from '@ngxs/store/internals';
 
 import { NgxsConfig } from '../src/symbols';
 
@@ -220,7 +220,7 @@ describe('Selector', () => {
   });
 
   describe('(Selector Options)', () => {
-    function setupStore(states: StateClass[], extendedOptions?: Partial<NgxsConfig>) {
+    function setupStore(states: ɵStateClass[], extendedOptions?: Partial<NgxsConfig>) {
       TestBed.configureTestingModule({
         imports: [NgxsModule.forRoot(states, extendedOptions)]
       });

--- a/packages/store/tests/state.spec.ts
+++ b/packages/store/tests/state.spec.ts
@@ -22,8 +22,9 @@ import {
   StateContext,
   Store
 } from '@ngxs/store';
+import { ɵMETA_KEY } from '@ngxs/store/internals';
 
-import { META_KEY, NgxsAfterBootstrap } from '../src/symbols';
+import { NgxsAfterBootstrap } from '../src/symbols';
 import { simplePatch } from '../src/internal/state-operators';
 
 describe('State', () => {
@@ -34,7 +35,7 @@ describe('State', () => {
     @Injectable()
     class BarState {}
 
-    const meta = (<any>BarState)[META_KEY];
+    const meta = (<any>BarState)[ɵMETA_KEY];
 
     expect(meta.name).toBe('moo');
   });
@@ -66,7 +67,7 @@ describe('State', () => {
       drink() {}
     }
 
-    const meta = (<any>Bar2State)[META_KEY];
+    const meta = (<any>Bar2State)[ɵMETA_KEY];
     expect(meta.actions[Eat.type]).toBeDefined();
     expect(meta.actions[Drink.type]).toBeDefined();
   });

--- a/packages/store/tests/store-isolation.spec.ts
+++ b/packages/store/tests/store-isolation.spec.ts
@@ -4,7 +4,7 @@ import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { TestBed } from '@angular/core/testing';
 import { Store, NgxsModule, State, Selector, SelectorOptions, StateToken } from '@ngxs/store';
-import { StateClass } from '@ngxs/store/internals';
+import { ɵStateClass } from '@ngxs/store/internals';
 
 describe('Store (isolation)', () => {
   describe('when selecting a child state', () => {
@@ -170,7 +170,7 @@ describe('Store (isolation)', () => {
       store.reset({ parent: { path: 'parent', child: 'parent.child' }, child: 'child' });
     }
 
-    function setup(states: StateClass<any>[]) {
+    function setup(states: ɵStateClass<any>[]) {
       TestBed.configureTestingModule({
         imports: [
           NgxsModule.forRoot(states, {


### PR DESCRIPTION
This commit relocates keys used for storing metadata and options on state classes to the internals package. It can now be exposed to plugin authors who need to retrieve metadata from state classes and prefer a stable key.