### PR TITLE
feat(store): add support for standalone APIs in schematics

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -9,11 +9,12 @@ checks:
   method-lines:
     config:
       threshold: 50
-exclude_paths:
+exclude_patterns:
   - '.github/'
   - 'assets/'
   - 'docs/'
   - 'packages/**/tests/'
+  - 'packages/store/schematics/src/utils/ng-utils/'
   - 'integrations/'
   - 'integration/'
   - 'tools/'

--- a/packages/store/jest.config.js
+++ b/packages/store/jest.config.js
@@ -9,6 +9,9 @@ module.exports = {
     }
   },
   coverageDirectory: '../../coverage/packages/store',
+  coveragePathIgnorePatterns: [
+    "<rootDir>/schematics/src/utils/ng-utils/**/*.ts"
+  ]
   transform: {
     '^.+\\.(ts|js|html)$': 'jest-preset-angular'
   },

--- a/packages/store/jest.config.js
+++ b/packages/store/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
   coverageDirectory: '../../coverage/packages/store',
   coveragePathIgnorePatterns: [
     "<rootDir>/schematics/src/utils/ng-utils/**/*.ts"
-  ]
+  ],
   transform: {
     '^.+\\.(ts|js|html)$': 'jest-preset-angular'
   },

--- a/packages/store/jest.config.js
+++ b/packages/store/jest.config.js
@@ -10,6 +10,7 @@ module.exports = {
   },
   coverageDirectory: '../../coverage/packages/store',
   coveragePathIgnorePatterns: [
+    "/node_modules/",
     "<rootDir>/schematics/src/utils/ng-utils/"
   ],
   transform: {

--- a/packages/store/jest.config.js
+++ b/packages/store/jest.config.js
@@ -10,7 +10,7 @@ module.exports = {
   },
   coverageDirectory: '../../coverage/packages/store',
   coveragePathIgnorePatterns: [
-    "<rootDir>/schematics/src/utils/ng-utils/**/*.ts"
+    "<rootDir>/schematics/src/utils/ng-utils/"
   ],
   transform: {
     '^.+\\.(ts|js|html)$': 'jest-preset-angular'

--- a/packages/store/schematics/src/ng-add/add-declaration.ts
+++ b/packages/store/schematics/src/ng-add/add-declaration.ts
@@ -1,0 +1,124 @@
+import { Rule, chain } from '@angular-devkit/schematics';
+import { addRootImport, addRootProvider } from '../utils/ng-utils/standalone/rules';
+import {
+  applyChangesToFile,
+  findBootstrapApplicationCall,
+  getMainFilePath,
+  getSourceFile
+} from '../utils/ng-utils/standalone/util';
+import { insertImport } from '@schematics/angular/utility/ast-utils';
+import { findAppConfig } from '../utils/ng-utils/standalone/app_config';
+import { LIBRARIES } from '../utils/common/lib.config';
+import { NormalizedNgxsPackageSchema } from './ng-add.factory';
+
+export function addDeclarationToStandaloneApp(options: NormalizedNgxsPackageSchema): Rule {
+  return async host => {
+    const mainFilePath = await getMainFilePath(host, options.project);
+    const bootstrapCall = findBootstrapApplicationCall(host, mainFilePath);
+    const appConfigFilePath =
+      findAppConfig(bootstrapCall, host, mainFilePath)?.filePath || mainFilePath;
+
+    const plugins = options.plugins
+      .filter(p => pluginData.has(p))
+      .map((p): [LIBRARIES, string] => [p, pluginData.get(p)!.standalone]);
+
+    const importPluginRules = plugins.map(([plugin, standaloneDeclaration]): Rule => {
+      return importTree => {
+        const change = insertImport(
+          getSourceFile(host, appConfigFilePath),
+          appConfigFilePath,
+          standaloneDeclaration,
+          plugin
+        );
+        applyChangesToFile(importTree, appConfigFilePath, [change]);
+      };
+    });
+    const pluginDeclarations = plugins
+      .map(([, standaloneDeclaration]) => `${standaloneDeclaration}()`)
+      .join(',\n');
+    return chain([
+      ...importPluginRules,
+      addRootProvider(
+        options.project,
+        ({ code, external }) =>
+          code`${external('provideStore', '@ngxs/store')}(\n[],\n${pluginDeclarations})`
+      )
+    ]);
+  };
+}
+
+export function addDeclarationToNonStandaloneApp(options: NormalizedNgxsPackageSchema): Rule {
+  const pluginRules = options.plugins
+    .map(p => [p, pluginData.get(p)?.module])
+    .filter((v): v is [LIBRARIES, string] => !!v[1])
+    .map(([plugin, moduleName]) => {
+      return addRootImport(
+        options.project,
+        ({ code, external }) => code`${external(moduleName, plugin)}.forRoot()`
+      );
+    });
+
+  const importPath = '@ngxs/store';
+
+  const moduleImportExtras =
+    '.forRoot([], { developmentMode: /** !environment.production */ false, selectorOptions: { suppressErrors: false, injectContainerState: false } })';
+
+  return chain([
+    addRootImport(
+      options.project,
+      ({ code, external }) => code`${external('NgxsModule', importPath)}${moduleImportExtras}`
+    ),
+    ...pluginRules
+  ]);
+}
+
+const pluginData: ReadonlyMap<LIBRARIES, { module?: string; standalone: string }> = new Map([
+  [
+    LIBRARIES.DEVTOOLS,
+    {
+      module: 'NgxsReduxDevtoolsPluginModule',
+      standalone: 'withNgxsReduxDevtoolsPlugin'
+    }
+  ],
+  [
+    LIBRARIES.FORM,
+    {
+      module: 'NgxsFormPluginModule',
+      standalone: 'withNgxsFormPlugin'
+    }
+  ],
+  [
+    LIBRARIES.LOGGER,
+    {
+      module: 'NgxsLoggerPluginModule',
+      standalone: 'withNgxsLoggerPlugin'
+    }
+  ],
+  [
+    LIBRARIES.ROUTER,
+    {
+      module: 'NgxsRouterPluginModule',
+      standalone: 'withNgxsRouterPlugin'
+    }
+  ],
+  [
+    LIBRARIES.STORAGE,
+    {
+      module: 'NgxsStoragePluginModule',
+      standalone: 'withNgxsStoragePlugin'
+    }
+  ],
+  [
+    LIBRARIES.STORE,
+    {
+      standalone: 'provideStore'
+    }
+  ],
+  [
+    LIBRARIES.WEBSOCKET,
+    {
+      module: 'NgxsWebsocketPluginModule',
+      standalone: 'withNgxsWebSocketPlugin'
+    }
+  ]
+]);

--- a/packages/store/schematics/src/ng-add/ng-add.factory.spec.ts
+++ b/packages/store/schematics/src/ng-add/ng-add.factory.spec.ts
@@ -40,12 +40,8 @@ describe('Ngxs ng-add Schematic', () => {
 
   let appTree: UnitTestTree;
   beforeEach(async () => {
-    appTree = await angularSchematicRunner
-      .runSchematicAsync('workspace', workspaceOptions)
-      .toPromise();
-    appTree = await angularSchematicRunner
-      .runSchematicAsync('application', appOptions, appTree)
-      .toPromise();
+    appTree = await angularSchematicRunner.runSchematic('workspace', workspaceOptions);
+    appTree = await angularSchematicRunner.runSchematic('application', appOptions, appTree);
   });
 
   describe('importing the Ngxs module', () => {
@@ -57,9 +53,8 @@ describe('Ngxs ng-add Schematic', () => {
       // Arrange
       const options: NgxsPackageSchema = { ...defaultOptions, project };
       // Act
-      const tree = await ngxsSchematicRunner
-        .runSchematicAsync('ngxs-init', options, appTree)
-        .toPromise();
+      const tree = await ngxsSchematicRunner.runSchematic('ngxs-init', options, appTree);
+
       // Assert
       const content = tree.readContent('/projects/foo/src/app/app.module.ts');
       expect(content).toMatch(/import { NgxsModule } from '@ngxs\/store'/);
@@ -72,7 +67,7 @@ describe('Ngxs ng-add Schematic', () => {
       // Arrange
       const options: NgxsPackageSchema = { ...defaultOptions, project: 'hello' };
       await expect(
-        ngxsSchematicRunner.runSchematicAsync('ng-add', options, appTree).toPromise()
+        ngxsSchematicRunner.runSchematic('ng-add', options, appTree)
       ).rejects.toThrow(`Project "${options.project}" does not exist.`);
     });
   });
@@ -81,9 +76,8 @@ describe('Ngxs ng-add Schematic', () => {
     it('should add ngxs store with provided plugins in package.json', async () => {
       const plugins = [LIBRARIES.DEVTOOLS, LIBRARIES.LOGGER];
       const options: NgxsPackageSchema = { plugins };
-      appTree = await ngxsSchematicRunner
-        .runSchematicAsync('ng-add', options, appTree)
-        .toPromise();
+      appTree = await ngxsSchematicRunner.runSchematic('ng-add', options, appTree);
+
       const packageJsonText = appTree.readContent('/package.json');
       const packageJson = JSON.parse(packageJsonText);
       expect(plugins.every(p => !!packageJson.dependencies[p])).toBeTruthy();
@@ -92,9 +86,8 @@ describe('Ngxs ng-add Schematic', () => {
     it('should add ngxs store with all plugins in package.json', async () => {
       const packages = Object.values(LIBRARIES).filter(v => v !== LIBRARIES.STORE);
       const options: NgxsPackageSchema = { plugins: packages };
-      appTree = await ngxsSchematicRunner
-        .runSchematicAsync('ng-add', options, appTree)
-        .toPromise();
+      appTree = await ngxsSchematicRunner.runSchematic('ng-add', options, appTree);
+
       const packageJsonText = appTree.readContent('/package.json');
       const packageJson = JSON.parse(packageJsonText);
       expect(packages.every(p => !!packageJson.dependencies[p])).toBeTruthy();
@@ -104,7 +97,7 @@ describe('Ngxs ng-add Schematic', () => {
       const packages = ['who-am-i'];
       const options: NgxsPackageSchema = { plugins: packages };
       await expect(
-        ngxsSchematicRunner.runSchematicAsync('ng-add', options, appTree).toPromise()
+        ngxsSchematicRunner.runSchematic('ng-add', options, appTree)
       ).rejects.toThrow();
     });
   });

--- a/packages/store/schematics/src/ng-add/ng-add.factory.ts
+++ b/packages/store/schematics/src/ng-add/ng-add.factory.ts
@@ -7,55 +7,65 @@ import {
   noop
 } from '@angular-devkit/schematics';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
-import * as ts from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
-import { addImportToModule } from '@schematics/angular/utility/ast-utils';
-import { InsertChange } from '@schematics/angular/utility/change';
 import {
   NodeDependencyType,
   addPackageJsonDependency,
   getPackageJsonDependency
 } from '@schematics/angular/utility/dependencies';
-import { getAppModulePath } from '@schematics/angular/utility/ng-ast-utils';
 
 import { LIBRARIES } from '../utils/common/lib.config';
-import { getProject } from '../utils/project';
 
 import { NgxsPackageSchema } from './ng-add.schema';
+import { getProjectMainFile } from '../utils/ng-utils/project';
+import { isStandaloneApp } from '../utils/ng-utils/ng-ast-utils';
+import {
+  addDeclarationToNonStandaloneApp,
+  addDeclarationToStandaloneApp
+} from './add-declaration';
+import { getProject } from '../utils/project';
 
 const versions = require('./../utils/versions.json');
 
+export type NormalizedNgxsPackageSchema = {
+  skipInstall: boolean;
+  plugins: LIBRARIES[];
+  project: string;
+};
+
 export function ngAdd(options: NgxsPackageSchema): Rule {
-  return chain([
-    addNgxsPackageToPackageJson(options),
-    addDeclarationToNgModule(options),
-    options.skipInstall ? noop() : runNpmPackageInstall()
-  ]);
+  return (host: Tree) => {
+    const normalizedSchema = normalizeSchema(host, options);
+
+    return chain([
+      addNgxsPackageToPackageJson(normalizedSchema),
+      addDeclaration(normalizedSchema),
+      normalizedSchema.skipInstall ? noop() : runNpmPackageInstall()
+    ]);
+  };
 }
 
-function addNgxsPackageToPackageJson(options: NgxsPackageSchema): Rule {
+function addNgxsPackageToPackageJson(schema: NormalizedNgxsPackageSchema): Rule {
   return (host: Tree, context: SchematicContext) => {
     const ngxsStoreVersion: string = versions['@ngxs/store'];
     if (!ngxsStoreVersion) {
       throw new SchematicsException('Could not resolve the version of "@ngxs/store"');
     }
 
-    Object.values(LIBRARIES)
-      .filter(lib => options.plugins?.includes(lib))
-      .forEach(name => {
-        const packageExists = getPackageJsonDependency(host, name);
-        if (packageExists === null) {
-          addPackageJsonDependency(host, {
-            type: NodeDependencyType.Default,
-            name,
-            version: ngxsStoreVersion
-          });
-          context.logger.info(`✅️ Added "${name}" into ${NodeDependencyType.Default}`);
-        } else {
-          context.logger.warn(
-            `✅️ "${name}" already exists in the ${NodeDependencyType.Default}`
-          );
-        }
-      });
+    schema.plugins!.forEach(name => {
+      const packageExists = getPackageJsonDependency(host, name);
+      if (packageExists === null) {
+        addPackageJsonDependency(host, {
+          type: NodeDependencyType.Default,
+          name,
+          version: ngxsStoreVersion
+        });
+        context.logger.info(`✅️ Added "${name}" into ${NodeDependencyType.Default}`);
+      } else {
+        context.logger.warn(
+          `✅️ "${name}" already exists in the ${NodeDependencyType.Default}`
+        );
+      }
+    });
     return host;
   };
 }
@@ -67,47 +77,27 @@ function runNpmPackageInstall(): Rule {
   };
 }
 
-function addDeclarationToNgModule(options: NgxsPackageSchema): Rule {
-  return (host: Tree) => {
-    const project = getProject(host, { project: options.project });
+function addDeclaration(schema: NormalizedNgxsPackageSchema): Rule {
+  return async (host: Tree) => {
+    const mainFile = getProjectMainFile(host, schema.project);
+    const isStandalone = isStandaloneApp(host, mainFile);
 
-    if (typeof project === 'undefined' || project === null) {
-      const message = options.project
-        ? `Project "${options.project}" does not exist.`
-        : 'Could not determine the project to update.';
-      throw new SchematicsException(message);
+    if (isStandalone) {
+      return addDeclarationToStandaloneApp(schema);
+    } else {
+      return addDeclarationToNonStandaloneApp(schema);
     }
+  };
+}
 
-    const modulePath = getAppModulePath(host, `${project.root}/src/main.ts`);
-
-    if (typeof modulePath === 'undefined') {
-      throw new SchematicsException(
-        `Module path for project "${options.project}" does not exist.`
-      );
-    }
-
-    const importPath = '@ngxs/store';
-
-    const moduleImport =
-      'NgxsModule.forRoot([], { developmentMode: /** !environment.production */ false, selectorOptions: { suppressErrors: false, injectContainerState: false } })';
-
-    const sourceBuffer = host.read(modulePath);
-
-    if (sourceBuffer !== null) {
-      const sourceText = sourceBuffer.toString();
-      const source = ts.createSourceFile(modulePath, sourceText, ts.ScriptTarget.Latest, true);
-
-      const changes = addImportToModule(source, modulePath, moduleImport, importPath);
-
-      const recorder = host.beginUpdate(modulePath);
-      for (const change of changes) {
-        if (change instanceof InsertChange) {
-          recorder.insertLeft(change.pos, change.toAdd);
-        }
-      }
-      host.commitUpdate(recorder);
-    }
-
-    return host;
+function normalizeSchema(host: Tree, schema: NgxsPackageSchema): NormalizedNgxsPackageSchema {
+  const projectName = getProject(host, schema.project)?.name;
+  if (!projectName) {
+    throw new SchematicsException(`Project "${schema.project}" does not exist.`);
+  }
+  return {
+    skipInstall: !!schema.skipInstall,
+    plugins: Object.values(LIBRARIES).filter(lib => schema.plugins?.includes(lib)) ?? [],
+    project: projectName
   };
 }

--- a/packages/store/schematics/src/utils/config.ts
+++ b/packages/store/schematics/src/utils/config.ts
@@ -128,16 +128,16 @@ export interface AppConfig {
   };
 }
 
-export function getWorkspacePath(host: Tree): string {
+export function getWorkspacePath(host: Tree): string | undefined {
   const possibleFiles = ['/angular.json', '/.angular.json', '/workspace.json'];
-  const path = possibleFiles.filter(path => host.exists(path))[0];
+  const path = possibleFiles.find(path => host.exists(path));
 
   return path;
 }
 
 export function getWorkspace(host: Tree) {
   const path = getWorkspacePath(host);
-  const configBuffer = host.read(path);
+  const configBuffer = path ? host.read(path) : null;
   if (configBuffer === null) {
     throw new SchematicsException(`Could not find (${path})`);
   }

--- a/packages/store/schematics/src/utils/ng-utils/README.md
+++ b/packages/store/schematics/src/utils/ng-utils/README.md
@@ -1,0 +1,1 @@
+The ng-utils folder represents a set of files copied from the @schematics/angular package's latest version. These utilities can be removed once @ngxs supports @angular >=16 as the minimum required version.

--- a/packages/store/schematics/src/utils/ng-utils/ast-utils.ts
+++ b/packages/store/schematics/src/utils/ng-utils/ast-utils.ts
@@ -1,0 +1,748 @@
+import { tags } from '@angular-devkit/core';
+import * as ts from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
+import { Change, InsertChange, NoopChange } from '@schematics/angular/utility/change';
+
+/**
+ * Add Import `import { symbolName } from fileName` if the import doesn't exit
+ * already. Assumes fileToEdit can be resolved and accessed.
+ * @param fileToEdit File we want to add import to.
+ * @param symbolName Item to import.
+ * @param fileName Path to the file.
+ * @param isDefault If true, import follows style for importing default exports.
+ * @param alias Alias that the symbol should be inserted under.
+ * @return Change
+ */
+export function insertImport(
+  source: ts.SourceFile,
+  fileToEdit: string,
+  symbolName: string,
+  fileName: string,
+  isDefault = false,
+  alias?: string
+): Change {
+  const rootNode = source;
+  const allImports = findNodes(rootNode, ts.isImportDeclaration);
+  const importExpression = alias ? `${symbolName} as ${alias}` : symbolName;
+
+  // get nodes that map to import statements from the file fileName
+  const relevantImports = allImports.filter(node => {
+    return (
+      ts.isStringLiteralLike(node.moduleSpecifier) && node.moduleSpecifier.text === fileName
+    );
+  });
+
+  if (relevantImports.length > 0) {
+    const hasNamespaceImport = relevantImports.some(node => {
+      return node.importClause?.namedBindings?.kind === ts.SyntaxKind.NamespaceImport;
+    });
+
+    // if imports * from fileName, don't add symbolName
+    if (hasNamespaceImport) {
+      return new NoopChange();
+    }
+
+    const imports = relevantImports.flatMap(node => {
+      return node.importClause?.namedBindings &&
+        ts.isNamedImports(node.importClause.namedBindings)
+        ? node.importClause.namedBindings.elements
+        : [];
+    });
+
+    // insert import if it's not there
+    if (!imports.some(node => (node.propertyName || node.name).text === symbolName)) {
+      const fallbackPos =
+        findNodes(relevantImports[0], ts.SyntaxKind.CloseBraceToken)[0].getStart() ||
+        findNodes(relevantImports[0], ts.SyntaxKind.FromKeyword)[0].getStart();
+
+      return insertAfterLastOccurrence(
+        imports,
+        `, ${importExpression}`,
+        fileToEdit,
+        fallbackPos
+      );
+    }
+
+    return new NoopChange();
+  }
+
+  // no such import declaration exists
+  const useStrict = findNodes(rootNode, ts.isStringLiteral).filter(
+    n => n.text === 'use strict'
+  );
+  let fallbackPos = 0;
+  if (useStrict.length > 0) {
+    fallbackPos = useStrict[0].end;
+  }
+  const open = isDefault ? '' : '{ ';
+  const close = isDefault ? '' : ' }';
+  // if there are no imports or 'use strict' statement, insert import at beginning of file
+  const insertAtBeginning = allImports.length === 0 && useStrict.length === 0;
+  const separator = insertAtBeginning ? '' : ';\n';
+  const toInsert =
+    `${separator}import ${open}${importExpression}${close}` +
+    ` from '${fileName}'${insertAtBeginning ? ';\n' : ''}`;
+
+  return insertAfterLastOccurrence(
+    allImports,
+    toInsert,
+    fileToEdit,
+    fallbackPos,
+    ts.SyntaxKind.StringLiteral
+  );
+}
+
+/**
+ * Find all nodes from the AST in the subtree of node of SyntaxKind kind.
+ * @param node
+ * @param kind
+ * @param max The maximum number of items to return.
+ * @param recursive Continue looking for nodes of kind recursive until end
+ * the last child even when node of kind has been found.
+ * @return all nodes of kind, or [] if none is found
+ */
+export function findNodes(
+  node: ts.Node,
+  kind: ts.SyntaxKind,
+  max?: number,
+  recursive?: boolean
+): ts.Node[];
+
+/**
+ * Find all nodes from the AST in the subtree that satisfy a type guard.
+ * @param node
+ * @param guard
+ * @param max The maximum number of items to return.
+ * @param recursive Continue looking for nodes of kind recursive until end
+ * the last child even when node of kind has been found.
+ * @return all nodes that satisfy the type guard, or [] if none is found
+ */
+export function findNodes<T extends ts.Node>(
+  node: ts.Node,
+  guard: (node: ts.Node) => node is T,
+  max?: number,
+  recursive?: boolean
+): T[];
+
+export function findNodes<T extends ts.Node>(
+  node: ts.Node,
+  kindOrGuard: ts.SyntaxKind | ((node: ts.Node) => node is T),
+  max = Infinity,
+  recursive = false
+): T[] {
+  if (!node || max == 0) {
+    return [];
+  }
+
+  const test =
+    typeof kindOrGuard === 'function'
+      ? kindOrGuard
+      : (node: ts.Node): node is T => node.kind === kindOrGuard;
+
+  const arr: T[] = [];
+  if (test(node)) {
+    arr.push(node);
+    max--;
+  }
+  if (max > 0 && (recursive || !test(node))) {
+    for (const child of node.getChildren()) {
+      findNodes(child, test, max, recursive).forEach(node => {
+        if (max > 0) {
+          arr.push(node);
+        }
+        max--;
+      });
+
+      if (max <= 0) {
+        break;
+      }
+    }
+  }
+
+  return arr;
+}
+
+/**
+ * Get all the nodes from a source.
+ * @param sourceFile The source file object.
+ * @returns {Array<ts.Node>} An array of all the nodes in the source.
+ */
+export function getSourceNodes(sourceFile: ts.SourceFile): ts.Node[] {
+  const nodes: ts.Node[] = [sourceFile];
+  const result: ts.Node[] = [];
+
+  while (nodes.length > 0) {
+    const node = nodes.shift();
+
+    if (node) {
+      result.push(node);
+      if (node.getChildCount(sourceFile) >= 0) {
+        nodes.unshift(...node.getChildren());
+      }
+    }
+  }
+
+  return result;
+}
+
+export function findNode(node: ts.Node, kind: ts.SyntaxKind, text: string): ts.Node | null {
+  if (node.kind === kind && node.getText() === text) {
+    return node;
+  }
+
+  let foundNode: ts.Node | null = null;
+  ts.forEachChild(node, childNode => {
+    foundNode = foundNode || findNode(childNode, kind, text);
+  });
+
+  return foundNode;
+}
+
+/**
+ * Helper for sorting nodes.
+ * @return function to sort nodes in increasing order of position in sourceFile
+ */
+function nodesByPosition(first: ts.Node, second: ts.Node): number {
+  return first.getStart() - second.getStart();
+}
+
+/**
+ * Insert `toInsert` after the last occurence of `ts.SyntaxKind[nodes[i].kind]`
+ * or after the last of occurence of `syntaxKind` if the last occurence is a sub child
+ * of ts.SyntaxKind[nodes[i].kind] and save the changes in file.
+ *
+ * @param nodes insert after the last occurence of nodes
+ * @param toInsert string to insert
+ * @param file file to insert changes into
+ * @param fallbackPos position to insert if toInsert happens to be the first occurence
+ * @param syntaxKind the ts.SyntaxKind of the subchildren to insert after
+ * @return Change instance
+ * @throw Error if toInsert is first occurence but fall back is not set
+ */
+export function insertAfterLastOccurrence(
+  nodes: ts.Node[] | ts.NodeArray<ts.Node>,
+  toInsert: string,
+  file: string,
+  fallbackPos: number,
+  syntaxKind?: ts.SyntaxKind
+): Change {
+  let lastItem: ts.Node | undefined;
+  for (const node of nodes) {
+    if (!lastItem || lastItem.getStart() < node.getStart()) {
+      lastItem = node;
+    }
+  }
+  if (syntaxKind && lastItem) {
+    lastItem = findNodes(lastItem, syntaxKind).sort(nodesByPosition).pop();
+  }
+  if (!lastItem && fallbackPos == undefined) {
+    throw new Error(
+      `tried to insert ${toInsert} as first occurence with no fallback position`
+    );
+  }
+  const lastItemPosition: number = lastItem ? lastItem.getEnd() : fallbackPos;
+
+  return new InsertChange(file, lastItemPosition, toInsert);
+}
+
+function _angularImportsFromNode(node: ts.ImportDeclaration): { [name: string]: string } {
+  const ms = node.moduleSpecifier;
+  let modulePath: string;
+  switch (ms.kind) {
+    case ts.SyntaxKind.StringLiteral:
+      modulePath = (ms as ts.StringLiteral).text;
+      break;
+    default:
+      return {};
+  }
+
+  if (!modulePath.startsWith('@angular/')) {
+    return {};
+  }
+
+  if (node.importClause) {
+    if (node.importClause.name) {
+      // This is of the form `import Name from 'path'`. Ignore.
+      return {};
+    } else if (node.importClause.namedBindings) {
+      const nb = node.importClause.namedBindings;
+      if (nb.kind == ts.SyntaxKind.NamespaceImport) {
+        // This is of the form `import * as name from 'path'`. Return `name.`.
+        return {
+          [nb.name.text + '.']: modulePath
+        };
+      } else {
+        // This is of the form `import {a,b,c} from 'path'`
+        const namedImports = nb;
+
+        return namedImports.elements
+          .map((is: ts.ImportSpecifier) =>
+            is.propertyName ? is.propertyName.text : is.name.text
+          )
+          .reduce((acc: { [name: string]: string }, curr: string) => {
+            acc[curr] = modulePath;
+
+            return acc;
+          }, {});
+      }
+    }
+
+    return {};
+  } else {
+    // This is of the form `import 'path';`. Nothing to do.
+    return {};
+  }
+}
+
+export function getDecoratorMetadata(
+  source: ts.SourceFile,
+  identifier: string,
+  module: string
+): ts.Node[] {
+  const angularImports = findNodes(source, ts.isImportDeclaration)
+    .map(node => _angularImportsFromNode(node))
+    .reduce((acc, current) => {
+      for (const key of Object.keys(current)) {
+        acc[key] = current[key];
+      }
+
+      return acc;
+    }, {});
+
+  return getSourceNodes(source)
+    .filter(node => {
+      return (
+        node.kind == ts.SyntaxKind.Decorator &&
+        (node as ts.Decorator).expression.kind == ts.SyntaxKind.CallExpression
+      );
+    })
+    .map(node => (node as ts.Decorator).expression as ts.CallExpression)
+    .filter(expr => {
+      if (expr.expression.kind == ts.SyntaxKind.Identifier) {
+        const id = expr.expression as ts.Identifier;
+
+        return id.text == identifier && angularImports[id.text] === module;
+      } else if (expr.expression.kind == ts.SyntaxKind.PropertyAccessExpression) {
+        // This covers foo.NgModule when importing * as foo.
+        const paExpr = expr.expression as ts.PropertyAccessExpression;
+        // If the left expression is not an identifier, just give up at that point.
+        if (paExpr.expression.kind !== ts.SyntaxKind.Identifier) {
+          return false;
+        }
+
+        const id = paExpr.name.text;
+        const moduleId = (paExpr.expression as ts.Identifier).text;
+
+        return id === identifier && angularImports[moduleId + '.'] === module;
+      }
+
+      return false;
+    })
+    .filter(
+      expr =>
+        expr.arguments[0] && expr.arguments[0].kind == ts.SyntaxKind.ObjectLiteralExpression
+    )
+    .map(expr => expr.arguments[0] as ts.ObjectLiteralExpression);
+}
+
+export function getMetadataField(
+  node: ts.ObjectLiteralExpression,
+  metadataField: string
+): ts.ObjectLiteralElement[] {
+  return (
+    node.properties
+      .filter(ts.isPropertyAssignment)
+      // Filter out every fields that's not "metadataField". Also handles string literals
+      // (but not expressions).
+      .filter(({ name }) => {
+        return (
+          (ts.isIdentifier(name) || ts.isStringLiteral(name)) && name.text === metadataField
+        );
+      })
+  );
+}
+
+export function addSymbolToNgModuleMetadata(
+  source: ts.SourceFile,
+  ngModulePath: string,
+  metadataField: string,
+  symbolName: string,
+  importPath: string | null = null
+): Change[] {
+  const nodes = getDecoratorMetadata(source, 'NgModule', '@angular/core');
+  const node = nodes[0];
+
+  // Find the decorator declaration.
+  if (!node || !ts.isObjectLiteralExpression(node)) {
+    return [];
+  }
+
+  // Get all the children property assignment of object literals.
+  const matchingProperties = getMetadataField(node, metadataField);
+
+  if (matchingProperties.length == 0) {
+    // We haven't found the field in the metadata declaration. Insert a new field.
+    let position: number;
+    let toInsert: string;
+    if (node.properties.length == 0) {
+      position = node.getEnd() - 1;
+      toInsert = `\n  ${metadataField}: [\n${tags.indentBy(4)`${symbolName}`}\n  ]\n`;
+    } else {
+      const childNode = node.properties[node.properties.length - 1];
+      position = childNode.getEnd();
+      // Get the indentation of the last element, if any.
+      const text = childNode.getFullText(source);
+      const matches = text.match(/^(\r?\n)(\s*)/);
+      if (matches) {
+        toInsert =
+          `,${matches[0]}${metadataField}: [${matches[1]}` +
+          `${tags.indentBy(matches[2].length + 2)`${symbolName}`}${matches[0]}]`;
+      } else {
+        toInsert = `, ${metadataField}: [${symbolName}]`;
+      }
+    }
+    if (importPath !== null) {
+      return [
+        new InsertChange(ngModulePath, position, toInsert),
+        insertImport(source, ngModulePath, symbolName.replace(/\..*$/, ''), importPath)
+      ];
+    } else {
+      return [new InsertChange(ngModulePath, position, toInsert)];
+    }
+  }
+  const assignment = matchingProperties[0];
+
+  // If it's not an array, nothing we can do really.
+  if (
+    !ts.isPropertyAssignment(assignment) ||
+    !ts.isArrayLiteralExpression(assignment.initializer)
+  ) {
+    return [];
+  }
+
+  let expresssion: ts.Expression | ts.ArrayLiteralExpression;
+  const assignmentInit = assignment.initializer;
+  const elements = assignmentInit.elements;
+
+  if (elements.length) {
+    const symbolsArray = elements.map(node => tags.oneLine`${node.getText()}`);
+    if (symbolsArray.includes(tags.oneLine`${symbolName}`)) {
+      return [];
+    }
+
+    expresssion = elements[elements.length - 1];
+  } else {
+    expresssion = assignmentInit;
+  }
+
+  let toInsert: string;
+  let position = expresssion.getEnd();
+  if (ts.isArrayLiteralExpression(expresssion)) {
+    // We found the field but it's empty. Insert it just before the `]`.
+    position--;
+    toInsert = `\n${tags.indentBy(4)`${symbolName}`}\n  `;
+  } else {
+    // Get the indentation of the last element, if any.
+    const text = expresssion.getFullText(source);
+    const matches = text.match(/^(\r?\n)(\s*)/);
+    if (matches) {
+      toInsert = `,${matches[1]}${tags.indentBy(matches[2].length)`${symbolName}`}`;
+    } else {
+      toInsert = `, ${symbolName}`;
+    }
+  }
+
+  if (importPath !== null) {
+    return [
+      new InsertChange(ngModulePath, position, toInsert),
+      insertImport(source, ngModulePath, symbolName.replace(/\..*$/, ''), importPath)
+    ];
+  }
+
+  return [new InsertChange(ngModulePath, position, toInsert)];
+}
+
+/**
+ * Custom function to insert a declaration (component, pipe, directive)
+ * into NgModule declarations. It also imports the component.
+ */
+export function addDeclarationToModule(
+  source: ts.SourceFile,
+  modulePath: string,
+  classifiedName: string,
+  importPath: string
+): Change[] {
+  return addSymbolToNgModuleMetadata(
+    source,
+    modulePath,
+    'declarations',
+    classifiedName,
+    importPath
+  );
+}
+
+/**
+ * Custom function to insert an NgModule into NgModule imports. It also imports the module.
+ */
+export function addImportToModule(
+  source: ts.SourceFile,
+  modulePath: string,
+  classifiedName: string,
+  importPath: string
+): Change[] {
+  return addSymbolToNgModuleMetadata(
+    source,
+    modulePath,
+    'imports',
+    classifiedName,
+    importPath
+  );
+}
+
+/**
+ * Custom function to insert a provider into NgModule. It also imports it.
+ */
+export function addProviderToModule(
+  source: ts.SourceFile,
+  modulePath: string,
+  classifiedName: string,
+  importPath: string
+): Change[] {
+  return addSymbolToNgModuleMetadata(
+    source,
+    modulePath,
+    'providers',
+    classifiedName,
+    importPath
+  );
+}
+
+/**
+ * Custom function to insert an export into NgModule. It also imports it.
+ */
+export function addExportToModule(
+  source: ts.SourceFile,
+  modulePath: string,
+  classifiedName: string,
+  importPath: string
+): Change[] {
+  return addSymbolToNgModuleMetadata(
+    source,
+    modulePath,
+    'exports',
+    classifiedName,
+    importPath
+  );
+}
+
+/**
+ * Custom function to insert an export into NgModule. It also imports it.
+ */
+export function addBootstrapToModule(
+  source: ts.SourceFile,
+  modulePath: string,
+  classifiedName: string,
+  importPath: string
+): Change[] {
+  return addSymbolToNgModuleMetadata(
+    source,
+    modulePath,
+    'bootstrap',
+    classifiedName,
+    importPath
+  );
+}
+
+/**
+ * Determine if an import already exists.
+ */
+export function isImported(
+  source: ts.SourceFile,
+  classifiedName: string,
+  importPath: string
+): boolean {
+  const allNodes = getSourceNodes(source);
+  const matchingNodes = allNodes
+    .filter(ts.isImportDeclaration)
+    .filter(
+      imp => ts.isStringLiteral(imp.moduleSpecifier) && imp.moduleSpecifier.text === importPath
+    )
+    .filter(imp => {
+      if (!imp.importClause) {
+        return false;
+      }
+      const nodes = findNodes(imp.importClause, ts.isImportSpecifier).filter(
+        n => n.getText() === classifiedName
+      );
+
+      return nodes.length > 0;
+    });
+
+  return matchingNodes.length > 0;
+}
+
+/**
+ * Returns the RouterModule declaration from NgModule metadata, if any.
+ */
+export function getRouterModuleDeclaration(source: ts.SourceFile): ts.Expression | undefined {
+  const result = getDecoratorMetadata(source, 'NgModule', '@angular/core');
+  const node = result[0];
+  if (!node || !ts.isObjectLiteralExpression(node)) {
+    return undefined;
+  }
+
+  const matchingProperties = getMetadataField(node, 'imports');
+  if (!matchingProperties) {
+    return;
+  }
+
+  const assignment = matchingProperties[0] as ts.PropertyAssignment;
+
+  if (assignment.initializer.kind !== ts.SyntaxKind.ArrayLiteralExpression) {
+    return;
+  }
+
+  const arrLiteral = assignment.initializer as ts.ArrayLiteralExpression;
+
+  return arrLiteral.elements
+    .filter(el => el.kind === ts.SyntaxKind.CallExpression)
+    .find(el => (el as ts.Identifier).getText().startsWith('RouterModule'));
+}
+
+/**
+ * Adds a new route declaration to a router module (i.e. has a RouterModule declaration)
+ */
+export function addRouteDeclarationToModule(
+  source: ts.SourceFile,
+  fileToAdd: string,
+  routeLiteral: string
+): Change {
+  const routerModuleExpr = getRouterModuleDeclaration(source);
+  if (!routerModuleExpr) {
+    throw new Error(
+      `Couldn't find a route declaration in ${fileToAdd}.\n` +
+        `Use the '--module' option to specify a different routing module.`
+    );
+  }
+  const scopeConfigMethodArgs = (routerModuleExpr as ts.CallExpression).arguments;
+  if (!scopeConfigMethodArgs.length) {
+    const { line } = source.getLineAndCharacterOfPosition(routerModuleExpr.getStart());
+    throw new Error(
+      `The router module method doesn't have arguments ` + `at line ${line} in ${fileToAdd}`
+    );
+  }
+
+  let routesArr: ts.ArrayLiteralExpression | undefined;
+  const routesArg = scopeConfigMethodArgs[0];
+
+  // Check if the route declarations array is
+  // an inlined argument of RouterModule or a standalone variable
+  if (ts.isArrayLiteralExpression(routesArg)) {
+    routesArr = routesArg;
+  } else {
+    const routesVarName = routesArg.getText();
+    let routesVar;
+    if (routesArg.kind === ts.SyntaxKind.Identifier) {
+      routesVar = source.statements.filter(ts.isVariableStatement).find(v => {
+        return v.declarationList.declarations[0].name.getText() === routesVarName;
+      });
+    }
+
+    if (!routesVar) {
+      const { line } = source.getLineAndCharacterOfPosition(routesArg.getStart());
+      throw new Error(
+        `No route declaration array was found that corresponds ` +
+          `to router module at line ${line} in ${fileToAdd}`
+      );
+    }
+
+    routesArr = findNodes(
+      routesVar,
+      ts.SyntaxKind.ArrayLiteralExpression,
+      1
+    )[0] as ts.ArrayLiteralExpression;
+  }
+
+  const occurrencesCount = routesArr.elements.length;
+  const text = routesArr.getFullText(source);
+
+  let route: string = routeLiteral;
+  let insertPos = routesArr.elements.pos;
+
+  if (occurrencesCount > 0) {
+    const lastRouteLiteral = [...routesArr.elements].pop() as ts.Expression;
+    const lastRouteIsWildcard =
+      ts.isObjectLiteralExpression(lastRouteLiteral) &&
+      lastRouteLiteral.properties.some(
+        n =>
+          ts.isPropertyAssignment(n) &&
+          ts.isIdentifier(n.name) &&
+          n.name.text === 'path' &&
+          ts.isStringLiteral(n.initializer) &&
+          n.initializer.text === '**'
+      );
+
+    const indentation = text.match(/\r?\n(\r?)\s*/) || [];
+    const routeText = `${indentation[0] || ' '}${routeLiteral}`;
+
+    // Add the new route before the wildcard route
+    // otherwise we'll always redirect to the wildcard route
+    if (lastRouteIsWildcard) {
+      insertPos = lastRouteLiteral.pos;
+      route = `${routeText},`;
+    } else {
+      insertPos = lastRouteLiteral.end;
+      route = `,${routeText}`;
+    }
+  }
+
+  return new InsertChange(fileToAdd, insertPos, route);
+}
+
+/** Asserts if the specified node is a named declaration (e.g. class, interface). */
+function isNamedNode(
+  node: ts.Node & { name?: ts.Node }
+): node is ts.Node & { name: ts.Identifier } {
+  return !!node.name && ts.isIdentifier(node.name);
+}
+
+/**
+ * Determines if a SourceFile has a top-level declaration whose name matches a specific symbol.
+ * Can be used to avoid conflicts when inserting new imports into a file.
+ * @param sourceFile File in which to search.
+ * @param symbolName Name of the symbol to search for.
+ * @param skipModule Path of the module that the symbol may have been imported from. Used to
+ * avoid false positives where the same symbol we're looking for may have been imported.
+ */
+export function hasTopLevelIdentifier(
+  sourceFile: ts.SourceFile,
+  symbolName: string,
+  skipModule: string | null = null
+): boolean {
+  for (const node of sourceFile.statements) {
+    if (isNamedNode(node) && node.name.text === symbolName) {
+      return true;
+    }
+
+    if (
+      ts.isVariableStatement(node) &&
+      node.declarationList.declarations.some(decl => {
+        return isNamedNode(decl) && decl.name.text === symbolName;
+      })
+    ) {
+      return true;
+    }
+
+    if (
+      ts.isImportDeclaration(node) &&
+      ts.isStringLiteralLike(node.moduleSpecifier) &&
+      node.moduleSpecifier.text !== skipModule &&
+      node.importClause?.namedBindings &&
+      ts.isNamedImports(node.importClause.namedBindings) &&
+      node.importClause.namedBindings.elements.some(el => el.name.text === symbolName)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/packages/store/schematics/src/utils/ng-utils/ng-ast-utils.ts
+++ b/packages/store/schematics/src/utils/ng-utils/ng-ast-utils.ts
@@ -1,0 +1,88 @@
+import { normalize } from '@angular-devkit/core';
+import { SchematicsException, Tree } from '@angular-devkit/schematics';
+import { dirname } from 'path';
+import * as ts from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
+import { findNode, getSourceNodes } from '@schematics/angular/utility/ast-utils';
+import { findBootstrapApplicationCall } from '@schematics/angular/private/standalone';
+
+export function findBootstrapModuleCall(
+  host: Tree,
+  mainPath: string
+): ts.CallExpression | null {
+  const mainText = host.readText(mainPath);
+  const source = ts.createSourceFile(mainPath, mainText, ts.ScriptTarget.Latest, true);
+
+  const allNodes = getSourceNodes(source);
+
+  let bootstrapCall: ts.CallExpression | null = null;
+
+  for (const node of allNodes) {
+    let bootstrapCallNode: ts.Node | null = null;
+    bootstrapCallNode = findNode(node, ts.SyntaxKind.Identifier, 'bootstrapModule');
+
+    // Walk up the parent until CallExpression is found.
+    while (
+      bootstrapCallNode &&
+      bootstrapCallNode.parent &&
+      bootstrapCallNode.parent.kind !== ts.SyntaxKind.CallExpression
+    ) {
+      bootstrapCallNode = bootstrapCallNode.parent;
+    }
+
+    if (
+      bootstrapCallNode !== null &&
+      bootstrapCallNode.parent !== undefined &&
+      bootstrapCallNode.parent.kind === ts.SyntaxKind.CallExpression
+    ) {
+      bootstrapCall = bootstrapCallNode.parent as ts.CallExpression;
+      break;
+    }
+  }
+
+  return bootstrapCall;
+}
+
+function findBootstrapModulePath(host: Tree, mainPath: string): string {
+  const bootstrapCall = findBootstrapModuleCall(host, mainPath);
+  if (!bootstrapCall) {
+    throw new SchematicsException('Bootstrap call not found');
+  }
+
+  const bootstrapModule = bootstrapCall.arguments[0];
+
+  const mainText = host.readText(mainPath);
+  const source = ts.createSourceFile(mainPath, mainText, ts.ScriptTarget.Latest, true);
+  const allNodes = getSourceNodes(source);
+  const bootstrapModuleRelativePath = allNodes
+    .filter(ts.isImportDeclaration)
+    .filter(imp => {
+      return findNode(imp, ts.SyntaxKind.Identifier, bootstrapModule.getText());
+    })
+    .map(imp => {
+      const modulePathStringLiteral = imp.moduleSpecifier as ts.StringLiteral;
+
+      return modulePathStringLiteral.text;
+    })[0];
+
+  return bootstrapModuleRelativePath;
+}
+
+export function getAppModulePath(host: Tree, mainPath: string): string {
+  const moduleRelativePath = findBootstrapModulePath(host, mainPath);
+  const mainDir = dirname(mainPath);
+  const modulePath = normalize(`/${mainDir}/${moduleRelativePath}.ts`);
+
+  return modulePath;
+}
+
+export function isStandaloneApp(host: Tree, mainPath: string): boolean {
+  const source = ts.createSourceFile(
+    mainPath,
+    host.readText(mainPath),
+    ts.ScriptTarget.Latest,
+    true
+  );
+  const bootstrapCall = findBootstrapApplicationCall(source);
+
+  return bootstrapCall !== null;
+}

--- a/packages/store/schematics/src/utils/ng-utils/project.ts
+++ b/packages/store/schematics/src/utils/ng-utils/project.ts
@@ -1,0 +1,19 @@
+import { SchematicsException, Tree } from '@angular-devkit/schematics';
+import { getProject, isLib } from '../project';
+
+export function getProjectMainFile(host: Tree, project?: string) {
+  const resolvedProject = getProject(host, project);
+  if (!resolvedProject) {
+    throw new SchematicsException(`Project "${project}" does not exist.`);
+  }
+  if (isLib(host, project)) {
+    throw new SchematicsException(`Invalid project type`);
+  }
+  const projectOptions = resolvedProject.architect['build'].options;
+
+  if (!projectOptions?.main) {
+    throw new SchematicsException(`Could not find the main file`);
+  }
+
+  return projectOptions.main as string;
+}

--- a/packages/store/schematics/src/utils/ng-utils/standalone/app_config.ts
+++ b/packages/store/schematics/src/utils/ng-utils/standalone/app_config.ts
@@ -1,0 +1,119 @@
+import { Tree } from '@angular-devkit/schematics';
+import { dirname, join } from 'path';
+import * as ts from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
+import { getSourceFile } from './util';
+
+/** App config that was resolved to its source node. */
+export interface ResolvedAppConfig {
+  /** Tree-relative path of the file containing the app config. */
+  filePath: string;
+
+  /** Node defining the app config. */
+  node: ts.ObjectLiteralExpression;
+}
+
+/**
+ * Resolves the node that defines the app config from a bootstrap call.
+ * @param bootstrapCall Call for which to resolve the config.
+ * @param tree File tree of the project.
+ * @param filePath File path of the bootstrap call.
+ */
+export function findAppConfig(
+  bootstrapCall: ts.CallExpression,
+  tree: Tree,
+  filePath: string
+): ResolvedAppConfig | null {
+  if (bootstrapCall.arguments.length > 1) {
+    const config = bootstrapCall.arguments[1];
+
+    if (ts.isObjectLiteralExpression(config)) {
+      return { filePath, node: config };
+    }
+
+    if (ts.isIdentifier(config)) {
+      return resolveAppConfigFromIdentifier(config, tree, filePath);
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolves the app config from an identifier referring to it.
+ * @param identifier Identifier referring to the app config.
+ * @param tree File tree of the project.
+ * @param bootstapFilePath Path of the bootstrap call.
+ */
+function resolveAppConfigFromIdentifier(
+  identifier: ts.Identifier,
+  tree: Tree,
+  bootstapFilePath: string
+): ResolvedAppConfig | null {
+  const sourceFile = identifier.getSourceFile();
+
+  for (const node of sourceFile.statements) {
+    // Only look at relative imports. This will break if the app uses a path
+    // mapping to refer to the import, but in order to resolve those, we would
+    // need knowledge about the entire program.
+    if (
+      !ts.isImportDeclaration(node) ||
+      !node.importClause?.namedBindings ||
+      !ts.isNamedImports(node.importClause.namedBindings) ||
+      !ts.isStringLiteralLike(node.moduleSpecifier) ||
+      !node.moduleSpecifier.text.startsWith('.')
+    ) {
+      continue;
+    }
+
+    for (const specifier of node.importClause.namedBindings.elements) {
+      if (specifier.name.text !== identifier.text) {
+        continue;
+      }
+
+      // Look for a variable with the imported name in the file. Note that ideally we would use
+      // the type checker to resolve this, but we can't because these utilities are set up to
+      // operate on individual files, not the entire program.
+      const filePath = join(dirname(bootstapFilePath), node.moduleSpecifier.text + '.ts');
+      const importedSourceFile = getSourceFile(tree, filePath);
+      const resolvedVariable = findAppConfigFromVariableName(
+        importedSourceFile,
+        (specifier.propertyName || specifier.name).text
+      );
+
+      if (resolvedVariable) {
+        return { filePath, node: resolvedVariable };
+      }
+    }
+  }
+
+  const variableInSameFile = findAppConfigFromVariableName(sourceFile, identifier.text);
+
+  return variableInSameFile ? { filePath: bootstapFilePath, node: variableInSameFile } : null;
+}
+
+/**
+ * Finds an app config within the top-level variables of a file.
+ * @param sourceFile File in which to search for the config.
+ * @param variableName Name of the variable containing the config.
+ */
+function findAppConfigFromVariableName(
+  sourceFile: ts.SourceFile,
+  variableName: string
+): ts.ObjectLiteralExpression | null {
+  for (const node of sourceFile.statements) {
+    if (ts.isVariableStatement(node)) {
+      for (const decl of node.declarationList.declarations) {
+        if (
+          ts.isIdentifier(decl.name) &&
+          decl.name.text === variableName &&
+          decl.initializer &&
+          ts.isObjectLiteralExpression(decl.initializer)
+        ) {
+          return decl.initializer;
+        }
+      }
+    }
+  }
+
+  return null;
+}

--- a/packages/store/schematics/src/utils/ng-utils/standalone/code_block.ts
+++ b/packages/store/schematics/src/utils/ng-utils/standalone/code_block.ts
@@ -1,0 +1,107 @@
+import { Rule, Tree } from '@angular-devkit/schematics';
+import * as ts from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
+import { hasTopLevelIdentifier, insertImport } from '../ast-utils';
+import { applyToUpdateRecorder } from '@schematics/angular/utility/change';
+
+/** Generated code that hasn't been interpolated yet. */
+export interface PendingCode {
+  /** Code that will be inserted. */
+  expression: string;
+
+  /** Imports that need to be added to the file in which the code is inserted. */
+  imports: PendingImports;
+}
+
+/** Map keeping track of imports and aliases under which they're referred to in an expresion. */
+type PendingImports = Map<string, Map<string, string>>;
+
+/** Counter used to generate unique IDs. */
+let uniqueIdCounter = 0;
+
+/**
+ * Callback invoked by a Rule that produces the code
+ * that needs to be inserted somewhere in the app.
+ */
+export type CodeBlockCallback = (block: CodeBlock) => PendingCode;
+
+/**
+ * Utility class used to generate blocks of code that
+ * can be inserted by the devkit into a user's app.
+ */
+export class CodeBlock {
+  private _imports: PendingImports = new Map<string, Map<string, string>>();
+
+  // Note: the methods here are defined as arrow function so that they can be destructured by
+  // consumers without losing their context. This makes the API more concise.
+
+  /** Function used to tag a code block in order to produce a `PendingCode` object. */
+  code = (strings: TemplateStringsArray, ...params: unknown[]): PendingCode => {
+    return {
+      expression: strings.map((part, index) => part + (params[index] || '')).join(''),
+      imports: this._imports
+    };
+  };
+
+  /**
+   * Used inside of a code block to mark external symbols and which module they should be imported
+   * from. When the code is inserted, the required import statements will be produced automatically.
+   * @param symbolName Name of the external symbol.
+   * @param moduleName Module from which the symbol should be imported.
+   */
+  external = (symbolName: string, moduleName: string): string => {
+    if (!this._imports.has(moduleName)) {
+      this._imports.set(moduleName, new Map());
+    }
+
+    const symbolsPerModule = this._imports.get(moduleName) as Map<string, string>;
+
+    if (!symbolsPerModule.has(symbolName)) {
+      symbolsPerModule.set(symbolName, `@@__SCHEMATIC_PLACEHOLDER_${uniqueIdCounter++}__@@`);
+    }
+
+    return symbolsPerModule.get(symbolName) as string;
+  };
+
+  /**
+   * Produces the necessary rules to transform a `PendingCode` object into valid code.
+   * @param initialCode Code pending transformed.
+   * @param filePath Path of the file in which the code will be inserted.
+   */
+  static transformPendingCode(initialCode: PendingCode, filePath: string) {
+    const code = { ...initialCode };
+    const rules: Rule[] = [];
+
+    code.imports.forEach((symbols, moduleName) => {
+      symbols.forEach((placeholder, symbolName) => {
+        rules.push((tree: Tree) => {
+          const recorder = tree.beginUpdate(filePath);
+          const sourceFile = ts.createSourceFile(
+            filePath,
+            tree.readText(filePath),
+            ts.ScriptTarget.Latest,
+            true
+          );
+
+          // Note that this could still technically clash if there's a top-level symbol called
+          // `${symbolName}_alias`, however this is unlikely. We can revisit this if it becomes
+          // a problem.
+          const alias = hasTopLevelIdentifier(sourceFile, symbolName, moduleName)
+            ? symbolName + '_alias'
+            : undefined;
+
+          code.expression = code.expression.replace(
+            new RegExp(placeholder, 'g'),
+            alias || symbolName
+          );
+
+          applyToUpdateRecorder(recorder, [
+            insertImport(sourceFile, filePath, symbolName, moduleName, false, alias)
+          ]);
+          tree.commitUpdate(recorder);
+        });
+      });
+    });
+
+    return { code, rules };
+  }
+}

--- a/packages/store/schematics/src/utils/ng-utils/standalone/index.ts
+++ b/packages/store/schematics/src/utils/ng-utils/standalone/index.ts
@@ -1,0 +1,1 @@
+export { addRootImport, addRootProvider } from './rules';

--- a/packages/store/schematics/src/utils/ng-utils/standalone/rules.ts
+++ b/packages/store/schematics/src/utils/ng-utils/standalone/rules.ts
@@ -1,0 +1,262 @@
+import { tags } from '@angular-devkit/core';
+import { Rule, SchematicsException, Tree, chain } from '@angular-devkit/schematics';
+import * as ts from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
+import {
+  addSymbolToNgModuleMetadata,
+  insertAfterLastOccurrence
+} from '@schematics/angular/utility/ast-utils';
+import { InsertChange } from '@schematics/angular/utility/change';
+import { getAppModulePath } from '@schematics/angular/utility/ng-ast-utils';
+import { ResolvedAppConfig, findAppConfig } from './app_config';
+import { CodeBlock, CodeBlockCallback, PendingCode } from './code_block';
+import {
+  applyChangesToFile,
+  findBootstrapApplicationCall,
+  findProvidersLiteral,
+  getMainFilePath,
+  getSourceFile,
+  isMergeAppConfigCall
+} from './util';
+import { isStandaloneApp } from '../ng-ast-utils';
+
+/**
+ * Adds an import to the root of the project.
+ * @param project Name of the project to which to add the import.
+ * @param callback Function that generates the code block which should be inserted.
+ * @example
+ *
+ * ```ts
+ * import { Rule } from '@angular-devkit/schematics';
+ * import { addRootImport } from '@schematics/angular/utility';
+ *
+ * export default function(): Rule {
+ *   return addRootImport('default', ({code, external}) => {
+ *     return code`${external('MyModule', '@my/module')}.forRoot({})`;
+ *   });
+ * }
+ * ```
+ */
+export function addRootImport(project: string, callback: CodeBlockCallback): Rule {
+  return getRootInsertionRule(project, callback, 'imports', {
+    name: 'importProvidersFrom',
+    module: '@angular/core'
+  });
+}
+
+/**
+ * Adds a provider to the root of the project.
+ * @param project Name of the project to which to add the import.
+ * @param callback Function that generates the code block which should be inserted.
+ * @example
+ *
+ * ```ts
+ * import { Rule } from '@angular-devkit/schematics';
+ * import { addRootProvider } from '@schematics/angular/utility';
+ *
+ * export default function(): Rule {
+ *   return addRootProvider('default', ({code, external}) => {
+ *     return code`${external('provideLibrary', '@my/library')}({})`;
+ *   });
+ * }
+ * ```
+ */
+export function addRootProvider(project: string, callback: CodeBlockCallback): Rule {
+  return getRootInsertionRule(project, callback, 'providers');
+}
+
+/**
+ * Creates a rule that inserts code at the root of either a standalone or NgModule-based project.
+ * @param project Name of the project into which to inser tthe code.
+ * @param callback Function that generates the code block which should be inserted.
+ * @param ngModuleField Field of the root NgModule into which the code should be inserted, if the
+ * app is based on NgModule
+ * @param standaloneWrapperFunction Function with which to wrap the code if the app is standalone.
+ */
+function getRootInsertionRule(
+  project: string,
+  callback: CodeBlockCallback,
+  ngModuleField: string,
+  standaloneWrapperFunction?: { name: string; module: string }
+): Rule {
+  return async host => {
+    const mainFilePath = await getMainFilePath(host, project);
+    const codeBlock = new CodeBlock();
+
+    if (isStandaloneApp(host, mainFilePath)) {
+      return tree =>
+        addProviderToStandaloneBootstrap(
+          tree,
+          callback(codeBlock),
+          mainFilePath,
+          standaloneWrapperFunction
+        );
+    }
+
+    const modulePath = getAppModulePath(host, mainFilePath);
+    const pendingCode = CodeBlock.transformPendingCode(callback(codeBlock), modulePath);
+
+    return chain([
+      ...pendingCode.rules,
+      tree => {
+        const changes = addSymbolToNgModuleMetadata(
+          getSourceFile(tree, modulePath),
+          modulePath,
+          ngModuleField,
+          pendingCode.code.expression,
+          // Explicitly set the import path to null since we deal with imports here separately.
+          null
+        );
+
+        applyChangesToFile(tree, modulePath, changes);
+      }
+    ]);
+  };
+}
+
+/**
+ * Adds a provider to the root of a standalone project.
+ * @param host Tree of the root rule.
+ * @param pendingCode Code that should be inserted.
+ * @param mainFilePath Path to the project's main file.
+ * @param wrapperFunction Optional function with which to wrap the provider.
+ */
+function addProviderToStandaloneBootstrap(
+  host: Tree,
+  pendingCode: PendingCode,
+  mainFilePath: string,
+  wrapperFunction?: { name: string; module: string }
+): Rule {
+  const bootstrapCall = findBootstrapApplicationCall(host, mainFilePath);
+  const fileToEdit =
+    findAppConfig(bootstrapCall, host, mainFilePath)?.filePath || mainFilePath;
+  const { code, rules } = CodeBlock.transformPendingCode(pendingCode, fileToEdit);
+
+  return chain([
+    ...rules,
+    () => {
+      let wrapped: PendingCode;
+      let additionalRules: Rule[];
+
+      if (wrapperFunction) {
+        const block = new CodeBlock();
+        const result = CodeBlock.transformPendingCode(
+          block.code`${block.external(wrapperFunction.name, wrapperFunction.module)}(${
+            code.expression
+          })`,
+          fileToEdit
+        );
+
+        wrapped = result.code;
+        additionalRules = result.rules;
+      } else {
+        wrapped = code;
+        additionalRules = [];
+      }
+
+      return chain([
+        ...additionalRules,
+        tree => insertStandaloneRootProvider(tree, mainFilePath, wrapped.expression)
+      ]);
+    }
+  ]);
+}
+
+/**
+ * Inserts a string expression into the root of a standalone project.
+ * @param tree File tree used to modify the project.
+ * @param mainFilePath Path to the main file of the project.
+ * @param expression Code expression to be inserted.
+ */
+function insertStandaloneRootProvider(
+  tree: Tree,
+  mainFilePath: string,
+  expression: string
+): void {
+  const bootstrapCall = findBootstrapApplicationCall(tree, mainFilePath);
+  const appConfig = findAppConfig(bootstrapCall, tree, mainFilePath);
+
+  if (bootstrapCall.arguments.length === 0) {
+    throw new SchematicsException(
+      `Cannot add provider to invalid bootstrapApplication call in ${
+        bootstrapCall.getSourceFile().fileName
+      }`
+    );
+  }
+
+  if (appConfig) {
+    addProvidersExpressionToAppConfig(tree, appConfig, expression);
+
+    return;
+  }
+
+  const newAppConfig = `, {\n${tags.indentBy(2)`providers: [${expression}]`}\n}`;
+  let targetCall: ts.CallExpression;
+
+  if (bootstrapCall.arguments.length === 1) {
+    targetCall = bootstrapCall;
+  } else if (isMergeAppConfigCall(bootstrapCall.arguments[1])) {
+    targetCall = bootstrapCall.arguments[1];
+  } else {
+    throw new SchematicsException(
+      `Cannot statically analyze bootstrapApplication call in ${
+        bootstrapCall.getSourceFile().fileName
+      }`
+    );
+  }
+
+  applyChangesToFile(tree, mainFilePath, [
+    insertAfterLastOccurrence(
+      targetCall.arguments as any as ts.Node[],
+      newAppConfig,
+      mainFilePath,
+      targetCall.getEnd() - 1
+    )
+  ]);
+}
+
+/**
+ * Adds a string expression to an app config object.
+ * @param tree File tree used to modify the project.
+ * @param appConfig Resolved configuration object of the project.
+ * @param expression Code expression to be inserted.
+ */
+function addProvidersExpressionToAppConfig(
+  tree: Tree,
+  appConfig: ResolvedAppConfig,
+  expression: string
+): void {
+  const { node, filePath } = appConfig;
+  const configProps = node.properties;
+  const providersLiteral = findProvidersLiteral(node);
+
+  // If there's a `providers` property, we can add the provider
+  // to it, otherwise we need to declare it ourselves.
+  if (providersLiteral) {
+    const hasTrailingComma = providersLiteral.elements.hasTrailingComma;
+
+    applyChangesToFile(tree, filePath, [
+      insertAfterLastOccurrence(
+        providersLiteral.elements as any as ts.Node[],
+        (hasTrailingComma || providersLiteral.elements.length === 0 ? '' : ', ') + expression,
+        filePath,
+        providersLiteral.getStart() + 1
+      )
+    ]);
+  } else {
+    const prop = tags.indentBy(2)`providers: [${expression}]`;
+    let toInsert: string;
+    let insertPosition: number;
+
+    if (configProps.length === 0) {
+      toInsert = '\n' + prop + '\n';
+      insertPosition = node.getEnd() - 1;
+    } else {
+      const hasTrailingComma = configProps.hasTrailingComma;
+      toInsert = (hasTrailingComma ? '' : ',') + '\n' + prop;
+      insertPosition =
+        configProps[configProps.length - 1].getEnd() + (hasTrailingComma ? 1 : 0);
+    }
+
+    applyChangesToFile(tree, filePath, [new InsertChange(filePath, insertPosition, toInsert)]);
+  }
+}

--- a/packages/store/schematics/src/utils/ng-utils/standalone/util.ts
+++ b/packages/store/schematics/src/utils/ng-utils/standalone/util.ts
@@ -1,0 +1,164 @@
+import { SchematicsException, Tree } from '@angular-devkit/schematics';
+import * as ts from '@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript';
+import { targetBuildNotFoundError } from '@schematics/angular/utility/project-targets';
+import { getWorkspace } from '@schematics/angular/utility/workspace';
+import { Change, applyToUpdateRecorder } from '@schematics/angular/utility/change';
+
+/**
+ * Finds the main file of a project.
+ * @param tree File tree for the project.
+ * @param projectName Name of the project in which to search.
+ */
+export async function getMainFilePath(tree: Tree, projectName: string): Promise<string> {
+  const workspace = await getWorkspace(tree);
+  const project = workspace.projects.get(projectName);
+  const buildTarget = project?.targets.get('build');
+
+  if (!buildTarget) {
+    throw targetBuildNotFoundError();
+  }
+
+  const options = buildTarget.options as Record<string, string>;
+
+  return buildTarget.builder === '@angular-devkit/build-angular:application'
+    ? options.browser
+    : options.main;
+}
+
+/**
+ * Gets a TypeScript source file at a specific path.
+ * @param tree File tree of a project.
+ * @param path Path to the file.
+ */
+export function getSourceFile(tree: Tree, path: string): ts.SourceFile {
+  const content = tree.readText(path);
+  const source = ts.createSourceFile(path, content, ts.ScriptTarget.Latest, true);
+
+  return source;
+}
+
+/** Finds the call to `bootstrapApplication` within a file. */
+export function findBootstrapApplicationCall(
+  tree: Tree,
+  mainFilePath: string
+): ts.CallExpression {
+  const sourceFile = getSourceFile(tree, mainFilePath);
+  const localName = findImportLocalName(
+    sourceFile,
+    'bootstrapApplication',
+    '@angular/platform-browser'
+  );
+
+  if (localName) {
+    let result: ts.CallExpression | null = null;
+
+    sourceFile.forEachChild(function walk(node) {
+      if (
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === localName
+      ) {
+        result = node;
+      }
+
+      if (!result) {
+        node.forEachChild(walk);
+      }
+    });
+
+    if (result) {
+      return result;
+    }
+  }
+
+  throw new SchematicsException(`Could not find bootstrapApplication call in ${mainFilePath}`);
+}
+
+/**
+ * Finds the local name of an imported symbol. Could be the symbol name itself or its alias.
+ * @param sourceFile File within which to search for the import.
+ * @param name Actual name of the import, not its local alias.
+ * @param moduleName Name of the module from which the symbol is imported.
+ */
+function findImportLocalName(
+  sourceFile: ts.SourceFile,
+  name: string,
+  moduleName: string
+): string | null {
+  for (const node of sourceFile.statements) {
+    // Only look for top-level imports.
+    if (
+      !ts.isImportDeclaration(node) ||
+      !ts.isStringLiteral(node.moduleSpecifier) ||
+      node.moduleSpecifier.text !== moduleName
+    ) {
+      continue;
+    }
+
+    // Filter out imports that don't have the right shape.
+    if (
+      !node.importClause ||
+      !node.importClause.namedBindings ||
+      !ts.isNamedImports(node.importClause.namedBindings)
+    ) {
+      continue;
+    }
+
+    // Look through the elements of the declaration for the specific import.
+    for (const element of node.importClause.namedBindings.elements) {
+      if ((element.propertyName || element.name).text === name) {
+        // The local name is always in `name`.
+        return element.name.text;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Applies a set of changes to a file.
+ * @param tree File tree of the project.
+ * @param path Path to the file that is being changed.
+ * @param changes Changes that should be applied to the file.
+ */
+export function applyChangesToFile(tree: Tree, path: string, changes: Change[]) {
+  if (changes.length > 0) {
+    const recorder = tree.beginUpdate(path);
+    applyToUpdateRecorder(recorder, changes);
+    tree.commitUpdate(recorder);
+  }
+}
+
+/** Checks whether a node is a call to `mergeApplicationConfig`. */
+export function isMergeAppConfigCall(node: ts.Node): node is ts.CallExpression {
+  if (!ts.isCallExpression(node)) {
+    return false;
+  }
+
+  const localName = findImportLocalName(
+    node.getSourceFile(),
+    'mergeApplicationConfig',
+    '@angular/core'
+  );
+
+  return !!localName && ts.isIdentifier(node.expression) && node.expression.text === localName;
+}
+
+/** Finds the `providers` array literal within an application config. */
+export function findProvidersLiteral(
+  config: ts.ObjectLiteralExpression
+): ts.ArrayLiteralExpression | null {
+  for (const prop of config.properties) {
+    if (
+      ts.isPropertyAssignment(prop) &&
+      ts.isIdentifier(prop.name) &&
+      prop.name.text === 'providers' &&
+      ts.isArrayLiteralExpression(prop.initializer)
+    ) {
+      return prop.initializer;
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Adding support for standalone APIs in schematics

With this PR `ng-add` will be able to add NGXS plugins both to root module as modules and to app.config as provider functions.

![image](https://github.com/ngxs/store/assets/33101123/f1c7166d-efeb-403a-9f13-5e0845d7f2a0)
![image](https://github.com/ngxs/store/assets/33101123/94d90755-8470-40b6-8d84-0d17b0d8c5a1)


Please note that there's a new folder `packages/store/schematics/src/utils/ng-utils`. It contains files that were copied from the `@schematics/angular@16.2` package. It contains very convenient utils that allow adding declarations both in standalone and regular Angular apps. There's no point to reinvent the bicycle and try to implement that functionality ourselves as we will be able to use them directly from `@schematics/angular` as we'll start to support the v17 as the minimum required version.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
