### PR TITLE
fix(store): `setState` and `patchState` should both return `<void>`

### DIFF
--- a/packages/store/src/internal/internals.ts
+++ b/packages/store/src/internal/internals.ts
@@ -20,7 +20,7 @@ export type StatesByName = ɵPlainObjectOf<ɵStateClassInternal>;
 export interface StateOperations<T> {
   getState(): T;
 
-  setState(val: T): T;
+  setState(val: T): void;
 
   dispatch(actionOrActions: any | any[]): Observable<void>;
 }

--- a/packages/store/src/internal/state-context-factory.ts
+++ b/packages/store/src/internal/state-context-factory.ts
@@ -27,16 +27,18 @@ export class StateContextFactory {
         const currentAppState = root.getState();
         return getState(currentAppState, mappedStore.path);
       },
-      patchState(val: Partial<T>): T {
+      patchState(val: Partial<T>): void {
         const currentAppState = root.getState();
         const patchOperator = simplePatch<T>(val);
-        return setStateFromOperator(root, currentAppState, patchOperator, mappedStore.path);
+        setStateFromOperator(root, currentAppState, patchOperator, mappedStore.path);
       },
-      setState(val: T | StateOperator<T>): T {
+      setState(val: T | StateOperator<T>): void {
         const currentAppState = root.getState();
-        return isStateOperator(val)
-          ? setStateFromOperator(root, currentAppState, val, mappedStore.path)
-          : setStateValue(root, currentAppState, val, mappedStore.path);
+        if (isStateOperator(val)) {
+          setStateFromOperator(root, currentAppState, val, mappedStore.path);
+        } else {
+          setStateValue(root, currentAppState, val, mappedStore.path);
+        }
       },
       dispatch(actions: any | any[]): Observable<void> {
         return root.dispatch(actions);

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -119,7 +119,7 @@ export class Store {
    * for plugin's who need to modify the state directly or unit testing.
    */
   reset(state: any) {
-    return this._internalStateOperations.getRootStateOperations().setState(state);
+    this._internalStateOperations.getRootStateOperations().setState(state);
   }
 
   private getStoreBoundSelectorFn(selector: any) {

--- a/packages/store/src/symbols.ts
+++ b/packages/store/src/symbols.ts
@@ -114,12 +114,12 @@ export interface StateContext<T> {
   /**
    * Reset the state to a new value.
    */
-  setState(val: T | StateOperator<T>): T;
+  setState(val: T | StateOperator<T>): void;
 
   /**
    * Patch the existing state with the provided value.
    */
-  patchState(val: Partial<T>): T;
+  patchState(val: Partial<T>): void;
 
   /**
    * Dispatch a new action and return the dispatched observable.

--- a/packages/store/types/tests/dispatch.lint.ts
+++ b/packages/store/types/tests/dispatch.lint.ts
@@ -92,7 +92,7 @@ describe('[TEST]: Action Types', () => {
   it('should be correct type base API', () => {
     assertType(() => store.snapshot()); // $ExpectType any
     assertType(() => store.subscribe()); // $ExpectType Subscription
-    assertType(() => store.reset({})); // $ExpectType any
+    assertType(() => store.reset({})); // $ExpectType void
     assertType(() => store.reset()); // $ExpectError
   });
 });


### PR DESCRIPTION
This commit modifies the signatures of `setState` and `patchState` to return `<void>`. Previously, they were returning `<T>`, which was historically a mistake. This change also impacts the `Store.reset` method since it utilizes `setState`, resulting in `Store.reset` now also returning `<void>`.

`setState` is designed to update the state, and as such, the method itself should not generate a return value. Users should utilize `getState` to retrieve the latest value accordingly.
