### PR TITLE
fix(store): log feature states added before store is initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ $ npm install @ngxs/store@dev
 
 ### To become next patch version
 
+- Fix: Log feature states added before store is initialized [#2067](https://github.com/ngxs/store/pull/2067)
 - Fix: Show error when state initialization order is invalid [#2066](https://github.com/ngxs/store/pull/2066), [#2067](https://github.com/ngxs/store/pull/2067)
 - Fix: Storage Plugin - Access local and session storages globals only in browser [#2034](https://github.com/ngxs/store/pull/2034)
 - Fix: Storage Plugin - Require only `getItem` and `setItem` on engines [#2036](https://github.com/ngxs/store/pull/2036)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ $ npm install @ngxs/store@dev
 
 ### To become next patch version
 
-- Fix: Show error when state initialization order is invalid [#2066](https://github.com/ngxs/store/pull/2066)
+- Fix: Show error when state initialization order is invalid [#2066](https://github.com/ngxs/store/pull/2066), [#2067](https://github.com/ngxs/store/pull/2067)
 - Fix: Storage Plugin - Access local and session storages globals only in browser [#2034](https://github.com/ngxs/store/pull/2034)
 - Fix: Storage Plugin - Require only `getItem` and `setItem` on engines [#2036](https://github.com/ngxs/store/pull/2036)
 - Fix: Router Plugin - Expose `NGXS_ROUTER_PLUGIN_OPTIONS` privately [#2037](https://github.com/ngxs/store/pull/2037)

--- a/packages/store/src/configs/messages.config.ts
+++ b/packages/store/src/configs/messages.config.ts
@@ -1,3 +1,5 @@
+import { PlainObject } from '@ngxs/store/internals';
+
 export function throwStateNameError(name: string): never {
   throw new Error(
     `${name} is not a valid state name. It needs to be a valid object property name.`
@@ -40,12 +42,21 @@ export function getUndecoratedStateInIvyWarningMessage(name: string): string {
   return `'${name}' class should be decorated with @Injectable() right after the @State() decorator`;
 }
 
-export function getInvalidInitializationOrderMessage() {
-  return (
+export function getInvalidInitializationOrderMessage(addedStates?: PlainObject) {
+  let message =
     'You have an invalid state initialization order. This typically occurs when `NgxsModule.forFeature`\n' +
     'or `provideStates` is called before `NgxsModule.forRoot` or `provideStore`.\n' +
-    'One example is when `NgxsRouterPluginModule.forRoot` is called before `NgxsModule.forRoot`.'
-  );
+    'One example is when `NgxsRouterPluginModule.forRoot` is called before `NgxsModule.forRoot`.';
+
+  if (addedStates) {
+    const stateNames = Object.keys(addedStates).map(stateName => `"${stateName}"`);
+
+    message +=
+      '\nFeature states added before the store initialization is complete: ' +
+      `${stateNames.join(', ')}.`;
+  }
+
+  return message;
 }
 
 export function throwSelectFactoryNotConnectedError(): never {

--- a/packages/store/src/internal/lifecycle-state-manager.ts
+++ b/packages/store/src/internal/lifecycle-state-manager.ts
@@ -57,7 +57,7 @@ export class LifecycleStateManager implements OnDestroy {
         action instanceof UpdateState &&
         !this._initStateHasBeenDispatched
       ) {
-        console.error(getInvalidInitializationOrderMessage());
+        console.error(getInvalidInitializationOrderMessage(action.addedStates));
       }
     }
 

--- a/packages/store/tests/issues/state-initialization-order.spec.ts
+++ b/packages/store/tests/issues/state-initialization-order.spec.ts
@@ -2,17 +2,21 @@ import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { NgxsModule, State, Store } from '@ngxs/store';
 
-describe('State stream order of updates', () => {
+describe('State initialization order', () => {
   @Injectable()
   @State({ name: 'counter', defaults: 0 })
   class CounterState {}
+
+  @Injectable()
+  @State({ name: 'posts', defaults: 0 })
+  class PostsState {}
 
   it('should log an error into the console when the state initialization order is invalid', () => {
     // Arrange
     const errorSpy = jest.spyOn(console, 'error').mockImplementation();
 
     TestBed.configureTestingModule({
-      imports: [NgxsModule.forFeature([CounterState]), NgxsModule.forRoot()]
+      imports: [NgxsModule.forFeature([CounterState, PostsState]), NgxsModule.forRoot()]
     });
 
     // Act
@@ -22,6 +26,12 @@ describe('State stream order of updates', () => {
       // Assert
       expect(errorSpy).toHaveBeenCalledWith(
         expect.stringMatching(/invalid state initialization order/)
+      );
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Feature states added before the store initialization is complete: "posts", "counter".'
+        )
       );
     } finally {
       errorSpy.mockRestore();


### PR DESCRIPTION
In this commit, the logged error has been improved to contain feature states, that were added, before the store initialization is complete.