### PR TITLE
fix(store): `ctx.getState` should return `DeepReadOnly<>`

### DIFF
--- a/integration/app/store/todos/todo/todo.state.ts
+++ b/integration/app/store/todos/todo/todo.state.ts
@@ -27,19 +27,19 @@ export class TodoState implements NgxsOnInit, NgxsAfterBootstrap {
     return state.filter(s => s.indexOf('panda') > -1);
   }
 
-  ngxsOnInit({ getState, setState }: StateContext<Todo[]>) {
-    const state: Todo[] = getState();
+  ngxsOnInit(ctx: StateContext<Todo[]>) {
+    const state = ctx.getState();
     const payload: Todo = 'NgxsOnInit todo';
     if (!state.includes(payload)) {
-      setState([...state, payload]);
+      ctx.setState([...state, payload]);
     }
   }
 
-  ngxsAfterBootstrap({ getState, setState }: StateContext<Todo[]>): void {
-    const state: Todo[] = getState();
+  ngxsAfterBootstrap(ctx: StateContext<Todo[]>): void {
+    const state = ctx.getState();
     const payload: Todo = 'NgxsAfterBootstrap todo';
     if (!state.includes(payload)) {
-      setState([...state, payload]);
+      ctx.setState([...state, payload]);
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "ts-jest": "29.1.1",
     "ts-node": "^8.10.2",
     "tslib": "^2.3.0",
+    "type-fest": "4.12.0",
     "typescript": "5.2.2",
     "zone.js": "0.14.0"
   }

--- a/packages/hmr-plugin/src/internal/hmr-lifecycle.ts
+++ b/packages/hmr-plugin/src/internal/hmr-lifecycle.ts
@@ -42,7 +42,7 @@ export class HmrLifecycle<T extends Partial<NgxsHmrLifeCycle<S>>, S> {
     if (typeof this.ngAppModule.hmrNgxsStoreBeforeOnDestroy === 'function') {
       state = this.ngAppModule.hmrNgxsStoreBeforeOnDestroy(ctx);
     } else {
-      state = ctx.getState();
+      state = ctx.getState() as Partial<S>;
     }
 
     ctx.dispatch(new HmrBeforeDestroyAction(state));

--- a/packages/hmr-plugin/src/internal/hmr-state-context-factory.ts
+++ b/packages/hmr-plugin/src/internal/hmr-state-context-factory.ts
@@ -22,7 +22,7 @@ export class HmrStateContextFactory<T, S> {
   public createStateContext(): StateContext<S> {
     return {
       dispatch: actions => this.store!.dispatch(actions),
-      getState: () => <S>this.store!.snapshot(),
+      getState: () => this.store!.snapshot(),
       setState: val => {
         if (isStateOperator(val)) {
           const currentState = this.store!.snapshot();

--- a/packages/store/ng-package.json
+++ b/packages/store/ng-package.json
@@ -3,5 +3,6 @@
   "lib": {
     "entryFile": "index.ts"
   },
-  "dest": "../../@ngxs/store"
+  "dest": "../../@ngxs/store",
+  "allowedNonPeerDependencies": ["type-fest"]
 }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "license": "MIT",
   "sideEffects": false,
+  "dependencies": {
+    "type-fest": "4.12.0"
+  },
   "peerDependencies": {
     "@angular/core": ">=12.0.0 <18.0.0",
     "rxjs": ">=6.5.5"

--- a/packages/store/src/internal/internals.ts
+++ b/packages/store/src/internal/internals.ts
@@ -1,4 +1,5 @@
 import { InjectionToken, inject } from '@angular/core';
+import type { ReadonlyDeep } from 'type-fest';
 import { Observable } from 'rxjs';
 
 import {
@@ -18,7 +19,7 @@ export type StateKeyGraph = ɵPlainObjectOf<string[]>;
 export type StatesByName = ɵPlainObjectOf<ɵStateClassInternal>;
 
 export interface StateOperations<T> {
-  getState(): T;
+  getState(): ReadonlyDeep<T>;
 
   setState(val: T): T;
 

--- a/packages/store/src/internal/state-context-factory.ts
+++ b/packages/store/src/internal/state-context-factory.ts
@@ -1,7 +1,9 @@
 import { Injectable } from '@angular/core';
+import type { ReadonlyDeep } from 'type-fest';
+import { Observable } from 'rxjs';
+
 import { getValue, setValue } from '@ngxs/store/plugins';
 import { ExistingState, StateOperator, isStateOperator } from '@ngxs/store/operators';
-import { Observable } from 'rxjs';
 
 import { StateContext } from '../symbols';
 import { MappedStore, StateOperations } from '../internal/internals';
@@ -23,7 +25,7 @@ export class StateContextFactory {
     const root = this._internalStateOperations.getRootStateOperations();
 
     return {
-      getState(): T {
+      getState(): ReadonlyDeep<T> {
         const currentAppState = root.getState();
         return getState(currentAppState, mappedStore.path);
       },

--- a/packages/store/src/symbols.ts
+++ b/packages/store/src/symbols.ts
@@ -1,8 +1,9 @@
 import { Injectable, InjectionToken, Type, inject } from '@angular/core';
+import type { ReadonlyDeep } from 'type-fest';
 import { Observable } from 'rxjs';
 
 import { StateOperator } from '@ngxs/store/operators';
-import { ɵPlainObject, ɵSharedSelectorOptions, ɵStateClass } from '@ngxs/store/internals';
+import { ɵStateClass, ɵPlainObject, ɵSharedSelectorOptions } from '@ngxs/store/internals';
 
 import { NgxsExecutionStrategy } from './execution/symbols';
 import { DispatchOutsideZoneNgxsExecutionStrategy } from './execution/dispatch-outside-zone-ngxs-execution-strategy';
@@ -109,7 +110,7 @@ export interface StateContext<T> {
   /**
    * Get the current state.
    */
-  getState(): T;
+  getState(): ReadonlyDeep<T>;
 
   /**
    * Reset the state to a new value.

--- a/yarn.lock
+++ b/yarn.lock
@@ -11773,6 +11773,11 @@ type-detect@4.0.8:
   resolved "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
+type-fest@4.12.0:
+  version "4.12.0"
+  resolved "https://registry.npmjs.org/type-fest/-/type-fest-4.12.0.tgz#00ae70d02161b81ecd095158143c4bb8c879760d"
+  integrity sha512-5Y2/pp2wtJk8o08G0CMkuFPCO354FGwk/vbidxrdhRGZfd0tFnb4Qb8anp9XxXriwBgVPjdWbKpGl4J9lJY2jQ==
+
 type-fest@^0.18.0:
   version "0.18.1"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz#db4bc151a4a2cf4eebf9add5db75508db6cc841f"


### PR DESCRIPTION
This commit modifies the return value of `StateContext.getState` from `<T>` to `ReadonlyDeep<T>`.
The `ReadonlyDeep` type is provided by the `type-fest` package, which is now included in the
dependencies of `@ngxs/store` and will be installed automatically with it.

This change is necessary because `getState` should return an immutable object, and users should
not have any reason to directly modify it.

Please note that this change is breaking and is part of the v4 release preparation.