### PR TITLE
fix(schematics): dasherize the state and store file name

### DIFF
--- a/packages/store/schematics/src/actions/files/__name__.actions.ts__template__
+++ b/packages/store/schematics/src/actions/files/__name__.actions.ts__template__
@@ -1,4 +1,4 @@
 export class <%= classify(name) %>Action {
-    public static readonly type = '[<%= classify(name) %>] Add item';
-    constructor(public payload: any) { }
+    static readonly type = '[<%= classify(name) %>] Add item';
+    constructor(readonly payload: any) { }
 }

--- a/packages/store/schematics/src/starter-kit/files/store/auth/auth.actions.ts__template__
+++ b/packages/store/schematics/src/starter-kit/files/store/auth/auth.actions.ts__template__
@@ -1,7 +1,6 @@
 import { AuthenticationStateModel } from './auth.state';
 
 export class SetAuthData {
-  public static readonly type = '[Auth] Auth data';
-
-  constructor(public payload: AuthenticationStateModel) {}
+  static readonly type = '[Auth] Auth data';
+  constructor(readonly payload: AuthenticationStateModel) {}
 }

--- a/packages/store/schematics/src/starter-kit/files/store/auth/auth.state.ts__template__
+++ b/packages/store/schematics/src/starter-kit/files/store/auth/auth.state.ts__template__
@@ -25,7 +25,7 @@ export interface AuthenticationStateModel {
 @Injectable()
 export class AuthState {
   @Selector()
-  public static getAuthData(state: AuthenticationStateModel): AuthenticationStateModel {
+  static getAuthData(state: AuthenticationStateModel): AuthenticationStateModel {
     return AuthState.getInstanceState(state);
   }
 
@@ -38,7 +38,7 @@ export class AuthState {
   }
 
   @Action(SetAuthData)
-  public setAuthData(
+  setAuthData(
     { setState }: StateContext<AuthenticationStateModel>,
     { payload }: SetAuthData
   ) {

--- a/packages/store/schematics/src/starter-kit/files/store/dashboard/states/dictionary/dictionary.actions.ts__template__
+++ b/packages/store/schematics/src/starter-kit/files/store/dashboard/states/dictionary/dictionary.actions.ts__template__
@@ -1,13 +1,10 @@
 import { DictionaryStateModel } from './dictionary.state';
 
 export class SetDictionaryData {
-  public static readonly type = '[Dictionary] Set dictionary data action';
-
-  constructor(public payload: DictionaryStateModel) {}
+  static readonly type = '[Dictionary] Set dictionary data action';
+  constructor(readonly payload: DictionaryStateModel) {}
 }
 
 export class DictionaryReset {
-  public static readonly type = '[Dictionary] Reset dictionary action';
-
-  constructor() {}
+  static readonly type = '[Dictionary] Reset dictionary action';
 }

--- a/packages/store/schematics/src/starter-kit/files/store/dashboard/states/dictionary/dictionary.state.ts__template__
+++ b/packages/store/schematics/src/starter-kit/files/store/dashboard/states/dictionary/dictionary.state.ts__template__
@@ -23,12 +23,12 @@ export interface DictionaryStateModel {
 @Injectable()
 export class DictionaryState {
   @Selector()
-  public static getDictionaryState(state: DictionaryStateModel): DictionaryStateModel {
+  static getDictionaryState(state: DictionaryStateModel): DictionaryStateModel {
     return DictionaryState.getInstanceState(state);
   }
 
   @Selector()
-  public static getDictionaryContent(state: DictionaryStateModel) {
+  static getDictionaryContent(state: DictionaryStateModel) {
     return state.content;
   }
 
@@ -41,7 +41,7 @@ export class DictionaryState {
   }
 
   @Action(SetDictionaryData)
-  public setTasks(
+  setTasks(
     { setState }: StateContext<DictionaryStateModel>,
     { payload }: SetDictionaryData
   ) {
@@ -49,7 +49,7 @@ export class DictionaryState {
   }
 
   @Action(DictionaryReset)
-  public resetTasks({ setState }: StateContext<DictionaryStateModel>) {
+  resetTasks({ setState }: StateContext<DictionaryStateModel>) {
     const initialState = {
       content: [],
       page: 0,

--- a/packages/store/schematics/src/starter-kit/files/store/dashboard/states/user/user.actions.ts__template__
+++ b/packages/store/schematics/src/starter-kit/files/store/dashboard/states/user/user.actions.ts__template__
@@ -1,6 +1,6 @@
 import { UserStateModel } from './user.state';
 
 export class SetUser {
-  public static readonly type = '[SetUser] action';
-  constructor(public payload: UserStateModel) {}
+  static readonly type = '[SetUser] action';
+  constructor(readonly payload: UserStateModel) {}
 }

--- a/packages/store/schematics/src/starter-kit/files/store/dashboard/states/user/user.state.ts__template__
+++ b/packages/store/schematics/src/starter-kit/files/store/dashboard/states/user/user.state.ts__template__
@@ -31,12 +31,12 @@ export interface UserStateModel {
 @Injectable()
 export class UserState {
   @Selector()
-  public static getUser(state: UserStateModel): UserStateModel {
+  static getUser(state: UserStateModel): UserStateModel {
     return state;
   }
 
   @Action(SetUser)
-  public setUser(ctx: StateContext<UserStateModel>, { payload }: SetUser) {
+  setUser(ctx: StateContext<UserStateModel>, { payload }: SetUser) {
     ctx.setState(payload);
   }
 }

--- a/packages/store/schematics/src/state/files/__name__.state.ts__template__
+++ b/packages/store/schematics/src/state/files/__name__.state.ts__template__
@@ -15,7 +15,7 @@ export interface <%= classify(name) %>StateModel {
 export class <%= classify(name) %>State {
 
     @Selector()
-    public static getState(state: <%= classify(name) %>StateModel) {
+    static getState(state: <%= classify(name) %>StateModel) {
         return state;
     }
 

--- a/packages/store/schematics/src/state/state.factory.ts
+++ b/packages/store/schematics/src/state/state.factory.ts
@@ -21,6 +21,11 @@ export function state(options: StateSchema): Rule {
       ? normalizedOptions.path
       : join(normalizedOptions.path, normalizedOptions.name);
 
-    return generateFiles(url('./files'), path, { ...options, isStandalone }, options.spec);
+    return generateFiles(
+      url('./files'),
+      path,
+      { ...normalizedOptions, isStandalone },
+      options.spec
+    );
   };
 }

--- a/packages/store/schematics/src/store/files/__name__.actions.ts__template__
+++ b/packages/store/schematics/src/store/files/__name__.actions.ts__template__
@@ -1,4 +1,4 @@
 export class <%= classify(name) %>Action {
-  public static readonly type = '[<%= classify(name) %>] Add item';
-  constructor(public payload: string) { }
+  static readonly type = '[<%= classify(name) %>] Add item';
+  constructor(readonly payload: string) { }
 }

--- a/packages/store/schematics/src/store/files/__name__.state.ts__template__
+++ b/packages/store/schematics/src/store/files/__name__.state.ts__template__
@@ -16,12 +16,12 @@ export interface <%= classify(name) %>StateModel {
 export class <%= classify(name) %>State {
 
   @Selector()
-  public static getState(state: <%= classify(name) %>StateModel) {
+  static getState(state: <%= classify(name) %>StateModel) {
     return state;
   }
 
   @Action(<%= classify(name) %>Action)
-  public add(ctx: StateContext<<%= classify(name) %>StateModel>, { payload }: <%= classify(name) %>Action) {
+  add(ctx: StateContext<<%= classify(name) %>StateModel>, { payload }: <%= classify(name) %>Action) {
     const stateModel = ctx.getState();
     stateModel.items = [...stateModel.items, payload];
     ctx.setState(stateModel);

--- a/packages/store/schematics/src/store/store.factory.ts
+++ b/packages/store/schematics/src/store/store.factory.ts
@@ -21,6 +21,11 @@ export function store(options: StoreSchema): Rule {
       ? normalizedOptions.path
       : join(normalizedOptions.path, normalizedOptions.name);
 
-    return generateFiles(url('./files'), path, { ...options, isStandalone }, options.spec);
+    return generateFiles(
+      url('./files'),
+      path,
+      { ...normalizedOptions, isStandalone },
+      options.spec
+    );
   };
 }


### PR DESCRIPTION
When we use the schematics and we provide a camelCase or a PascalCase name to `state` or a `store` , the file name generation is not dasherized.

**Store** 

_Before_
> ng generate @ngxs/store:store --path src/app --name MyStore
CREATE src/app/my-store/`MyStore`.actions.ts 
CREATE src/app/my-store/`MyStore`.state.spec.ts
CREATE src/app/my-store/`MyStore`.state.ts 

_After_
> ng generate @ngxs/store:store --path src/app --name MyStore
CREATE src/app/my-store/`my-store`.actions.ts
CREATE src/app/my-store/`my-store`.state.spec.ts 
CREATE src/app/my-store/`my-store`.state.ts


**State**

_Before_
> ng generate @ngxs/store:state --path src/app --name MyState
CREATE src/app/my-state/`MyState`.state.spec.ts
CREATE src/app/my-state/`MyState`.state.ts

_After_
> ng generate @ngxs/store:state --path src/app --name MyState
CREATE src/app/my-state/`my-state`.state.spec.ts
CREATE src/app/my-state/`my-state`.state.ts
