### PR TITLE
fix(store): do not inject container state by default

### DIFF
--- a/packages/router-plugin/tests/issues/issue-1718-url-recognition.spec.ts
+++ b/packages/router-plugin/tests/issues/issue-1718-url-recognition.spec.ts
@@ -36,8 +36,6 @@ describe('URL recognition in guards (https://github.com/ngxs/store/issues/1718)'
   })
   class DetailsComponent {}
 
-  interface AppStateModel {}
-
   @State({
     name: 'app',
     defaults: {}
@@ -45,10 +43,7 @@ describe('URL recognition in guards (https://github.com/ngxs/store/issues/1718)'
   @Injectable()
   class AppState {
     @Selector([RouterState.state])
-    static getActiveRoute(
-      _stateModel: AppStateModel,
-      route: RouterStateSnapshot
-    ): ActivatedRouteSnapshot {
+    static getActiveRoute(route: RouterStateSnapshot): ActivatedRouteSnapshot {
       let state: ActivatedRouteSnapshot = route.root;
       while (state.firstChild) {
         state = state.firstChild;

--- a/packages/store/internals/testing/tests/ngxs.setup.spec.ts
+++ b/packages/store/internals/testing/tests/ngxs.setup.spec.ts
@@ -5,6 +5,7 @@ import { Injectable } from '@angular/core';
 
 describe('Full testing NGXS States with NgxsTestBed', () => {
   @State<any>({ name: 'app', defaults: { count: 0 } })
+  @Injectable()
   class AppState implements NgxsOnInit, NgxsAfterBootstrap {
     public ngxsOnInit(ctx: StateContext<any>): void {
       this.triggerLifecycle(ctx, 'AppState.ngxsOnInit');

--- a/packages/store/src/decorators/selector/selector.ts
+++ b/packages/store/src/decorators/selector/selector.ts
@@ -42,10 +42,9 @@ export function Selector<T extends SelectorDef<any>>(selectors?: T[]): SelectorT
       configurable: true,
       get() {
         return memoizedFn;
-      }
+      },
+      originalFn
     };
-    // Add hidden property to descriptor
-    (<any>newDescriptor)['originalFn'] = originalFn;
     return newDescriptor;
   };
 }

--- a/packages/store/src/selectors/selector-utils.ts
+++ b/packages/store/src/selectors/selector-utils.ts
@@ -110,8 +110,19 @@ function getSelectorsToApply(
   containerClass: any
 ) {
   const selectorsToApply = [];
+  // The container state refers to the state class that includes the
+  // definition of the selector function, for example:
+  // @State()
+  // class AnimalsState {
+  //   @Selector()
+  //   static getAnimals(state: AnimalsStateModel) {}
+  // }
+  // The `AnimalsState` serves as the container state. Additionally, the
+  // selector may reside within a namespace or another class lacking the
+  // `@State` decorator, thus not being treated as the container state.
   const canInjectContainerState =
-    selectors.length === 0 || selectorOptions.injectContainerState;
+    selectorOptions.injectContainerState || selectors.length === 0;
+
   if (containerClass && canInjectContainerState) {
     // If we are on a state class, add it as the first selector parameter
     const metadata = ɵgetStoreMetadata(containerClass);
@@ -119,9 +130,7 @@ function getSelectorsToApply(
       selectorsToApply.push(containerClass);
     }
   }
-  if (selectors) {
-    selectorsToApply.push(...selectors);
-  }
+  selectorsToApply.push(...selectors);
   return selectorsToApply;
 }
 

--- a/packages/store/src/symbols.ts
+++ b/packages/store/src/symbols.ts
@@ -95,7 +95,7 @@ export class NgxsConfig {
    * Defining shared selector options
    */
   selectorOptions: ɵSharedSelectorOptions = {
-    injectContainerState: true, // TODO: default is true in v3, will change in v4
+    injectContainerState: false,
     suppressErrors: false
   };
 }

--- a/packages/store/tests/helpers/todo.state.ts
+++ b/packages/store/tests/helpers/todo.state.ts
@@ -1,3 +1,4 @@
+import { Injectable } from '@angular/core';
 import { State, Action } from '../../src/public_api';
 
 export class AddTodo {
@@ -15,6 +16,7 @@ export class RemoveTodo {
   name: 'todos',
   defaults: []
 })
+@Injectable()
 export class TodoState {
   @Action(AddTodo)
   addTodo(state: string[], action: AddTodo) {

--- a/packages/store/tests/select-signal.spec.ts
+++ b/packages/store/tests/select-signal.spec.ts
@@ -86,26 +86,6 @@ describe('Selector', () => {
       expect(slice()).toBe('Hello');
     });
 
-    it('should select multiples', () => {
-      TestBed.configureTestingModule({
-        imports: [NgxsModule.forRoot([MyState, MyState2])]
-      });
-
-      const store = TestBed.inject(Store);
-      const slice = store.selectSignal(MyState2.foo);
-      expect(slice()).toBe('HelloHello');
-    });
-
-    it('should select multiples from self and others', () => {
-      TestBed.configureTestingModule({
-        imports: [NgxsModule.forRoot([MyState, MyState2])]
-      });
-
-      const store = TestBed.inject(Store);
-      const slice = store.selectSignal(MyState2.fooBar);
-      expect(slice()).toBe('HelloHelloWorld');
-    });
-
     it('context should be defined inside selector', () => {
       @State<any>({
         name: 'counter',
@@ -501,11 +481,6 @@ describe('Selector', () => {
           return state.bar;
         }
 
-        @Selector([MyStateV3.bar])
-        static v3StyleSelector_FooAndBar(state: MyStateModel, bar: string) {
-          return state.foo + bar;
-        }
-
         @Selector([MyStateV3.foo, MyStateV3.bar])
         @SelectorOptions({ injectContainerState: false })
         static v4StyleSelector_FooAndBar(foo: string, bar: string) {
@@ -524,15 +499,6 @@ describe('Selector', () => {
           throw new Error('This is a forced error');
         }
       }
-
-      it('should select from a v3 selector', () => {
-        // Arrange
-        const store = setupStore([MyStateV3]);
-        // Act
-        const slice = store.selectSignal(MyStateV3.v3StyleSelector_FooAndBar);
-        // Assert
-        expect(slice()).toBe('FooBar');
-      });
 
       it('should select from a v4 selector', () => {
         // Arrange

--- a/packages/store/tests/selector.spec.ts
+++ b/packages/store/tests/selector.spec.ts
@@ -28,6 +28,11 @@ describe('Selector', () => {
   @Injectable()
   class MyState {
     @Selector()
+    static getState(state: MyStateModel) {
+      return state;
+    }
+
+    @Selector()
     static foo(state: MyStateModel) {
       return state.foo;
     }
@@ -79,37 +84,6 @@ describe('Selector', () => {
       const store: Store = TestBed.inject(Store);
       const slice = store.selectSnapshot(MetaSelector.foo);
       expect(slice).toBe('Hello');
-    });
-
-    it('should still be usable as a function', () => {
-      TestBed.configureTestingModule({
-        imports: [NgxsModule.forRoot([MyState])]
-      });
-
-      const store: Store = TestBed.inject(Store);
-      const myState = store.selectSnapshot<MyStateModel>(MyState);
-      const slice = MyState.foo(myState);
-      expect(slice).toBe('Hello');
-    });
-
-    it('should select multiples', () => {
-      TestBed.configureTestingModule({
-        imports: [NgxsModule.forRoot([MyState, MyState2])]
-      });
-
-      const store: Store = TestBed.inject(Store);
-      const slice = store.selectSnapshot(MyState2.foo);
-      expect(slice).toBe('HelloHello');
-    });
-
-    it('should select multiples from self and others', () => {
-      TestBed.configureTestingModule({
-        imports: [NgxsModule.forRoot([MyState, MyState2])]
-      });
-
-      const store: Store = TestBed.inject(Store);
-      const slice = store.selectSnapshot(MyState2.fooBar);
-      expect(slice).toBe('HelloHelloWorld');
     });
 
     it('context should be defined inside selector', () => {
@@ -507,11 +481,6 @@ describe('Selector', () => {
           return state.bar;
         }
 
-        @Selector([MyStateV3.bar])
-        static v3StyleSelector_FooAndBar(state: MyStateModel, bar: string) {
-          return state.foo + bar;
-        }
-
         @Selector([MyStateV3.foo, MyStateV3.bar])
         @SelectorOptions({ injectContainerState: false })
         static v4StyleSelector_FooAndBar(foo: string, bar: string) {
@@ -530,15 +499,6 @@ describe('Selector', () => {
           throw new Error('This is a forced error');
         }
       }
-
-      it('should select from a v3 selector', () => {
-        // Arrange
-        const store = setupStore([MyStateV3]);
-        // Act
-        const slice = store.selectSnapshot(MyStateV3.v3StyleSelector_FooAndBar);
-        // Assert
-        expect(slice).toBe('FooBar');
-      });
 
       it('should select from a v4 selector', () => {
         // Arrange
@@ -631,7 +591,7 @@ describe('Selector', () => {
       });
 
       const store: Store = TestBed.inject(Store);
-      const myState = store.selectSnapshot<MyStateModel>(MyState);
+      const myState = store.selectSnapshot<MyStateModel>(MyState.getState);
       const selector = createSelector([MyState], (state: MyStateModel) => state.foo);
       const slice: string = selector(myState);
       expect(slice).toBe('Hello');
@@ -731,6 +691,11 @@ describe('Selector', () => {
     @Injectable()
     class TasksState {
       @Selector()
+      static getTasks(state: number[]) {
+        return state;
+      }
+
+      @Selector()
       static reverse(state: number[]): number[] {
         return state.reverse();
       }
@@ -748,7 +713,7 @@ describe('Selector', () => {
       const store = TestBed.inject(Store);
       store.reset({ tasks: [1, 2, 3, 4] });
 
-      const tasks: number[] = store.selectSnapshot(TasksState);
+      const tasks: number[] = store.selectSnapshot(TasksState.getTasks);
       const reverse: number[] = store.selectSnapshot(TasksState.reverse);
       expect(tasks).toEqual([4, 3, 2, 1]);
       expect(reverse).toEqual([4, 3, 2, 1]);
@@ -767,7 +732,7 @@ describe('Selector', () => {
       const store = TestBed.inject(Store);
       store.reset({ tasks: [1, 2, 3, 4] });
 
-      const tasks: number[] = store.selectSnapshot(TasksState);
+      const tasks: number[] = store.selectSnapshot(TasksState.getTasks);
       expect(tasks).toEqual([1, 2, 3, 4]);
 
       try {
@@ -787,6 +752,11 @@ describe('Selector', () => {
     })
     @Injectable()
     class NumberListState {
+      @Selector()
+      static getNumberList(state: number[]) {
+        return state;
+      }
+
       @Selector()
       static reverse(state: number[]): number[] {
         return state.reverse();
@@ -810,7 +780,9 @@ describe('Selector', () => {
 
       let snapshot: number[] = [];
 
-      store.select(NumberListState).subscribe((state: number[]) => (snapshot = state));
+      store
+        .select(NumberListState.getNumberList)
+        .subscribe((state: number[]) => (snapshot = state));
       expect(snapshot).toEqual([1, 2, 3, 4]);
 
       store.select(NumberListState.reverse).subscribe(

--- a/packages/store/tests/zone.spec.ts
+++ b/packages/store/tests/zone.spec.ts
@@ -113,6 +113,7 @@ describe('zone', () => {
   it('"select" should be performed outside Angular zone', () => {
     let ticks = 0;
 
+    @Injectable()
     class MockApplicationRef extends ApplicationRef {
       public tick(): void {
         ticks++;


### PR DESCRIPTION
This commit updates the `injectContainerState` configuration property to default to false. This change will affect the behavior of `@Selector()`s, as they will no longer receive the container state as the first argument if there are any selectors in the list.

The current behavior is as follows:

```ts
@State()
class NotificationsState {
  @Selector()
  static getNotifications(state: NotificationsStateModel) {
    return state.notifications;
  }

  @Selector([NotificationsState.getNotifications])
  static getUnreadTotal(state: NotificationsStateModel, notifications: Notification[]) {
    return notifications.reduce(() => ..., 0);
  }
}
```

You might notice that the `getUnreadTotal` selector will have the notifications state injected as the first argument before accessing the notifications list.

This update has been made to prevent injecting the container state as the first argument if there are any selectors provided in the `@Selector([...])` decorator. However, this change does not affect the `@Selector()` decorator with no arguments.