### PR TITLE
docs: update `concepts/select.md`

### DIFF
--- a/docs/concepts/actions.md
+++ b/docs/concepts/actions.md
@@ -60,6 +60,7 @@ Here we have an action that should trigger feeding a zebra with hay.
 ```ts
 export class FeedZebra {
   static readonly type = '[Zoo] Feed Zebra';
+
   constructor(
     public name: string,
     public hayAmount: number
@@ -121,11 +122,13 @@ Don't suffix your actions:
 ```ts
 export class AddTodo {
   static readonly type = '[Todo] Add';
+
   constructor(public payload: any) {}
 }
 
 export class EditTodo {
   static readonly type = '[Todo] Edit';
+
   constructor(public payload: any) {}
 }
 
@@ -135,6 +138,7 @@ export class FetchAllTodos {
 
 export class DeleteTodo {
   static readonly type = '[Todo] Delete';
+
   constructor(public id: number) {}
 }
 ```
@@ -143,23 +147,28 @@ here we group similar actions into the `Todo` namespace.
 In this case just import namespace instead of multiple action classes in same file.
 
 ```ts
-export namespace Todo {
+const ACTION_SCOPE = '[Todo]';
+
+export namespace TodoActions {
   export class Add {
-    static readonly type = '[Todo] Add';
+    static readonly type = `${ACTION_SCOPE} Add`;
+
     constructor(public payload: any) {}
   }
 
   export class Edit {
-    static readonly type = '[Todo] Edit';
+    static readonly type = `${ACTION_SCOPE} Edit`;
+
     constructor(public payload: any) {}
   }
 
   export class FetchAll {
-    static readonly type = '[Todo] Fetch All';
+    static readonly type = `${ACTION_SCOPE} Fetch All`;
   }
 
   export class Delete {
-    static readonly type = '[Todo] Delete';
+    static readonly type = `${ACTION_SCOPE} Delete`;
+
     constructor(public id: number) {}
   }
 }

--- a/docs/concepts/select.md
+++ b/docs/concepts/select.md
@@ -133,8 +133,10 @@ These options can also be provided through the `@SelectorOptions` decorator at a
 
 #### `injectContainerState`
 
-- `true` will cause all selectors defined within a state class to receive the container class' state model as their first parameter. As a result every selector would be re-evaluated after any change to that state.
-- `false` will prevent the injection of the container state model as the first parameter of a selector method (defined within a state class) that joins to other selectors for its parameters.
+> ⚠️ This property is only useful for migrating codebases from NGXS v3 to v4. It is not recommended to keep it set to `true`. In v4 and newer versions, users should have no reason to set this property explicitly.
+
+- `true` will cause all selectors defined within a state class to receive the container class' state model as their first parameter. As a result every selector would be re-evaluated after any change to that state (**this should only be used during migrations**).
+- `false` will prevent the injection of the container state model as the first parameter of a selector method (defined within a state class) that joins to other selectors for its parameters (**this is the default value now**).
 
 ### Memoized Selectors with Arguments
 


### PR DESCRIPTION
This commit completely updates the `select.md` to adopt a signal-first approach, as previously, all examples were based on observables. Most developers transitioning to NGXS would prefer to see examples using signals, as this concept is being heavily promoted by Angular.

Additionally, this commit removes examples using the `@Select` decorator since it's not usable and has critical issues due to its lack of integration with Angular's dependency injection.

Furthermore, the "special considerations" block has been removed, as the issues it addressed are no longer a concern.