### PR TITLE
fix(store): enable throwing errors from selectors by default

### DIFF
--- a/packages/store/src/selectors/selector-utils.ts
+++ b/packages/store/src/selectors/selector-utils.ts
@@ -10,6 +10,10 @@ import {
 
 import { CreationMetadata, RuntimeSelectorInfo } from './selector-models';
 
+declare const ngDevMode: boolean;
+
+const NG_DEV_MODE = typeof ngDevMode !== 'undefined' && ngDevMode;
+
 export function createRootSelectorFactory<T extends (...args: any[]) => any>(
   selectorMetaData: ɵSelectorMetaDataModel,
   selectors: any[] | undefined,
@@ -22,18 +26,35 @@ export function createRootSelectorFactory<T extends (...args: any[]) => any>(
       selectors
     );
 
+    const { suppressErrors } = selectorOptions;
+
     return function selectFromRoot(rootState: any) {
       // Determine arguments from the app state using the selectors
       const results = argumentSelectorFunctions.map(argFn => argFn(rootState));
 
-      // if the lambda tries to access a something on the
-      // state that doesn't exist, it will throw a TypeError.
-      // since this is quite usual behaviour, we simply return undefined if so.
+      // If the lambda attempts to access something in the state that doesn't exist,
+      // it will throw a `TypeError`. Since this behavior is common, we simply return
+      // `undefined` in such cases.
       try {
         return memoizedSelectorFn(...results);
       } catch (ex) {
-        if (ex instanceof TypeError && selectorOptions.suppressErrors) {
+        if (suppressErrors && ex instanceof TypeError) {
           return undefined;
+        }
+
+        // We're logging an error in this function because it may be used by `select`,
+        // `selectSignal`, and `selectSnapshot`. Therefore, there's no need to catch
+        // exceptions there to log errors.
+        if (NG_DEV_MODE) {
+          const message =
+            'The selector below has thrown an error upon invocation. ' +
+            'Please check for any unsafe property access that may result in null ' +
+            'or undefined values.';
+
+          // Avoid concatenating the message with the original function, as this will
+          // invoke `toString()` on the function. Instead, log it as the second argument.
+          // This way, developers will be able to navigate to the actual code in the browser.
+          console.error(message, selectorMetaData.originalFn);
         }
 
         throw ex;

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -54,16 +54,14 @@ export class Store {
     const selectorFn = this.getStoreBoundSelectorFn(selector);
     return this._selectableStateStream.pipe(
       map(selectorFn),
-      catchError((err: Error): Observable<never> | Observable<undefined> => {
+      catchError((error: Error): Observable<never> | Observable<undefined> => {
         // if error is TypeError we swallow it to prevent usual errors with property access
-        const { suppressErrors } = this._config.selectorOptions;
-
-        if (err instanceof TypeError && suppressErrors) {
+        if (this._config.selectorOptions.suppressErrors && error instanceof TypeError) {
           return of(undefined);
         }
 
         // rethrow other errors
-        return throwError(err);
+        return throwError(error);
       }),
       distinctUntilChanged(),
       leaveNgxs(this._internalExecutionStrategy)

--- a/packages/store/src/symbols.ts
+++ b/packages/store/src/symbols.ts
@@ -96,7 +96,7 @@ export class NgxsConfig {
    */
   selectorOptions: ɵSharedSelectorOptions = {
     injectContainerState: true, // TODO: default is true in v3, will change in v4
-    suppressErrors: true // TODO: default is true in v3, will change in v4
+    suppressErrors: false
   };
 }
 

--- a/packages/store/tests/select-signal.spec.ts
+++ b/packages/store/tests/select-signal.spec.ts
@@ -753,20 +753,6 @@ describe('Selector', () => {
       expect(reverse).toEqual([4, 3, 2, 1]);
     });
 
-    it('should be incorrect mutation', () => {
-      TestBed.configureTestingModule({
-        imports: [NgxsModule.forRoot([TasksState], { developmentMode: true })]
-      });
-
-      const store = TestBed.inject(Store);
-      store.reset({ tasks: [1, 2, 3, 4] });
-
-      const tasks = store.selectSignal(TasksState.getTasks);
-      const reverse = store.selectSignal(TasksState.reverse);
-      expect(tasks()).toEqual([1, 2, 3, 4]);
-      expect(reverse()).toEqual(undefined as any);
-    });
-
     it('should be correct catch errors with selectSnapshot', () => {
       TestBed.configureTestingModule({
         imports: [

--- a/packages/store/tests/selector.spec.ts
+++ b/packages/store/tests/selector.spec.ts
@@ -754,20 +754,6 @@ describe('Selector', () => {
       expect(reverse).toEqual([4, 3, 2, 1]);
     });
 
-    it('should be incorrect mutation', () => {
-      TestBed.configureTestingModule({
-        imports: [NgxsModule.forRoot([TasksState], { developmentMode: true })]
-      });
-
-      const store = TestBed.inject(Store);
-      store.reset({ tasks: [1, 2, 3, 4] });
-
-      const tasks: number[] = store.selectSnapshot(TasksState);
-      const reverse: number[] = store.selectSnapshot(TasksState.reverse);
-      expect(tasks).toEqual([1, 2, 3, 4]);
-      expect(reverse).toEqual(undefined as any);
-    });
-
     it('should be correct catch errors with selectSnapshot', () => {
       TestBed.configureTestingModule({
         imports: [


### PR DESCRIPTION
This commit updates the `suppressErrors` configuration property to default to falsy.
Consequently, if the selector function throws a type error (such as when accessing a
property unsafely), the error will now be thrown.

`selectSnapshot` will throw synchronously, while errors from `select` will be thrown
asynchronously because the RxJS error reporter operates within a `setTimeout`.

We log errors in development mode to assist developers in identifying selectors that have thrown.

This change is breaking and is part of the v4 release preparation.