### PR TITLE
refactor(store): rely on `ngDevMode` to be always defined

### DIFF
--- a/packages/router-plugin/internals/src/symbols.ts
+++ b/packages/router-plugin/internals/src/symbols.ts
@@ -2,7 +2,7 @@ import { InjectionToken } from '@angular/core';
 
 declare const ngDevMode: boolean;
 
-const NG_DEV_MODE = typeof ngDevMode === 'undefined' || ngDevMode;
+const NG_DEV_MODE = typeof ngDevMode !== 'undefined' && ngDevMode;
 
 export const enum NavigationActionTiming {
   PreActivation = 1,

--- a/packages/storage-plugin/internals/src/symbols.ts
+++ b/packages/storage-plugin/internals/src/symbols.ts
@@ -10,7 +10,7 @@ export const ɵDEFAULT_STATE_KEY = '@@STATE';
 
 declare const ngDevMode: boolean;
 
-const NG_DEV_MODE = typeof ngDevMode === 'undefined' || ngDevMode;
+const NG_DEV_MODE = typeof ngDevMode !== 'undefined' && ngDevMode;
 
 export const enum StorageOption {
   LocalStorage,

--- a/packages/storage-plugin/src/engines.ts
+++ b/packages/storage-plugin/src/engines.ts
@@ -4,7 +4,7 @@ import { StorageEngine } from '@ngxs/storage-plugin/internals';
 
 declare const ngDevMode: boolean;
 
-const NG_DEV_MODE = typeof ngDevMode === 'undefined' || ngDevMode;
+const NG_DEV_MODE = typeof ngDevMode !== 'undefined' && ngDevMode;
 
 export const LOCAL_STORAGE_ENGINE = new InjectionToken<StorageEngine | null>(
   NG_DEV_MODE ? 'LOCAL_STORAGE_ENGINE' : '',

--- a/packages/storage-plugin/src/storage.plugin.ts
+++ b/packages/storage-plugin/src/storage.plugin.ts
@@ -23,7 +23,7 @@ import { ɵNgxsStoragePluginKeysManager } from './keys-manager';
 
 declare const ngDevMode: boolean;
 
-const NG_DEV_MODE = typeof ngDevMode === 'undefined' || ngDevMode;
+const NG_DEV_MODE = typeof ngDevMode !== 'undefined' && ngDevMode;
 
 @Injectable()
 export class NgxsStoragePlugin implements NgxsPlugin {

--- a/packages/store/internals/src/initial-state.ts
+++ b/packages/store/internals/src/initial-state.ts
@@ -4,7 +4,7 @@ import { ɵPlainObject } from './symbols';
 
 declare const ngDevMode: boolean;
 
-const NG_DEV_MODE = typeof ngDevMode === 'undefined' || ngDevMode;
+const NG_DEV_MODE = typeof ngDevMode !== 'undefined' && ngDevMode;
 
 export class ɵInitialState {
   private static _value: ɵPlainObject = {};

--- a/packages/store/internals/src/internal-tokens.ts
+++ b/packages/store/internals/src/internal-tokens.ts
@@ -2,7 +2,7 @@ import { InjectionToken } from '@angular/core';
 
 declare const ngDevMode: boolean;
 
-const NG_DEV_MODE = typeof ngDevMode === 'undefined' || ngDevMode;
+const NG_DEV_MODE = typeof ngDevMode !== 'undefined' && ngDevMode;
 
 // These tokens are internal and can change at any point.
 

--- a/packages/store/plugins/src/symbols.ts
+++ b/packages/store/plugins/src/symbols.ts
@@ -2,7 +2,7 @@ import { InjectionToken } from '@angular/core';
 
 declare const ngDevMode: boolean;
 
-const NG_DEV_MODE = typeof ngDevMode === 'undefined' || ngDevMode;
+const NG_DEV_MODE = typeof ngDevMode !== 'undefined' && ngDevMode;
 
 // The injection token is used to resolve to custom NGXS plugins provided
 // at the root level through either `{provide}` scheme or `withNgxsPlugin`.

--- a/packages/store/src/decorators/action.ts
+++ b/packages/store/src/decorators/action.ts
@@ -11,9 +11,7 @@ export function Action(
   options?: ɵActionOptions
 ): MethodDecorator {
   return (target: any, name: string | symbol): void => {
-    // Caretaker note: we have still left the `typeof` condition in order to avoid
-    // creating a breaking change for projects that still use the View Engine.
-    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
       const isStaticMethod = target.hasOwnProperty('prototype');
 
       if (isStaticMethod) {

--- a/packages/store/src/decorators/selector/selector.ts
+++ b/packages/store/src/decorators/selector/selector.ts
@@ -23,9 +23,7 @@ export function Selector<T extends SelectorDef<any>>(selectors?: T[]): SelectorT
 
     const originalFn = descriptor?.value;
 
-    // Caretaker note: we have still left the `typeof` condition in order to avoid
-    // creating a breaking change for projects that still use the View Engine.
-    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
       if (originalFn && typeof originalFn !== 'function') {
         throwSelectorDecoratorError();
       }

--- a/packages/store/src/decorators/state.ts
+++ b/packages/store/src/decorators/state.ts
@@ -48,7 +48,7 @@ function mutateMetaData<T>(params: MutateMetaOptions<T>): void {
   const stateName: string | null =
     typeof name === 'string' ? name : (name && name.getName()) || null;
 
-  if (typeof ngDevMode === 'undefined' || ngDevMode) {
+  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
     ensureStateNameIsValid(stateName);
   }
 

--- a/packages/store/src/dev-features/symbols.ts
+++ b/packages/store/src/dev-features/symbols.ts
@@ -2,7 +2,7 @@ import { InjectionToken } from '@angular/core';
 
 import { ActionType } from '../actions/symbols';
 
-const NG_DEV_MODE = typeof ngDevMode === 'undefined' || ngDevMode;
+const NG_DEV_MODE = typeof ngDevMode !== 'undefined' && ngDevMode;
 
 export interface NgxsDevelopmentOptions {
   // This allows setting only `true` because there's no reason to set `false`.

--- a/packages/store/src/execution/dispatch-outside-zone-ngxs-execution-strategy.ts
+++ b/packages/store/src/execution/dispatch-outside-zone-ngxs-execution-strategy.ts
@@ -10,9 +10,7 @@ export class DispatchOutsideZoneNgxsExecutionStrategy implements NgxsExecutionSt
     private _ngZone: NgZone,
     @Inject(PLATFORM_ID) private _platformId: string
   ) {
-    // Caretaker note: we have still left the `typeof` condition in order to avoid
-    // creating a breaking change for projects that still use the View Engine.
-    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
       verifyZoneIsNotNooped(_ngZone);
     }
   }

--- a/packages/store/src/execution/symbols.ts
+++ b/packages/store/src/execution/symbols.ts
@@ -3,7 +3,7 @@ import { InjectionToken, inject, INJECTOR, Type, ɵglobal } from '@angular/core'
 import { NoopNgxsExecutionStrategy } from './noop-ngxs-execution-strategy';
 import { DispatchOutsideZoneNgxsExecutionStrategy } from './dispatch-outside-zone-ngxs-execution-strategy';
 
-const NG_DEV_MODE = typeof ngDevMode === 'undefined' || ngDevMode;
+const NG_DEV_MODE = typeof ngDevMode !== 'undefined' && ngDevMode;
 
 /**
  * Consumers have the option to utilize the execution strategy provided by

--- a/packages/store/src/internal/dispatcher.ts
+++ b/packages/store/src/internal/dispatcher.ts
@@ -57,7 +57,7 @@ export class InternalDispatcher {
   }
 
   private dispatchSingle(action: any): Observable<void> {
-    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
       const type: string | undefined = getActionTypeFromInstance(action);
       if (!type) {
         const error = new Error(

--- a/packages/store/src/internal/internals.ts
+++ b/packages/store/src/internal/internals.ts
@@ -12,7 +12,7 @@ import { NgxsConfig } from '../symbols';
 
 declare const ngDevMode: boolean;
 
-const NG_DEV_MODE = typeof ngDevMode === 'undefined' || ngDevMode;
+const NG_DEV_MODE = typeof ngDevMode !== 'undefined' && ngDevMode;
 
 export type StateKeyGraph = ɵPlainObjectOf<string[]>;
 export type StatesByName = ɵPlainObjectOf<ɵStateClassInternal>;
@@ -140,9 +140,7 @@ export function buildGraph(stateClasses: ɵStateClassInternal[]): StateKeyGraph 
   const findName = (stateClass: ɵStateClassInternal) => {
     const meta = stateClasses.find(g => g === stateClass);
 
-    // Caretaker note: we have still left the `typeof` condition in order to avoid
-    // creating a breaking change for projects that still use the View Engine.
-    if ((typeof ngDevMode === 'undefined' || ngDevMode) && !meta) {
+    if (NG_DEV_MODE && !meta) {
       throw new Error(
         `Child state not found: ${stateClass}. \r\nYou may have forgotten to add states to module`
       );
@@ -260,9 +258,7 @@ export function topologicalSort(graph: StateKeyGraph): string[] {
     visited[name] = true;
 
     graph[name].forEach((dep: string) => {
-      // Caretaker note: we have still left the `typeof` condition in order to avoid
-      // creating a breaking change for projects that still use the View Engine.
-      if ((typeof ngDevMode === 'undefined' || ngDevMode) && ancestors.indexOf(dep) >= 0) {
+      if (NG_DEV_MODE && ancestors.indexOf(dep) >= 0) {
         throw new Error(
           `Circular dependency '${dep}' is required by '${name}': ${ancestors.join(' -> ')}`
         );

--- a/packages/store/src/internal/lifecycle-state-manager.ts
+++ b/packages/store/src/internal/lifecycle-state-manager.ts
@@ -20,7 +20,7 @@ import { MappedStore, StatesAndDefaults } from './internals';
 import { NgxsLifeCycle, NgxsSimpleChange, StateContext } from '../symbols';
 import { getInvalidInitializationOrderMessage } from '../configs/messages.config';
 
-const NG_DEV_MODE = typeof ngDevMode === 'undefined' || ngDevMode;
+const NG_DEV_MODE = typeof ngDevMode !== 'undefined' && ngDevMode;
 
 @Injectable({ providedIn: 'root' })
 export class LifecycleStateManager implements OnDestroy {

--- a/packages/store/src/internal/state-factory.ts
+++ b/packages/store/src/internal/state-factory.ts
@@ -60,7 +60,7 @@ import { ensureStateNameIsUnique, ensureStatesAreDecorated } from '../utils/stor
 import { ensureStateClassIsInjectable } from '../ivy/ivy-enabled-in-dev-mode';
 import { NgxsUnhandledActionsLogger } from '../dev-features/ngxs-unhandled-actions-logger';
 
-const NG_DEV_MODE = typeof ngDevMode === 'undefined' || ngDevMode;
+const NG_DEV_MODE = typeof ngDevMode !== 'undefined' && ngDevMode;
 
 function cloneDefaults(defaults: any): any {
   let value = defaults === undefined ? {} : defaults;

--- a/packages/store/src/internal/state-operations.ts
+++ b/packages/store/src/internal/state-operations.ts
@@ -27,7 +27,7 @@ export class InternalStateOperations {
       dispatch: (actionOrActions: any | any[]) => this._dispatcher.dispatch(actionOrActions)
     };
 
-    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
       return this._config.developmentMode
         ? ensureStateAndActionsAreImmutable(rootStateOperations)
         : rootStateOperations;

--- a/packages/store/src/internal/state-operators.ts
+++ b/packages/store/src/internal/state-operators.ts
@@ -6,7 +6,7 @@ import { ExistingState, StateOperator } from '@ngxs/store/operators';
 
 export function simplePatch<T>(value: Partial<T>): StateOperator<T> {
   return (existingState: ExistingState<T>) => {
-    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
       if (Array.isArray(value)) {
         throwPatchingArrayError();
       } else if (typeof value !== 'object') {

--- a/packages/store/src/selectors/create-model-selector.ts
+++ b/packages/store/src/selectors/create-model-selector.ts
@@ -16,7 +16,7 @@ export function createModelSelector<T extends SelectorMap>(selectorMap: T): Mode
   const selectorKeys = Object.keys(selectorMap);
   const selectors = Object.values(selectorMap);
 
-  if (typeof ngDevMode === 'undefined' || ngDevMode) {
+  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
     ensureValidSelectorMap<T>({
       prefix: '[createModelSelector]',
       selectorMap,

--- a/packages/store/src/selectors/create-pick-selector.ts
+++ b/packages/store/src/selectors/create-pick-selector.ts
@@ -10,7 +10,7 @@ export function createPickSelector<TModel, Keys extends (keyof TModel)[]>(
   selector: TypedSelector<TModel>,
   keys: [...Keys]
 ) {
-  if (typeof ngDevMode === 'undefined' || ngDevMode) {
+  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
     ensureValidSelector(selector, { prefix: '[createPickSelector]' });
   }
   const validKeys = keys.filter(Boolean);

--- a/packages/store/src/selectors/create-property-selectors.ts
+++ b/packages/store/src/selectors/create-property-selectors.ts
@@ -11,7 +11,7 @@ export type PropertySelectors<TModel> = {
 export function createPropertySelectors<TModel>(
   parentSelector: SelectorDef<TModel>
 ): PropertySelectors<TModel> {
-  if (typeof ngDevMode === 'undefined' || ngDevMode) {
+  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
     ensureValidSelector(parentSelector, {
       prefix: '[createPropertySelectors]',
       noun: 'parent selector'

--- a/packages/store/src/standalone-features/initializers.ts
+++ b/packages/store/src/standalone-features/initializers.ts
@@ -10,7 +10,7 @@ import { SelectFactory } from '../decorators/select/select-factory';
 import { InternalStateOperations } from '../internal/state-operations';
 import { LifecycleStateManager } from '../internal/lifecycle-state-manager';
 
-const NG_DEV_MODE = typeof ngDevMode === 'undefined' || ngDevMode;
+const NG_DEV_MODE = typeof ngDevMode !== 'undefined' && ngDevMode;
 
 /**
  * This function is shared by both NgModule and standalone features.

--- a/packages/store/src/symbols.ts
+++ b/packages/store/src/symbols.ts
@@ -7,7 +7,7 @@ import { ɵSharedSelectorOptions, ɵStateClass } from '@ngxs/store/internals';
 import { NgxsExecutionStrategy } from './execution/symbols';
 import { DispatchOutsideZoneNgxsExecutionStrategy } from './execution/dispatch-outside-zone-ngxs-execution-strategy';
 
-const NG_DEV_MODE = typeof ngDevMode === 'undefined' || ngDevMode;
+const NG_DEV_MODE = typeof ngDevMode !== 'undefined' && ngDevMode;
 
 // The injection token is used to resolve a list of states provided at
 // the root level through either `NgxsModule.forRoot` or `provideStore`.

--- a/packages/websocket-plugin/src/symbols.ts
+++ b/packages/websocket-plugin/src/symbols.ts
@@ -2,7 +2,7 @@ import { InjectionToken } from '@angular/core';
 
 declare const ngDevMode: boolean;
 
-const NG_DEV_MODE = typeof ngDevMode === 'undefined' || ngDevMode;
+const NG_DEV_MODE = typeof ngDevMode !== 'undefined' && ngDevMode;
 
 export const NGXS_WEBSOCKET_OPTIONS = new InjectionToken<NgxsWebSocketPluginOptions>(
   NG_DEV_MODE ? 'NGXS_WEBSOCKET_OPTIONS' : ''


### PR DESCRIPTION
This commit updates all `ngDevMode` conditions to remove the check for `ngDevMode` being `undefined`. We can ensure it's always defined by Angular since VE has been dropped. However, the `typeof` check is still necessary to ensure code safety, as `ngDevMode` is a global variable provided by the framework.