### PR TITLE
fix(store): ensure features are initialized after root state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ $ npm install @ngxs/store@dev
 
 ### To become next patch version
 
-- Feat: schematics support a project option and standalone detection [#2089](https://github.com/ngxs/store/pull/2089)
+- Feat: Schematics support a project option and standalone detection [#2089](https://github.com/ngxs/store/pull/2089)
+- Fix: Ensure features are initialized after root state [#2083](https://github.com/ngxs/store/pull/2083)
 - Fix: Log feature states added before store is initialized [#2067](https://github.com/ngxs/store/pull/2067)
 - Fix: Show error when state initialization order is invalid [#2066](https://github.com/ngxs/store/pull/2066), [#2067](https://github.com/ngxs/store/pull/2067)
 - Fix: Router Plugin - Expose `NGXS_ROUTER_PLUGIN_OPTIONS` privately [#2037](https://github.com/ngxs/store/pull/2037)

--- a/packages/store/src/standalone-features/provide-store.ts
+++ b/packages/store/src/standalone-features/provide-store.ts
@@ -52,8 +52,8 @@ export function provideStore(
 
   return makeEnvironmentProviders([
     ...getRootProviders(states, options),
-    features,
-    NGXS_ROOT_ENVIRONMENT_INITIALIZER
+    NGXS_ROOT_ENVIRONMENT_INITIALIZER,
+    features
   ]);
 }
 


### PR DESCRIPTION
We have a check that ensures states are initialized in the correct order and that the `UpdateState` action shouldn't be dispatched before the `InitState` action. This code updates the order of environment providers to place features at the end. As a result, the root environment initializer runs earlier, dispatching the `InitState` action.