### PR TITLE
docs(form-plugin): npm package title and title of README mismatch

### DIFF
--- a/packages/form-plugin/README.md
+++ b/packages/form-plugin/README.md
@@ -1,3 +1,3 @@
-# @ngxs/forms-plugin
+# @ngxs/form-plugin
 
 Forms plugin for NGXS. See [repo](https://github.com/ngxs/store) for more info.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The npm package is `@ngxs/form-plugin` but the title in README is `@ngsx/forms-plugin` with an `s`

![image](https://github.com/ngxs/store/assets/10420994/01eb8caa-b7f0-45f4-bf9a-2947a5cbf70b)

Issue Number: N/A

## What is the new behavior?

The `s` is removed so the title matches the npm package

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
