### PR TITLE
fix(schematics): replace the deprecated api in the unit tests and add a missing decorator

### DIFF
--- a/packages/store/schematics/src/starter-kit/files/store/auth/auth.state.spec.ts__template__
+++ b/packages/store/schematics/src/starter-kit/files/store/auth/auth.state.spec.ts__template__
@@ -1,21 +1,21 @@
 import { NgxsModule, Store } from '@ngxs/store';
-import { async, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { AuthenticationStateModel, AuthState } from './auth.state';
 import { SetAuthData } from './auth.actions';
 
 describe('[TEST]: AuthStore', () => {
   let store: Store;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [NgxsModule.forRoot([AuthState])]
-    })
-      .compileComponents()
-      .then();
-    store = TestBed.get(Store);
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NgxsModule.forRoot([AuthState])],
+    }).compileComponents();
+
+    store = TestBed.inject(Store);
+  });
 
   it('Should be correct dispatch and value is empty', () => {
+    // Arrange
     const Authentication: AuthenticationStateModel = {
       id: '',
       firstName: '',
@@ -24,12 +24,17 @@ describe('[TEST]: AuthStore', () => {
       email: '',
       roles: []
     };
+
+    // Act
     store.dispatch(new SetAuthData(Authentication));
     const actual = store.selectSnapshot<AuthenticationStateModel>(AuthState.getAuthData);
+
+    // Assert
     expect(actual).toEqual(Authentication);
   });
 
   it('Should be correct dispatch and next value is correct completed', () => {
+    // Arrange
     const authentication: AuthenticationStateModel = {
       id: '12',
       firstName: 'Adam',
@@ -39,8 +44,11 @@ describe('[TEST]: AuthStore', () => {
       roles: ['ADMIN']
     };
 
+    // Act
     store.dispatch(new SetAuthData(authentication));
     const actual = store.selectSnapshot<AuthenticationStateModel>(AuthState.getAuthData);
+
+    // Assert
     expect(actual).toEqual(authentication);
   });
 });

--- a/packages/store/schematics/src/starter-kit/files/store/auth/auth.state.spec.ts__template__
+++ b/packages/store/schematics/src/starter-kit/files/store/auth/auth.state.spec.ts__template__
@@ -6,10 +6,10 @@ import { SetAuthData } from './auth.actions';
 describe('[TEST]: AuthStore', () => {
   let store: Store;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [NgxsModule.forRoot([AuthState])],
-    }).compileComponents();
+    });
 
     store = TestBed.inject(Store);
   });

--- a/packages/store/schematics/src/starter-kit/files/store/auth/auth.state.ts__template__
+++ b/packages/store/schematics/src/starter-kit/files/store/auth/auth.state.ts__template__
@@ -1,3 +1,4 @@
+import { Injectable } from '@angular/core';
 import { Action, Selector, State, StateContext } from '@ngxs/store';
 import { SetAuthData } from './auth.actions';
 
@@ -21,6 +22,7 @@ export interface AuthenticationStateModel {
     roles: []
   }
 })
+@Injectable()
 export class AuthState {
   @Selector()
   public static getAuthData(state: AuthenticationStateModel): AuthenticationStateModel {

--- a/packages/store/schematics/src/starter-kit/files/store/dashboard/states/dictionary/dictionary.state.spec.ts__template__
+++ b/packages/store/schematics/src/starter-kit/files/store/dashboard/states/dictionary/dictionary.state.spec.ts__template__
@@ -27,10 +27,10 @@ const data = [
 describe('[TEST]: Dictionary state', () => {
   let store: Store;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [NgxsModule.forRoot([DictionaryState])],
-    }).compileComponents();
+    });
 
     store = TestBed.inject(Store);
   });

--- a/packages/store/schematics/src/starter-kit/files/store/dashboard/states/dictionary/dictionary.state.spec.ts__template__
+++ b/packages/store/schematics/src/starter-kit/files/store/dashboard/states/dictionary/dictionary.state.spec.ts__template__
@@ -1,5 +1,5 @@
 import { NgxsModule, Store } from '@ngxs/store';
-import { async, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { DictionaryState, DictionaryStateModel } from './dictionary.state';
 import { DictionaryReset, SetDictionaryData } from './dictionary.actions';
 
@@ -27,16 +27,16 @@ const data = [
 describe('[TEST]: Dictionary state', () => {
   let store: Store;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [NgxsModule.forRoot([DictionaryState])]
-    })
-      .compileComponents()
-      .then();
-    store = TestBed.get(Store);
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NgxsModule.forRoot([DictionaryState])],
+    }).compileComponents();
+
+    store = TestBed.inject(Store);
+  });
 
   it('Should be correct dispatch and dictionary is empty', () => {
+    // Arrange
     const dictionary: DictionaryStateModel = {
       content: [],
       page: 0,
@@ -44,12 +44,17 @@ describe('[TEST]: Dictionary state', () => {
       totalPages: 0,
       totalElements: 0
     };
+
+    // Act
     store.dispatch(new SetDictionaryData(dictionary));
     const actual = store.selectSnapshot(DictionaryState.getDictionaryState);
+
+    // Assert
     expect(actual).toEqual(dictionary);
   });
 
   it('Should be state is filled DictionaryStateModel', () => {
+    // Arrange
     const dictionary: DictionaryStateModel = {
       content: data,
       page: 0,
@@ -57,12 +62,17 @@ describe('[TEST]: Dictionary state', () => {
       totalPages: 2,
       totalElements: 1
     };
+
+    // Act
     store.dispatch(new SetDictionaryData(dictionary));
     const actual = store.selectSnapshot(DictionaryState.getDictionaryState);
+
+    // Assert
     expect(actual).toEqual(dictionary);
   });
 
   it('should be reset state', function () {
+    // Arrange
     const dictionary: DictionaryStateModel = {
       content: [],
       page: 0,
@@ -70,8 +80,12 @@ describe('[TEST]: Dictionary state', () => {
       totalPages: 0,
       totalElements: 0
     };
+
+    // Act
     store.dispatch(new DictionaryReset());
     const actual = store.selectSnapshot(DictionaryState.getDictionaryState);
+
+    // Assert
     expect(actual).toEqual(dictionary);
   });
 });

--- a/packages/store/schematics/src/starter-kit/files/store/dashboard/states/dictionary/dictionary.state.ts__template__
+++ b/packages/store/schematics/src/starter-kit/files/store/dashboard/states/dictionary/dictionary.state.ts__template__
@@ -1,3 +1,4 @@
+import { Injectable } from '@angular/core';
 import { Action, Selector, State, StateContext } from '@ngxs/store';
 import { DictionaryReset, SetDictionaryData } from './dictionary.actions';
 
@@ -19,6 +20,7 @@ export interface DictionaryStateModel {
     totalElements: 0
   }
 })
+@Injectable()
 export class DictionaryState {
   @Selector()
   public static getDictionaryState(state: DictionaryStateModel): DictionaryStateModel {

--- a/packages/store/schematics/src/starter-kit/files/store/dashboard/states/user/user.state.spec.ts__template__
+++ b/packages/store/schematics/src/starter-kit/files/store/dashboard/states/user/user.state.spec.ts__template__
@@ -1,21 +1,21 @@
 import { NgxsModule, Store } from '@ngxs/store';
-import { async, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { UserStateModel, UserState } from './user.state';
 import { SetUser } from './user.actions';
 
 describe('[TEST]: User state', () => {
   let store: Store;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [NgxsModule.forRoot([UserState])]
-    })
-      .compileComponents()
-      .then();
-    store = TestBed.get(Store);
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NgxsModule.forRoot([UserState])],
+    }).compileComponents();
+
+    store = TestBed.inject(Store);
+  });
 
   it('Should be state is UserStateModel', () => {
+    // Arrange
     const user: UserStateModel = {
       userId: '',
       departmentCode: '',
@@ -27,13 +27,17 @@ describe('[TEST]: User state', () => {
       positionId: '',
       positionName: ''
     };
+
+    // Act
     store.dispatch(new SetUser(user));
     const actual = store.selectSnapshot(({ user }) => user);
 
+    // Assert
     expect(actual).toEqual(user);
   });
 
   it('Should be state is filled UserStateModel', () => {
+    // Arrange
     const user: UserStateModel = {
       userId: '12',
       departmentCode: '2392',
@@ -46,9 +50,11 @@ describe('[TEST]: User state', () => {
       positionName: 'admin'
     };
 
+    // Act
     store.dispatch(new SetUser(user));
     const actual = store.selectSnapshot<UserStateModel>(({ user }) => user);
 
+    // Assert
     expect(actual).toEqual(user);
   });
 });

--- a/packages/store/schematics/src/starter-kit/files/store/dashboard/states/user/user.state.spec.ts__template__
+++ b/packages/store/schematics/src/starter-kit/files/store/dashboard/states/user/user.state.spec.ts__template__
@@ -6,10 +6,10 @@ import { SetUser } from './user.actions';
 describe('[TEST]: User state', () => {
   let store: Store;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [NgxsModule.forRoot([UserState])],
-    }).compileComponents();
+    });
 
     store = TestBed.inject(Store);
   });

--- a/packages/store/schematics/src/starter-kit/files/store/dashboard/states/user/user.state.ts__template__
+++ b/packages/store/schematics/src/starter-kit/files/store/dashboard/states/user/user.state.ts__template__
@@ -1,3 +1,4 @@
+import { Injectable } from '@angular/core';
 import { Action, Selector, State, StateContext } from '@ngxs/store';
 import { SetUser } from './user.actions';
 
@@ -27,6 +28,7 @@ export interface UserStateModel {
     departmentName: ''
   }
 })
+@Injectable()
 export class UserState {
   @Selector()
   public static getUser(state: UserStateModel): UserStateModel {

--- a/packages/store/schematics/src/state/files/__name__.state.spec.ts__template__
+++ b/packages/store/schematics/src/state/files/__name__.state.spec.ts__template__
@@ -5,12 +5,12 @@ import { <%= classify(name) %>State, <%= classify(name) %>StateModel } from './<
 describe('<%= classify(name) %> state', () => {
     let store: Store;
 
-    beforeEach(async () => {
-        await TestBed.configureTestingModule({
-            imports: [NgxsModule.forRoot([<%= classify(name) %>State])]
-        }).compileComponents();
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [NgxsModule.forRoot([<%= classify(name) %>State])]
+      });
 
-        store = TestBed.inject(Store);
+      store = TestBed.inject(Store);
     });
 
     it('should create an empty state', () => {

--- a/packages/store/schematics/src/state/files/__name__.state.spec.ts__template__
+++ b/packages/store/schematics/src/state/files/__name__.state.spec.ts__template__
@@ -1,15 +1,17 @@
-import { TestBed, async } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { NgxsModule, Store } from '@ngxs/store';
 import { <%= classify(name) %>State, <%= classify(name) %>StateModel } from './<%= dasherize(name) %>.state';
 
 describe('<%= classify(name) %> state', () => {
     let store: Store;
-    beforeEach(async(() => {
-        TestBed.configureTestingModule({
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
             imports: [NgxsModule.forRoot([<%= classify(name) %>State])]
         }).compileComponents();
-        store = TestBed.get(Store);
-    }));
+
+        store = TestBed.inject(Store);
+    });
 
     it('should create an empty state', () => {
         const actual = store.selectSnapshot(<%= classify(name) %>State.getState);

--- a/packages/store/schematics/src/state/files/__name__.state.ts__template__
+++ b/packages/store/schematics/src/state/files/__name__.state.ts__template__
@@ -1,3 +1,4 @@
+import { Injectable } from '@angular/core';
 import { State, Selector } from '@ngxs/store';
 
 export interface <%= classify(name) %>StateModel {
@@ -10,6 +11,7 @@ export interface <%= classify(name) %>StateModel {
         items: []
     }
 })
+@Injectable()
 export class <%= classify(name) %>State {
 
     @Selector()

--- a/packages/store/schematics/src/store/files/__name__.state.spec.ts__template__
+++ b/packages/store/schematics/src/store/files/__name__.state.spec.ts__template__
@@ -1,16 +1,17 @@
-import { TestBed, async } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { NgxsModule, Store } from '@ngxs/store';
 import { <%= classify(name) %>State, <%= classify(name) %>StateModel } from './<%= dasherize(name) %>.state';
 import { <%= classify(name) %>Action } from './<%= dasherize(name) %>.actions';
 
 describe('<%= classify(name) %> store', () => {
   let store: Store;
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       imports: [NgxsModule.forRoot([<%= classify(name) %>State])]
     }).compileComponents();
-    store = TestBed.get(Store);
-  }));
+
+    store = TestBed.inject(Store);
+  });
 
   it('should create an action and add an item', () => {
     const expected: <%= classify(name) %>StateModel = {

--- a/packages/store/schematics/src/store/files/__name__.state.spec.ts__template__
+++ b/packages/store/schematics/src/store/files/__name__.state.spec.ts__template__
@@ -5,10 +5,10 @@ import { <%= classify(name) %>Action } from './<%= dasherize(name) %>.actions';
 
 describe('<%= classify(name) %> store', () => {
   let store: Store;
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
+  beforeEach(() => {
+    TestBed.configureTestingModule({
       imports: [NgxsModule.forRoot([<%= classify(name) %>State])]
-    }).compileComponents();
+    });
 
     store = TestBed.inject(Store);
   });

--- a/packages/store/schematics/src/store/files/__name__.state.ts__template__
+++ b/packages/store/schematics/src/store/files/__name__.state.ts__template__
@@ -1,3 +1,4 @@
+import { Injectable } from '@angular/core';
 import { State, Action, Selector, StateContext } from '@ngxs/store';
 import { <%= classify(name) %>Action } from './<%= dasherize(name) %>.actions';
 
@@ -11,6 +12,7 @@ export interface <%= classify(name) %>StateModel {
     items: []
   }
 })
+@Injectable()
 export class <%= classify(name) %>State {
 
   @Selector()

--- a/packages/store/schematics/src/utils/versions.json
+++ b/packages/store/schematics/src/utils/versions.json
@@ -1,3 +1,3 @@
 {
-  "@ngxs/store": "3.8.1"
+  "@ngxs/store": "3.8.2"
 }


### PR DESCRIPTION
This fix replaces the deprecated `async` testing function with an async/await, in the unit tests that are generated via the schematics.
It also adds the `@Injectable` decorator in the generated via the schematics state files