### PR TITLE
feat(store): export selector util types privately

### DIFF
--- a/packages/store/src/decorators/selector/selector.ts
+++ b/packages/store/src/decorators/selector/selector.ts
@@ -1,5 +1,5 @@
 import { throwSelectorDecoratorError } from '../../configs/messages.config';
-import { SelectorDef } from '../../selectors';
+import { ɵSelectorDef } from '../../selectors';
 import { createSelector } from '../../selectors/create-selector';
 import { SelectorSpec, SelectorType } from './symbols';
 
@@ -11,9 +11,9 @@ export function Selector(): SelectorType<unknown>;
 /**
  * Decorator for creating a state selector from the provided selectors (and optionally the container State, depending on the applicable Selector Options).
  */
-export function Selector<T extends SelectorDef<any>>(selectors: T[]): SelectorType<T>;
+export function Selector<T extends ɵSelectorDef<any>>(selectors: T[]): SelectorType<T>;
 
-export function Selector<T extends SelectorDef<any>>(selectors?: T[]): SelectorType<T> {
+export function Selector<T extends ɵSelectorDef<any>>(selectors?: T[]): SelectorType<T> {
   return <U>(
     target: any,
     key: string | symbol,

--- a/packages/store/src/private_api.ts
+++ b/packages/store/src/private_api.ts
@@ -1,2 +1,4 @@
 export { NgxsRootModule as ɵNgxsRootModule } from './modules/ngxs-root.module';
 export { NgxsFeatureModule as ɵNgxsFeatureModule } from './modules/ngxs-feature.module';
+
+export * from './selectors/private_api';

--- a/packages/store/src/selectors/create-property-selectors.ts
+++ b/packages/store/src/selectors/create-property-selectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from './create-selector';
 import { ensureValidSelector } from './selector-checks.util';
-import { SelectorDef } from './selector-types.util';
+import { ɵSelectorDef } from './selector-types.util';
 
 export type PropertySelectors<TModel> = {
   [P in keyof NonNullable<TModel>]-?: (
@@ -9,7 +9,7 @@ export type PropertySelectors<TModel> = {
 };
 
 export function createPropertySelectors<TModel>(
-  parentSelector: SelectorDef<TModel>
+  parentSelector: ɵSelectorDef<TModel>
 ): PropertySelectors<TModel> {
   if (typeof ngDevMode !== 'undefined' && ngDevMode) {
     ensureValidSelector(parentSelector, {

--- a/packages/store/src/selectors/create-selector.ts
+++ b/packages/store/src/selectors/create-selector.ts
@@ -2,9 +2,9 @@ import { CreationMetadata } from './selector-models';
 import { setupSelectorMetadata } from './selector-metadata';
 import { createMemoizedSelectorFn, createRootSelectorFactory } from './selector-utils';
 
-import { SelectorDef, SelectorReturnType } from './selector-types.util';
+import { ɵSelectorDef, ɵSelectorReturnType } from './selector-types.util';
 
-type SelectorArg = SelectorDef<any>;
+type SelectorArg = ɵSelectorDef<any>;
 
 /**
  * Function for creating a selector
@@ -14,7 +14,7 @@ type SelectorArg = SelectorDef<any>;
  */
 export function createSelector<
   S1 extends SelectorArg,
-  TProjector extends (s1: SelectorReturnType<S1>) => any
+  TProjector extends (s1: ɵSelectorReturnType<S1>) => any
 >(
   selectors: [S1],
   projector: TProjector,
@@ -24,7 +24,7 @@ export function createSelector<
 export function createSelector<
   S1 extends SelectorArg,
   S2 extends SelectorArg,
-  TProjector extends (s1: SelectorReturnType<S1>, s2: SelectorReturnType<S2>) => any
+  TProjector extends (s1: ɵSelectorReturnType<S1>, s2: ɵSelectorReturnType<S2>) => any
 >(
   selectors: [S1, S2],
   projector: TProjector,
@@ -36,9 +36,9 @@ export function createSelector<
   S2 extends SelectorArg,
   S3 extends SelectorArg,
   TProjector extends (
-    s1: SelectorReturnType<S1>,
-    s2: SelectorReturnType<S2>,
-    s3: SelectorReturnType<S3>
+    s1: ɵSelectorReturnType<S1>,
+    s2: ɵSelectorReturnType<S2>,
+    s3: ɵSelectorReturnType<S3>
   ) => any
 >(
   selectors: [S1, S2, S3],
@@ -52,10 +52,10 @@ export function createSelector<
   S3 extends SelectorArg,
   S4 extends SelectorArg,
   TProjector extends (
-    s1: SelectorReturnType<S1>,
-    s2: SelectorReturnType<S2>,
-    s3: SelectorReturnType<S3>,
-    s4: SelectorReturnType<S4>
+    s1: ɵSelectorReturnType<S1>,
+    s2: ɵSelectorReturnType<S2>,
+    s3: ɵSelectorReturnType<S3>,
+    s4: ɵSelectorReturnType<S4>
   ) => any
 >(
   selectors: [S1, S2, S3, S4],
@@ -70,11 +70,11 @@ export function createSelector<
   S4 extends SelectorArg,
   S5 extends SelectorArg,
   TProjector extends (
-    s1: SelectorReturnType<S1>,
-    s2: SelectorReturnType<S2>,
-    s3: SelectorReturnType<S3>,
-    s4: SelectorReturnType<S4>,
-    s5: SelectorReturnType<S5>
+    s1: ɵSelectorReturnType<S1>,
+    s2: ɵSelectorReturnType<S2>,
+    s3: ɵSelectorReturnType<S3>,
+    s4: ɵSelectorReturnType<S4>,
+    s5: ɵSelectorReturnType<S5>
   ) => any
 >(
   selectors: [S1, S2, S3, S4, S5],
@@ -90,12 +90,12 @@ export function createSelector<
   S5 extends SelectorArg,
   S6 extends SelectorArg,
   TProjector extends (
-    s1: SelectorReturnType<S1>,
-    s2: SelectorReturnType<S2>,
-    s3: SelectorReturnType<S3>,
-    s4: SelectorReturnType<S4>,
-    s5: SelectorReturnType<S5>,
-    s6: SelectorReturnType<S6>
+    s1: ɵSelectorReturnType<S1>,
+    s2: ɵSelectorReturnType<S2>,
+    s3: ɵSelectorReturnType<S3>,
+    s4: ɵSelectorReturnType<S4>,
+    s5: ɵSelectorReturnType<S5>,
+    s6: ɵSelectorReturnType<S6>
   ) => any
 >(
   selectors: [S1, S2, S3, S4, S5, S6],
@@ -112,13 +112,13 @@ export function createSelector<
   S6 extends SelectorArg,
   S7 extends SelectorArg,
   TProjector extends (
-    s1: SelectorReturnType<S1>,
-    s2: SelectorReturnType<S2>,
-    s3: SelectorReturnType<S3>,
-    s4: SelectorReturnType<S4>,
-    s5: SelectorReturnType<S5>,
-    s6: SelectorReturnType<S6>,
-    s7: SelectorReturnType<S7>
+    s1: ɵSelectorReturnType<S1>,
+    s2: ɵSelectorReturnType<S2>,
+    s3: ɵSelectorReturnType<S3>,
+    s4: ɵSelectorReturnType<S4>,
+    s5: ɵSelectorReturnType<S5>,
+    s6: ɵSelectorReturnType<S6>,
+    s7: ɵSelectorReturnType<S7>
   ) => any
 >(
   selectors: [S1, S2, S3, S4, S5, S6, S7],
@@ -136,14 +136,14 @@ export function createSelector<
   S7 extends SelectorArg,
   S8 extends SelectorArg,
   TProjector extends (
-    s1: SelectorReturnType<S1>,
-    s2: SelectorReturnType<S2>,
-    s3: SelectorReturnType<S3>,
-    s4: SelectorReturnType<S4>,
-    s5: SelectorReturnType<S5>,
-    s6: SelectorReturnType<S6>,
-    s7: SelectorReturnType<S7>,
-    s8: SelectorReturnType<S8>
+    s1: ɵSelectorReturnType<S1>,
+    s2: ɵSelectorReturnType<S2>,
+    s3: ɵSelectorReturnType<S3>,
+    s4: ɵSelectorReturnType<S4>,
+    s5: ɵSelectorReturnType<S5>,
+    s6: ɵSelectorReturnType<S6>,
+    s7: ɵSelectorReturnType<S7>,
+    s8: ɵSelectorReturnType<S8>
   ) => any
 >(
   selectors: [S1, S2, S3, S4, S5, S6, S7, S8],

--- a/packages/store/src/selectors/private_api.ts
+++ b/packages/store/src/selectors/private_api.ts
@@ -1,0 +1,12 @@
+/**
+ * These types are exported privately for developers who work on advanced
+ * utilities and may need to use these types externally. For instance,
+ * they may have a function that accepts selector functions and returns
+ * signals with the type corresponding to the return type of those selectors.
+ */
+export {
+  ɵSelectorFunc,
+  ɵStateSelector,
+  ɵSelectorDef,
+  ɵSelectorReturnType
+} from './selector-types.util';

--- a/packages/store/src/selectors/selector-checks.util.ts
+++ b/packages/store/src/selectors/selector-checks.util.ts
@@ -1,9 +1,9 @@
 import { ɵgetSelectorMetadata, ɵgetStoreMetadata } from '@ngxs/store/internals';
 
-import { SelectorDef } from './selector-types.util';
+import { ɵSelectorDef } from './selector-types.util';
 
 export function ensureValidSelector(
-  selector: SelectorDef<any>,
+  selector: ɵSelectorDef<any>,
   context: { prefix?: string; noun?: string } = {}
 ) {
   const noun = context.noun || 'selector';

--- a/packages/store/src/selectors/selector-types.util.ts
+++ b/packages/store/src/selectors/selector-types.util.ts
@@ -1,17 +1,17 @@
 import { ɵStateClass, StateToken } from '@ngxs/store/internals';
 
-export type SelectorFunc<TModel> = (...arg: any[]) => TModel;
+export type ɵSelectorFunc<TModel> = (...arg: any[]) => TModel;
 
-export type TypedSelector<TModel> = StateToken<TModel> | SelectorFunc<TModel>;
+export type TypedSelector<TModel> = StateToken<TModel> | ɵSelectorFunc<TModel>;
 
-export type StateSelector = ɵStateClass<any>;
+export type ɵStateSelector = ɵStateClass<any>;
 
-export type SelectorDef<TModel> = StateSelector | TypedSelector<TModel>;
+export type ɵSelectorDef<TModel> = ɵStateSelector | TypedSelector<TModel>;
 
-export type SelectorReturnType<T extends SelectorDef<any>> =
+export type ɵSelectorReturnType<T extends ɵSelectorDef<any>> =
   T extends StateToken<infer R1>
     ? R1
-    : T extends SelectorFunc<infer R2>
+    : T extends ɵSelectorFunc<infer R2>
       ? R2
       : T extends ɵStateClass<any>
         ? any /* (Block comment to stop prettier breaking the comment below)

--- a/packages/store/types/tests/create-selector.lint.ts
+++ b/packages/store/types/tests/create-selector.lint.ts
@@ -60,7 +60,7 @@ describe('[TEST]: createSelector', () => {
     assertType(() => store.selectSnapshot(TodoState.todoB())); // $ExpectType any
     assertType(() => store.selectSnapshot(TodoState.todoB)); // $ExpectType (s1: any) => any
     assertType(() => store.selectSnapshot(TodoState.todoC())); // $ExpectType any
-    assertType(() => store.selectSnapshot(TodoState.todoC)); // $ExpectType (s1: SelectorReturnType<S1>) => any
+    assertType(() => store.selectSnapshot(TodoState.todoC)); // $ExpectType (s1: ɵSelectorReturnType<S1>) => any
     assertType(() => store.selectSnapshot(TodoState.todoD())); // $ExpectType Observable<number>
     assertType(() => store.selectSnapshot(TodoState.todoD)); // $ExpectType (state: Observable<number>) => Observable<number>
   });


### PR DESCRIPTION
This commit privately exports `ɵSelectorFunc`, `ɵStateSelector`, `ɵSelectorDef`, and `ɵSelectorReturnType`, as they might be utilized by developers working on advanced utilities who need access to these types externally. For example, they may create a function that accepts selector functions and returns signals with types corresponding to the return types of those selectors.
