### PR TITLE
fix(store): patch operator must handle existing nulls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ dist-integration
 !.vscode/extensions.json
 
 # misc
+.yarn
 /.angular/cache
 /.sass-cache
 /connect.lock

--- a/packages/store/operators/src/patch.ts
+++ b/packages/store/operators/src/patch.ts
@@ -12,7 +12,7 @@ export function patch<T extends Record<string, any>>(
     let clone = null;
     for (const k in patchObject) {
       const newValue = patchObject[k];
-      const existingPropValue = existing[k];
+      const existingPropValue = existing?.[k];
       const newPropValue = isStateOperator(newValue)
         ? newValue(<any>existingPropValue)
         : newValue;

--- a/packages/store/operators/tests/patch.spec.ts
+++ b/packages/store/operators/tests/patch.spec.ts
@@ -43,26 +43,28 @@ describe('patch', () => {
   describe('when null provided for existing', () => {
     it('returns a new root with changed property set', () => {
       // Arrange
-      const original = { a: 1, b: 2, c: 3 };
+      const patchSpec = { a: 1, b: 2, c: 3 };
+      const existing = <any>null;
 
       // Act
-      const newValue = patch(original)(<any>null);
+      const newValue = patch(patchSpec)(existing);
 
       // Assert
-      expect(newValue).toEqual(original);
+      expect(newValue).toEqual(patchSpec);
     });
   });
 
   describe('when undefined provided for existing', () => {
     it('returns a new root with changed property set', () => {
       // Arrange
-      const original = { a: 1, b: 2, c: 3 };
+      const patchSpec = { a: 1, b: 2, c: 3 };
+      const existing = <any>undefined;
 
       // Act
-      const newValue = patch(original)(<any>undefined);
+      const newValue = patch(patchSpec)(existing);
 
       // Assert
-      expect(newValue).toEqual(original);
+      expect(newValue).toEqual(patchSpec);
     });
   });
 

--- a/packages/store/operators/tests/patch.spec.ts
+++ b/packages/store/operators/tests/patch.spec.ts
@@ -40,6 +40,32 @@ describe('patch', () => {
     });
   });
 
+  describe('when null provided for existing', () => {
+    it('returns a new root with changed property set', () => {
+      // Arrange
+      const original = { a: 1, b: 2, c: 3 };
+
+      // Act
+      const newValue = patch(original)(<any>null);
+
+      // Assert
+      expect(newValue).toEqual(original);
+    });
+  });
+
+  describe('when undefined provided for existing', () => {
+    it('returns a new root with changed property set', () => {
+      // Arrange
+      const original = { a: 1, b: 2, c: 3 };
+
+      // Act
+      const newValue = patch(original)(<any>undefined);
+
+      // Assert
+      expect(newValue).toEqual(original);
+    });
+  });
+
   describe('when object with primitive property values provided', () => {
     describe('with same values', () => {
       it('returns the same root', () => {
@@ -382,6 +408,79 @@ describe('patch', () => {
 
           // Assert
           expect<any>(newValue.b.hello).toEqual(patchTooDeep);
+        });
+
+        it(`creates deeply nested objects that don't exist`, () => {
+          // Arrange
+          interface Document {
+            name: string;
+          }
+
+          interface Group {
+            documents: Record<string, Document>;
+          }
+
+          interface Model {
+            groups: Record<string, Group>;
+          }
+
+          const original: Model = {
+            groups: {
+              group1: {
+                documents: {
+                  doc1: {
+                    name: 'Hello'
+                  }
+                }
+              }
+            }
+          };
+
+          // Act
+          const result = patch<Model>({
+            groups: patch<Record<string, Group>>({
+              group1: patch<Group>({
+                documents: patch<Record<string, Document>>({
+                  doc1: patch<Document>({
+                    name: 'Hello Updated'
+                  }),
+                  doc12: patch<Document>({
+                    name: 'Hello12'
+                  })
+                })
+              }),
+              group2: patch<Group>({
+                documents: patch<Record<string, Document>>({
+                  doc2: patch<Document>({
+                    name: 'Hello2'
+                  })
+                })
+              })
+            })
+          })(original);
+
+          // Assert
+          expect(result).toEqual({
+            groups: {
+              group1: {
+                documents: {
+                  doc1: {
+                    name: 'Hello Updated'
+                  },
+                  doc12: {
+                    name: 'Hello12'
+                  }
+                }
+              },
+              group2: {
+                documents: {
+                  doc2: {
+                    name: 'Hello2'
+                  }
+                }
+              }
+            }
+          });
         });
       });
     });


### PR DESCRIPTION
Changed patch operator not fail when the existing value is null by using a null save access to the key of the object

fixes #2063

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When the existing value of the patch operator is null/undefined it causes a key access error

Issue Number: #2063 

## What is the new behavior?

Does not throw an error if existin is null/undefined

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
