### PR TITLE
fix(store): `dispatch` return observable should be `<void>`

### DIFF
--- a/packages/store/src/internal/error-handler.ts
+++ b/packages/store/src/internal/error-handler.ts
@@ -16,11 +16,11 @@ import { NgxsExecutionStrategy } from '../execution/symbols';
  * 4) `toPromise()` without `catch` -> do `handleError()`
  * 5) `toPromise()` with `catch` -> don't `handleError()`
  */
-export function ngxsErrorHandler<T>(
+export function ngxsErrorHandler(
   internalErrorReporter: InternalErrorReporter,
   ngxsExecutionStrategy: NgxsExecutionStrategy
 ) {
-  return (source: Observable<T>) => {
+  return (source: Observable<void>) => {
     let subscribed = false;
 
     source.subscribe({
@@ -40,7 +40,7 @@ export function ngxsErrorHandler<T>(
       }
     });
 
-    return new Observable(subscriber => {
+    return new Observable<void>(subscriber => {
       subscribed = true;
       return source.pipe(leaveNgxs(ngxsExecutionStrategy)).subscribe(subscriber);
     });

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -1,4 +1,3 @@
-// tslint:disable:unified-signatures
 import { Inject, Injectable, Optional, Signal, Type, computed } from '@angular/core';
 import { Observable, of, Subscription, throwError } from 'rxjs';
 import { catchError, distinctUntilChanged, map, shareReplay, take } from 'rxjs/operators';
@@ -41,7 +40,7 @@ export class Store {
   /**
    * Dispatches event(s).
    */
-  dispatch(actionOrActions: any | any[]): Observable<any> {
+  dispatch(actionOrActions: any | any[]): Observable<void> {
     return this._internalStateOperations.getRootStateOperations().dispatch(actionOrActions);
   }
 

--- a/packages/store/types/tests/dispatch.lint.ts
+++ b/packages/store/types/tests/dispatch.lint.ts
@@ -60,11 +60,11 @@ describe('[TEST]: Action Types', () => {
   });
 
   it('should be correct type in dispatch', () => {
-    assertType(() => store.dispatch([])); // $ExpectType Observable<any>
-    assertType(() => store.dispatch(new FooAction('payload'))); // $ExpectType Observable<any>
-    assertType(() => store.dispatch(new BarAction('foo'))); // $ExpectType Observable<any>
+    assertType(() => store.dispatch([])); // $ExpectType Observable<void>
+    assertType(() => store.dispatch(new FooAction('payload'))); // $ExpectType Observable<void>
+    assertType(() => store.dispatch(new BarAction('foo'))); // $ExpectType Observable<void>
     assertType(() => store.dispatch()); // $ExpectError
-    assertType(() => store.dispatch({})); // $ExpectType Observable<any>
+    assertType(() => store.dispatch({})); // $ExpectType Observable<void>
   });
 
   it('should prevent invalid types passed through', () => {
@@ -83,10 +83,10 @@ describe('[TEST]: Action Types', () => {
       @Action({ foo: 123 }) increment4() {} // $ExpectError
     }
 
-    assertType(() => store.dispatch(new Increment())); // $ExpectType Observable<any>
-    assertType(() => store.dispatch({ type: 'INCREMENT' })); // $ExpectType Observable<any>
-    assertType(() => store.dispatch(Increment)); // $ExpectType Observable<any>
-    assertType(() => store.dispatch({ foo: 123 })); // $ExpectType Observable<any>
+    assertType(() => store.dispatch(new Increment())); // $ExpectType Observable<void>
+    assertType(() => store.dispatch({ type: 'INCREMENT' })); // $ExpectType Observable<void>
+    assertType(() => store.dispatch(Increment)); // $ExpectType Observable<void>
+    assertType(() => store.dispatch({ foo: 123 })); // $ExpectType Observable<void>
   });
 
   it('should be correct type base API', () => {


### PR DESCRIPTION
This commit updates all `dispatch` signatures to return `Observable<void>`. Initially, the signature was intended to be `void`, but historically, it was returning `Observable<any>`, where `any` represents the state snapshot.

This is a breaking change. We've been delaying this fix for years, but now all the necessary changes should finally be made to allow us to progress with the NGXS code itself. It's especially important to clean up old planned todos as well.