### PR TITLE
ci: remove `integration_ng15_tests` job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,10 +246,6 @@ workflows:
       ###     requires:
       ###       - build
 
-      - integration_ng15_tests:
-          requires:
-            - build
-
       - integration_ng16_tests:
           requires:
             - build


### PR DESCRIPTION
This should have been removed in the migration PR, but I probably missed it. This should re-enable publish on master.