### PR TITLE
feat(storage-plugin): require explicit options when providing storage plugin

### DIFF
--- a/docs/plugins/storage.md
+++ b/docs/plugins/storage.md
@@ -20,7 +20,7 @@ import { NgxsModule } from '@ngxs/store';
 import { NgxsStoragePluginModule } from '@ngxs/storage-plugin';
 
 @NgModule({
-  imports: [NgxsModule.forRoot([]), NgxsStoragePluginModule.forRoot()]
+  imports: [NgxsModule.forRoot([]), NgxsStoragePluginModule.forRoot({ keys: '*' })]
 })
 export class AppModule {}
 ```
@@ -32,7 +32,7 @@ initial state can be picked up by those plugins.
 
 The plugin has the following optional values:
 
-- `key`: State name(s) to be persisted. You can pass a string or array of strings that can be deeply nested via dot notation. If not provided, it defaults to all states using the `@@STATE` key.
+- `keys`: State name(s) to be persisted. You can pass an array of strings that can be deeply nested via dot notation. If not provided, you must explicitly specify the `*` option.
 - `namespace`: The namespace is used to prefix the key for the state slice. This is necessary when running micro frontend applications which use storage plugin. The namespace will eliminate the conflict between keys that might overlap.
 - `storage`: Storage strategy to use. This defaults to LocalStorage but you can pass SessionStorage or anything that implements the StorageEngine API.
 - `deserialize`: Custom deserializer. Defaults to `JSON.parse`
@@ -41,9 +41,9 @@ The plugin has the following optional values:
 - `beforeSerialize`: Interceptor executed before serialization
 - `afterDeserialize`: Interceptor executed after deserialization
 
-### Key option
+### Keys option
 
-The `key` option is used to determine what states should be persisted in the storage. `key` shouldn't be a random string, it has to coincide with your state names. Let's look at the below example:
+The `keys` option is used to determine what states should be persisted in the storage. `keys` shouldn't be a random string, it has to coincide with your state names. Let's look at the below example:
 
 ```ts
 // novels.state.ts
@@ -63,22 +63,22 @@ export class NovelsState {}
 export class DetectivesState {}
 ```
 
-In order to persist all states there is no need to provide the `key` option, so it's enough just to write:
+In order to persist all states, you have to provide `*` as the `keys` option:
 
 ```ts
 @NgModule({
-  imports: [NgxsStoragePluginModule.forRoot()]
+  imports: [NgxsStoragePluginModule.forRoot({ keys: '*' })]
 })
 export class AppModule {}
 ```
 
-But what if we wanted to persist only `NovelsState`? Then we would have needed to pass its name to the `key` option:
+But what if we wanted to persist only `NovelsState`? Then we would have needed to pass its name to the `keys` option:
 
 ```ts
 @NgModule({
   imports: [
     NgxsStoragePluginModule.forRoot({
-      key: 'novels'
+      keys: ['novels']
     })
   ]
 })
@@ -91,7 +91,7 @@ It's also possible to provide a state class as opposed to its name:
 @NgModule({
   imports: [
     NgxsStoragePluginModule.forRoot({
-      key: NovelsState
+      keys: [NovelsState]
     })
   ]
 })
@@ -104,7 +104,7 @@ And if we wanted to persist `NovelsState` and `DetectivesState`:
 @NgModule({
   imports: [
     NgxsStoragePluginModule.forRoot({
-      key: ['novels', 'detectives']
+      keys: ['novels', 'detectives']
     })
   ]
 })
@@ -147,7 +147,7 @@ import { LOCAL_STORAGE_ENGINE, SESSION_STORAGE_ENGINE } from '@ngxs/storage-plug
 @NgModule({
   imports: [
     NgxsStoragePluginModule.forRoot({
-      key: [
+      keys: [
         {
           key: 'novels', // or `NovelsState`
           engine: LOCAL_STORAGE_ENGINE
@@ -176,7 +176,7 @@ export class MyCustomStorageEngine implements StorageEngine {
 @NgModule({
   imports: [
     NgxsStoragePluginModule.forRoot({
-      key: [
+      keys: [
         {
           key: 'novels',
           engine: MyCustomStorageEngine
@@ -196,6 +196,7 @@ The namespace option should be provided when the storage plugin is used in micro
 @NgModule({
   imports: [
     NgxsStoragePluginModule.forRoot({
+      keys: '*',
       namespace: 'auth'
     })
   ]
@@ -222,7 +223,7 @@ export class MyStorageEngine implements StorageEngine {
 }
 
 @NgModule({
-  imports: [NgxsModule.forRoot([]), NgxsStoragePluginModule.forRoot()],
+  imports: [NgxsModule.forRoot([]), NgxsStoragePluginModule.forRoot({ keys: '*' })],
   providers: [
     {
       provide: STORAGE_ENGINE,
@@ -244,7 +245,7 @@ You can define your own logic before or after the state get serialized or deseri
 @NgModule({
   imports: [
     NgxsStoragePluginModule.forRoot({
-      key: 'counter',
+      keys: ['counter'],
       beforeSerialize: (obj, key) => {
         if (key === 'counter') {
           return {
@@ -275,6 +276,7 @@ is a strategy to migrate my state from `animals` to `newAnimals`.
   imports: [
     NgxsModule.forRoot([]),
     NgxsStoragePluginModule.forRoot({
+      keys: '*',
       migrations: [
         {
           version: 1,

--- a/integration/app/app.config.ts
+++ b/integration/app/app.config.ts
@@ -45,7 +45,7 @@ export const appConfig: ApplicationConfig = {
       withNgxsLoggerPlugin({ logger: console, collapsed: false, disabled: true }),
       withNgxsReduxDevtoolsPlugin({ disabled: environment.production }),
       withNgxsRouterPlugin(),
-      withNgxsStoragePlugin({ key: [TODOS_STORAGE_KEY] })
+      withNgxsStoragePlugin({ keys: [TODOS_STORAGE_KEY] })
     )
   ]
 };

--- a/integrations/hello-world-ng16/src/app/store/store.module.ts
+++ b/integrations/hello-world-ng16/src/app/store/store.module.ts
@@ -16,7 +16,7 @@ import { environment } from '../../environments/environment';
     NgxsReduxDevtoolsPluginModule.forRoot({ disabled: environment.production }),
     NgxsFormPluginModule.forRoot(),
     NgxsLoggerPluginModule.forRoot({ disabled: environment.production }),
-    NgxsStoragePluginModule.forRoot(),
+    NgxsStoragePluginModule.forRoot({ keys: '*' }),
     NgxsWebsocketPluginModule.forRoot(),
     NgxsRouterPluginModule.forRoot()
   ]

--- a/integrations/hello-world-ng17/src/app/store/store.module.ts
+++ b/integrations/hello-world-ng17/src/app/store/store.module.ts
@@ -16,7 +16,7 @@ import { environment } from '../../environments/environment';
     NgxsReduxDevtoolsPluginModule.forRoot({ disabled: environment.production }),
     NgxsFormPluginModule.forRoot(),
     NgxsLoggerPluginModule.forRoot({ disabled: environment.production }),
-    NgxsStoragePluginModule.forRoot(),
+    NgxsStoragePluginModule.forRoot({ keys: '*' }),
     NgxsWebsocketPluginModule.forRoot(),
     NgxsRouterPluginModule.forRoot()
   ]

--- a/packages/storage-plugin/internals/src/final-options.ts
+++ b/packages/storage-plugin/internals/src/final-options.ts
@@ -1,9 +1,13 @@
 import { InjectionToken, Injector } from '@angular/core';
 
-import { NgxsStoragePluginOptions, STORAGE_ENGINE, StorageEngine } from './symbols';
+import {
+  STORAGE_ENGINE,
+  StorageEngine,
+  ɵNgxsTransformedStoragePluginOptions
+} from './symbols';
 import { StorageKey, ɵextractStringKey, ɵisKeyWithExplicitEngine } from './storage-key';
 
-export interface ɵFinalNgxsStoragePluginOptions extends NgxsStoragePluginOptions {
+export interface ɵFinalNgxsStoragePluginOptions extends ɵNgxsTransformedStoragePluginOptions {
   keysWithEngines: {
     key: string;
     engine: StorageEngine;
@@ -14,15 +18,16 @@ declare const ngDevMode: boolean;
 
 const NG_DEV_MODE = typeof ngDevMode === 'undefined' || ngDevMode;
 
-export const ɵFINAL_NGXS_STORAGE_PLUGIN_OPTIONS = new InjectionToken<unknown>(
-  NG_DEV_MODE ? 'FINAL_NGXS_STORAGE_PLUGIN_OPTIONS' : ''
-);
+export const ɵFINAL_NGXS_STORAGE_PLUGIN_OPTIONS =
+  new InjectionToken<ɵFinalNgxsStoragePluginOptions>(
+    NG_DEV_MODE ? 'FINAL_NGXS_STORAGE_PLUGIN_OPTIONS' : ''
+  );
 
 export function ɵcreateFinalStoragePluginOptions(
   injector: Injector,
-  options: NgxsStoragePluginOptions
+  options: ɵNgxsTransformedStoragePluginOptions
 ): ɵFinalNgxsStoragePluginOptions {
-  const storageKeys: StorageKey[] = Array.isArray(options.key) ? options.key : [options.key!];
+  const storageKeys = options.keys;
 
   const keysWithEngines = storageKeys.map((storageKey: StorageKey) => {
     const key = ɵextractStringKey(storageKey);

--- a/packages/storage-plugin/internals/src/symbols.ts
+++ b/packages/storage-plugin/internals/src/symbols.ts
@@ -19,9 +19,9 @@ export const enum StorageOption {
 
 export interface NgxsStoragePluginOptions {
   /**
-   * Key for the state slice to store in the storage engine.
+   * Keys for the state slice to store in the storage engine.
    */
-  key?: undefined | StorageKey | StorageKey[];
+  keys: '*' | StorageKey[];
 
   /**
    * The namespace is used to prefix the key for the state slice. This is
@@ -83,9 +83,14 @@ export interface NgxsStoragePluginOptions {
   afterDeserialize?(obj: any, key: string): any;
 }
 
-export const ɵNGXS_STORAGE_PLUGIN_OPTIONS = new InjectionToken(
-  NG_DEV_MODE ? 'NGXS_STORAGE_PLUGIN_OPTIONS' : ''
-);
+export interface ɵNgxsTransformedStoragePluginOptions extends NgxsStoragePluginOptions {
+  keys: StorageKey[];
+}
+
+export const ɵNGXS_STORAGE_PLUGIN_OPTIONS =
+  new InjectionToken<ɵNgxsTransformedStoragePluginOptions>(
+    NG_DEV_MODE ? 'NGXS_STORAGE_PLUGIN_OPTIONS' : ''
+  );
 
 export const STORAGE_ENGINE = new InjectionToken<StorageEngine>(
   NG_DEV_MODE ? 'STORAGE_ENGINE' : ''

--- a/packages/storage-plugin/src/internals.ts
+++ b/packages/storage-plugin/src/internals.ts
@@ -3,20 +3,21 @@ import {
   ɵDEFAULT_STATE_KEY,
   StorageOption,
   StorageEngine,
-  NgxsStoragePluginOptions
+  NgxsStoragePluginOptions,
+  ɵNgxsTransformedStoragePluginOptions
 } from '@ngxs/storage-plugin/internals';
 
 export function storageOptionsFactory(
-  options: NgxsStoragePluginOptions | undefined
-): NgxsStoragePluginOptions {
+  options: NgxsStoragePluginOptions
+): ɵNgxsTransformedStoragePluginOptions {
   return {
-    key: [ɵDEFAULT_STATE_KEY],
     storage: StorageOption.LocalStorage,
     serialize: JSON.stringify,
     deserialize: JSON.parse,
     beforeSerialize: obj => obj,
     afterDeserialize: obj => obj,
-    ...options
+    ...options,
+    keys: options.keys === '*' ? [ɵDEFAULT_STATE_KEY] : options.keys
   };
 }
 
@@ -40,5 +41,5 @@ export function engineFactory(
 export function getStorageKey(key: string, options?: NgxsStoragePluginOptions): string {
   // Prepends the `namespace` option to any key if it's been provided by a user.
   // So `@@STATE` becomes `my-app:@@STATE`.
-  return options && options.namespace ? `${options.namespace}:${key}` : key;
+  return options?.namespace ? `${options.namespace}:${key}` : key;
 }

--- a/packages/storage-plugin/src/storage.module.ts
+++ b/packages/storage-plugin/src/storage.module.ts
@@ -28,7 +28,7 @@ export const USER_OPTIONS = new InjectionToken(NG_DEV_MODE ? 'USER_OPTIONS' : ''
 @NgModule()
 export class NgxsStoragePluginModule {
   static forRoot(
-    options?: NgxsStoragePluginOptions
+    options: NgxsStoragePluginOptions
   ): ModuleWithProviders<NgxsStoragePluginModule> {
     return {
       ngModule: NgxsStoragePluginModule,
@@ -63,7 +63,7 @@ export class NgxsStoragePluginModule {
 }
 
 export function withNgxsStoragePlugin(
-  options?: NgxsStoragePluginOptions
+  options: NgxsStoragePluginOptions
 ): EnvironmentProviders {
   return makeEnvironmentProviders([
     withNgxsPlugin(NgxsStoragePlugin),

--- a/packages/storage-plugin/tests/issues/issue-1146-invalid-rehydration.spec.ts
+++ b/packages/storage-plugin/tests/issues/issue-1146-invalid-rehydration.spec.ts
@@ -48,7 +48,7 @@ describe('Invalid state re-hydration (https://github.com/ngxs/store/issues/1146)
     imports: [
       BrowserModule,
       NgxsModule.forRoot([CounterState]),
-      NgxsStoragePluginModule.forRoot(),
+      NgxsStoragePluginModule.forRoot({ keys: '*' }),
       NgxsRouterPluginModule.forRoot(),
       RouterModule.forRoot([])
     ],

--- a/packages/storage-plugin/tests/issues/issue-1634-resolve-state-name.spec.ts
+++ b/packages/storage-plugin/tests/issues/issue-1634-resolve-state-name.spec.ts
@@ -30,7 +30,7 @@ describe('Resolve state name if the state class has been provided (https://githu
       imports: [
         NgxsModule.forRoot([CountriesState]),
         NgxsStoragePluginModule.forRoot({
-          key: [CountriesState]
+          keys: [CountriesState]
         })
       ]
     });

--- a/packages/storage-plugin/tests/issues/issue-1857-update-for-lazy-state.spec.ts
+++ b/packages/storage-plugin/tests/issues/issue-1857-update-for-lazy-state.spec.ts
@@ -45,7 +45,7 @@ describe('Update for lazy state (https://github.com/ngxs/store/issues/1857)', ()
     imports: [
       BrowserModule,
       NgxsModule.forRoot([]),
-      NgxsStoragePluginModule.forRoot(),
+      NgxsStoragePluginModule.forRoot({ keys: '*' }),
       FeatureStateModule
     ],
     declarations: [TestComponent],

--- a/packages/storage-plugin/tests/issues/issue-1916-key-state-notation.spec.ts
+++ b/packages/storage-plugin/tests/issues/issue-1916-key-state-notation.spec.ts
@@ -44,7 +44,7 @@ describe('State deserialization for keys with dot notation (https://github.com/n
       BrowserModule,
       NgxsModule.forRoot([BlogState, HomeState, AboutState]),
       NgxsStoragePluginModule.forRoot({
-        key: ['blog.name', HomeState, 'about.description']
+        keys: ['blog.name', HomeState, 'about.description']
       })
     ],
     declarations: [TestComponent],

--- a/packages/storage-plugin/tests/issues/issue-598-storage-engine-per-key.spec.ts
+++ b/packages/storage-plugin/tests/issues/issue-598-storage-engine-per-key.spec.ts
@@ -54,7 +54,7 @@ describe('Storage engine per individual key (https://github.com/ngxs/store/issue
       BrowserModule,
       NgxsModule.forRoot([BlogState, HomeState, EncryptedState]),
       NgxsStoragePluginModule.forRoot({
-        key: [
+        keys: [
           {
             key: 'blog.name',
             engine: SESSION_STORAGE_ENGINE

--- a/packages/storage-plugin/tests/issues/issue-restore-state-only-if-key-matches.spec.ts
+++ b/packages/storage-plugin/tests/issues/issue-restore-state-only-if-key-matches.spec.ts
@@ -81,7 +81,7 @@ describe('Restore state only if key matches', () => {
           ]),
           NgxsModule.forRoot([AuthState]),
           NgxsStoragePluginModule.forRoot({
-            key: [AuthState]
+            keys: [AuthState]
           })
         ],
         declarations: [TestComponent],

--- a/packages/storage-plugin/tests/storage.plugin.spec.ts
+++ b/packages/storage-plugin/tests/storage.plugin.spec.ts
@@ -76,7 +76,10 @@ describe('NgxsStoragePlugin', () => {
 
     // Act
     TestBed.configureTestingModule({
-      imports: [NgxsModule.forRoot([CounterState]), NgxsStoragePluginModule.forRoot()]
+      imports: [
+        NgxsModule.forRoot([CounterState]),
+        NgxsStoragePluginModule.forRoot({ keys: '*' })
+      ]
     });
 
     const store: Store = TestBed.inject(Store);
@@ -92,7 +95,10 @@ describe('NgxsStoragePlugin', () => {
 
     // Act
     TestBed.configureTestingModule({
-      imports: [NgxsModule.forRoot([CounterState]), NgxsStoragePluginModule.forRoot()]
+      imports: [
+        NgxsModule.forRoot([CounterState]),
+        NgxsStoragePluginModule.forRoot({ keys: '*' })
+      ]
     });
 
     const store: Store = TestBed.inject(Store);
@@ -128,7 +134,10 @@ describe('NgxsStoragePlugin', () => {
 
       // Act
       TestBed.configureTestingModule({
-        imports: [NgxsModule.forRoot([TestState]), NgxsStoragePluginModule.forRoot()]
+        imports: [
+          NgxsModule.forRoot([TestState]),
+          NgxsStoragePluginModule.forRoot({ keys: '*' })
+        ]
       });
 
       const store: Store = skipConsoleLogging(() => TestBed.inject(Store));
@@ -153,7 +162,10 @@ describe('NgxsStoragePlugin', () => {
 
       // Act
       TestBed.configureTestingModule({
-        imports: [NgxsModule.forRoot([TestState]), NgxsStoragePluginModule.forRoot()]
+        imports: [
+          NgxsModule.forRoot([TestState]),
+          NgxsStoragePluginModule.forRoot({ keys: '*' })
+        ]
       });
 
       const store: Store = skipConsoleLogging(() => TestBed.inject(Store));
@@ -178,7 +190,10 @@ describe('NgxsStoragePlugin', () => {
 
       // Act
       TestBed.configureTestingModule({
-        imports: [NgxsModule.forRoot([TestState]), NgxsStoragePluginModule.forRoot()]
+        imports: [
+          NgxsModule.forRoot([TestState]),
+          NgxsStoragePluginModule.forRoot({ keys: '*' })
+        ]
       });
 
       const store: Store = TestBed.inject(Store);
@@ -199,6 +214,7 @@ describe('NgxsStoragePlugin', () => {
       imports: [
         NgxsModule.forRoot([CounterState]),
         NgxsStoragePluginModule.forRoot({
+          keys: '*',
           migrations: [
             {
               version: 1,
@@ -237,7 +253,7 @@ describe('NgxsStoragePlugin', () => {
       imports: [
         NgxsModule.forRoot([CounterState]),
         NgxsStoragePluginModule.forRoot({
-          key: 'counter',
+          keys: ['counter'],
           migrations: [
             {
               version: 1,
@@ -274,6 +290,7 @@ describe('NgxsStoragePlugin', () => {
       imports: [
         NgxsModule.forRoot([CounterState]),
         NgxsStoragePluginModule.forRoot({
+          keys: '*',
           storage: StorageOption.SessionStorage
         })
       ]
@@ -293,6 +310,7 @@ describe('NgxsStoragePlugin', () => {
       imports: [
         NgxsModule.forRoot([CounterState]),
         NgxsStoragePluginModule.forRoot({
+          keys: '*',
           storage: StorageOption.SessionStorage
         })
       ]
@@ -352,6 +370,7 @@ describe('NgxsStoragePlugin', () => {
       imports: [
         NgxsModule.forRoot([CounterState]),
         NgxsStoragePluginModule.forRoot({
+          keys: '*',
           serialize(val) {
             return val;
           },
@@ -391,7 +410,7 @@ describe('NgxsStoragePlugin', () => {
     TestBed.configureTestingModule({
       imports: [
         NgxsModule.forRoot([CounterState]),
-        NgxsStoragePluginModule.forRoot(),
+        NgxsStoragePluginModule.forRoot({ keys: '*' }),
         NgxsModule.forFeature([LazyLoadedState])
       ]
     });
@@ -423,7 +442,7 @@ describe('NgxsStoragePlugin', () => {
         imports: [
           NgxsModule.forRoot([CounterState]),
           NgxsStoragePluginModule.forRoot({
-            key: CounterState
+            keys: [CounterState]
           })
         ]
       });
@@ -445,7 +464,7 @@ describe('NgxsStoragePlugin', () => {
         imports: [
           NgxsModule.forRoot([CounterState, NamesState]),
           NgxsStoragePluginModule.forRoot({
-            key: [CounterState, NamesState]
+            keys: [CounterState, NamesState]
           })
         ]
       });
@@ -471,7 +490,7 @@ describe('NgxsStoragePlugin', () => {
         imports: [
           NgxsModule.forRoot([CounterState, NamesState]),
           NgxsStoragePluginModule.forRoot({
-            key: [CounterState, 'names']
+            keys: [CounterState, 'names']
           })
         ]
       });
@@ -498,6 +517,7 @@ describe('NgxsStoragePlugin', () => {
         imports: [
           NgxsModule.forRoot([CounterState]),
           NgxsStoragePluginModule.forRoot({
+            keys: '*',
             beforeSerialize: obj => {
               return {
                 counter: {
@@ -531,7 +551,7 @@ describe('NgxsStoragePlugin', () => {
         imports: [
           NgxsModule.forRoot([CounterInfoState]),
           NgxsStoragePluginModule.forRoot({
-            key: 'counterInfo',
+            keys: ['counterInfo'],
             afterDeserialize: (obj, key) => {
               if (key === 'counterInfo') {
                 return new CounterInfoStateModel(obj.count);
@@ -562,7 +582,7 @@ describe('NgxsStoragePlugin', () => {
         TestBed.configureTestingModule({
           imports: [
             NgxsModule.forRoot([CounterState, NamesState], { developmentMode: true }),
-            NgxsStoragePluginModule.forRoot(options)
+            NgxsStoragePluginModule.forRoot(options as any)
           ]
         });
 
@@ -577,7 +597,7 @@ describe('NgxsStoragePlugin', () => {
           `${namespace}:${ɵDEFAULT_STATE_KEY}`,
           JSON.stringify({ counter: { count: 100 } })
         );
-        const { store } = testSetup({ namespace });
+        const { store } = testSetup({ keys: '*', namespace });
         const state: CounterStateModel = store.selectSnapshot(CounterState);
         // Assert
         expect(state.count).toBe(100);
@@ -591,7 +611,7 @@ describe('NgxsStoragePlugin', () => {
           `${namespace}:names`,
           JSON.stringify(['Mark', 'Artur', 'Max'])
         );
-        const { store } = testSetup({ namespace, key: [NamesState] });
+        const { store } = testSetup({ namespace, keys: [NamesState] });
         const names = store.selectSnapshot<string[]>(NamesState);
         const { count } = store.selectSnapshot<CounterStateModel>(CounterState);
         // Assert
@@ -609,7 +629,7 @@ describe('NgxsStoragePlugin', () => {
           `undefined+null+something_else`
         );
         const spy = jest.spyOn(console, 'error').mockImplementation();
-        testSetup({ namespace, key: [NamesState] });
+        testSetup({ namespace, keys: [NamesState] });
         // Assert
         try {
           expect(spy).toHaveBeenCalledWith(


### PR DESCRIPTION
This commit updates the implementation of the register signature for the storage plugin.
It now always requires `options` to be provided. We want to ensure clarity regarding the
states that we're going to serialize. When no `options` are provided, we implicitly provide
the `@@STATE` key, which defines that all states should be serialized. This implementation
doesn't compromise extendability because we implicitly rely on the internal mechanism that
transforms options. We should always require options to be provided and require developers
to specify serializable states explicitly.

This would allow us to have feature states because the feature registration mechanism would
also know if the user explicitly specified all states to be serialized at the root level or not.

**Note:** This change is breaking. However, it's time to make breaking changes to move forward,
as the current implementation is stale and acts as a blocker.