### PR TITLE
docs: section headings as uppercase

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -5,23 +5,23 @@
 
 ## INTRODUCTION
 
-- [Why](introduction/why.md)
-- [Installation](introduction/installation.md)
-- [Starter Kit](introduction/starter-kit.md)
-- [Schematics](introduction/schematics.md)
+- [WHY](introduction/why.md)
+- [INSTALLATION](introduction/installation.md)
+- [STARTER KIT](introduction/starter-kit.md)
+- [SCHEMATICS](introduction/schematics.md)
 
 ## CONCEPTS
 
-- [Store](concepts/store/README.md)
+- [STORE](concepts/store/README.md)
   - [Store Options](concepts/store/options.md)
   - [Error Handling](concepts/store/error-handling.md)
   - [Meta Reducers](concepts/store/meta-reducer.md)
-- [Actions](concepts/actions/README.md)
+- [ACTIONS](concepts/actions/README.md)
   - [Actions Life Cycle](concepts/actions/actions-life-cycle.md)
   - [Action Handlers](concepts/actions/action-handlers.md)
   - [Cancellation](concepts/actions/cancellation.md)
   - [Monitoring Unhandled Actions](concepts/actions/monitoring-unhandled-actions.md)
-- [State](concepts/state/README.md)
+- [STATE](concepts/state/README.md)
   - [Life-cycle](concepts/state/life-cycle.md)
   - [Composition](concepts/state/composition.md)
   - [Lazy Loading](concepts/state/lazy.md)
@@ -32,7 +32,7 @@
   - [Sub States Deprecation](concepts/state/sub-states-deprecation.md)
   - [Immutability Helpers](concepts/state/immutability-helpers.md)
   - [Error Handling](concepts/state/error-handling.md)
-- [Select](concepts/select/README.md)
+- [SELECT](concepts/select/README.md)
   - [Mapped Sub States](concepts/select/mapped-sub-states.md)
   - [Optimizing Selectors](concepts/select/optimizing-selectors.md)
   - [Selector Utils](concepts/select/selector-utils.md)
@@ -41,8 +41,8 @@
 
 ---
 
-- [Style Guide](style-guide.md)
-- [Plugins](plugins/README.md)
+- [STYLE GUIDE](style-guide.md)
+- [PLUGINS](plugins/README.md)
   - [CLI](plugins/cli.md)
   - [Logger](plugins/logger.md)
   - [Devtools](plugins/devtools.md)
@@ -51,7 +51,7 @@
   - [Web Socket](plugins/websocket.md)
   - [Router](plugins/router.md)
   - [HMR](plugins/hmr.md)
-- [Recipes](recipes/README.md)
+- [RECIPES](recipes/README.md)
   - [Authentication](recipes/authentication.md)
   - [Caching](recipes/cache.md)
   - [Component Events from NGXS](recipes/component-events-from-ngxs.md)
@@ -63,15 +63,15 @@
 
 ## COMMUNITY & LABS
 
-- [Community](community-and-labs/community/README.md)
+- [COMMUNITY](community-and-labs/community/README.md)
   - [FAQ](community-and-labs/community/faq.md)
   - [Resources](community-and-labs/community/projects.md)
   - [Contributors](community-and-labs/community/contributors.md)
   - [Contributing](community-and-labs/community/contributing.md)
   - [Sponsors](community-and-labs/community/sponsors.md)
-- [NGXS Labs](community-and-labs/ngxs-labs/README.md)
+- [NGXS LABS](community-and-labs/ngxs-labs/README.md)
   - [Introduction](community-and-labs/ngxs-labs/intro.md)
 
 ---
 
-- [Changelog](https://github.com/ngxs/store/blob/master/CHANGELOG.md)
+- [CHANGELOG](https://github.com/ngxs/store/blob/master/CHANGELOG.md)


### PR DESCRIPTION
Following a conversation with @arturovt, I'm opening a pull request to update the section headings. I've converted them all to uppercase. 

![image](https://github.com/ngxs/store/assets/7045092/22454944-0019-48ef-8ca9-b394011e978b)
