### PR TITLE
feat(store): improve action decorator types

### DIFF
--- a/packages/router-plugin/src/router.state.ts
+++ b/packages/router-plugin/src/router.state.ts
@@ -122,12 +122,12 @@ export class RouterState implements OnDestroy {
   }
 
   @Action([
-    RouterRequest,
-    RouterNavigation,
-    RouterError,
-    RouterCancel,
-    RouterDataResolved,
-    RouterNavigated
+    RouterRequest<RouterStateSnapshot>,
+    RouterNavigation<RouterStateSnapshot>,
+    RouterError<RouterStateModel, RouterStateSnapshot>,
+    RouterCancel<RouterStateModel, RouterStateSnapshot>,
+    RouterDataResolved<RouterStateSnapshot>,
+    RouterNavigated<RouterStateSnapshot>
   ])
   angularRouterAction(
     ctx: StateContext<RouterStateModel>,

--- a/packages/store/src/decorators/action.ts
+++ b/packages/store/src/decorators/action.ts
@@ -14,9 +14,7 @@ type ActionToPayload<Action extends ActionType> =
  * Given a list of action classes, returns the union of their payloads.
  */
 type ActionsToPayload<Actions extends readonly ActionType[]> = {
-  [K in keyof Actions]: Actions[K] extends ActionDef<any, infer ActionPayload>
-    ? ActionPayload
-    : never;
+  [K in keyof Actions]: ActionToPayload<Actions[K]>;
 }[number];
 
 /**

--- a/packages/store/src/decorators/action.ts
+++ b/packages/store/src/decorators/action.ts
@@ -1,16 +1,59 @@
 import { ɵActionOptions, ɵensureStoreMetadata } from '@ngxs/store/internals';
 
-import { ActionType } from '../actions/symbols';
+import { ActionDef, ActionType } from '../actions/symbols';
 import { throwActionDecoratorError } from '../configs/messages.config';
+import { StateContext } from '../symbols';
 
 /**
- * Decorates a method with a action information.
+ * Given an action class, returns its payload.
  */
-export function Action(
-  actions: ActionType | ActionType[],
+type ActionToPayload<Action extends ActionType> =
+  Action extends ActionDef<any, infer ActionPayload> ? ActionPayload : never;
+
+/**
+ * Given a list of action classes, returns the union of their payloads.
+ */
+type ActionsToPayload<Actions extends readonly ActionType[]> = {
+  [K in keyof Actions]: Actions[K] extends ActionDef<any, infer ActionPayload>
+    ? ActionPayload
+    : never;
+}[number];
+
+/**
+ * Given an action class or a list of action classes, returns the union of their payloads.
+ */
+type ActionOrActionsToPayload<ActionOrActions> = ActionOrActions extends ActionType
+  ? ActionToPayload<ActionOrActions>
+  : ActionOrActions extends ActionType[]
+    ? ActionsToPayload<ActionOrActions>
+    : never;
+
+/**
+ * Describes what methods can be decorated with an `@Action` decorator that has been passed the given action(s).
+ */
+type HandlerTypedPropertyDescriptor<ActionOrActions> =
+  | TypedPropertyDescriptor<() => any>
+  | TypedPropertyDescriptor<(stateContext: StateContext<any>) => any>
+  | TypedPropertyDescriptor<
+      (
+        stateContext: StateContext<any>,
+        action: ActionOrActionsToPayload<ActionOrActions>
+      ) => any
+    >;
+
+/**
+ * Decorates a method with action information.
+ */
+export function Action<ActionOrActions extends ActionType | ActionType[]>(
+  actions: ActionOrActions,
   options?: ɵActionOptions
-): MethodDecorator {
-  return (target: any, name: string | symbol): void => {
+) {
+  return (
+    target: any,
+    name: string | symbol,
+    // This parameter ensures that the decorated method has a call signature that could be passed an instance of the given action(s).
+    _descriptor: HandlerTypedPropertyDescriptor<ActionOrActions>
+  ): void => {
     if (typeof ngDevMode !== 'undefined' && ngDevMode) {
       const isStaticMethod = target.hasOwnProperty('prototype');
 
@@ -21,11 +64,9 @@ export function Action(
 
     const meta = ɵensureStoreMetadata(target.constructor);
 
-    if (!Array.isArray(actions)) {
-      actions = [actions];
-    }
+    const actionArray = Array.isArray(actions) ? actions : [actions];
 
-    for (const action of actions) {
+    for (const action of actionArray) {
       const type = action.type;
 
       if (!meta.actions[type]) {

--- a/packages/store/src/decorators/action.ts
+++ b/packages/store/src/decorators/action.ts
@@ -42,12 +42,21 @@ type HandlerTypedPropertyDescriptor<ActionOrActions> =
     >;
 
 /**
+ * The result of a call to the `@Action()` decorator with the given action(s) as its first argument.
+ */
+type ActionDecorator<ActionOrActions extends ActionType | ActionType[]> = (
+  target: any,
+  name: string | symbol,
+  _descriptor: HandlerTypedPropertyDescriptor<ActionOrActions>
+) => void;
+
+/**
  * Decorates a method with action information.
  */
 export function Action<ActionOrActions extends ActionType | ActionType[]>(
   actions: ActionOrActions,
   options?: ɵActionOptions
-) {
+): ActionDecorator<ActionOrActions> {
   return (
     target: any,
     name: string | symbol,

--- a/packages/store/types/tests/action.lint.ts
+++ b/packages/store/types/tests/action.lint.ts
@@ -1,5 +1,6 @@
 /* tslint:disable:max-line-length */
 /// <reference types="@types/jest" />
+import { Injectable } from '@angular/core';
 import {
   ofAction,
   ofActionCanceled,
@@ -8,7 +9,10 @@ import {
   ofActionErrored,
   ofActionSuccessful,
   Actions,
-  ActionDef
+  ActionDef,
+  State,
+  Action,
+  StateContext
 } from '@ngxs/store';
 
 describe('[TEST]: Action Operator Types', () => {
@@ -390,3 +394,68 @@ describe('[TEST]: Action Operator Types', () => {
     });
   });
 });
+
+describe('[TEST]: Action Decorator Types', () => {
+  class ActionString {
+    static type = 'ACTION 1';
+    constructor(public a: string) {}
+  }
+
+  class ActionNumber {
+    static type = 'ACTION 2';
+    constructor(public c: number) {}
+  }
+
+  class ActionString2 {
+    static type = 'ACTION 3';
+    constructor(public a: string) {}
+  }
+
+  class ActionNone {
+    static type = 'ACTION 4';
+  }
+
+  it('decorator matches method', () => {
+    @State({
+      name: 'test'
+    })
+    @Injectable()
+    class TestClass {
+      @Action(ActionString)
+      noArgs() {}
+  
+      @Action(ActionString)
+      singleActionWithOnlyStateContextArg(context: StateContext<any>) {}
+  
+      @Action(ActionString)
+      singleActionWithStateContextAndPayloadArg(context: StateContext<any>, payload: ActionString) {}
+  
+      @Action([ActionString, ActionNumber])
+      multipleActionListWithStateContextAndUnionPayloadArg(context: StateContext<any>, payload: ActionNumber | ActionString) {}
+  
+      @Action([ActionString, ActionString2])
+      multipleActionListWithStateContextAndIntersectionPayloadArg(context: StateContext<any>, payload: { a: string }) {}
+    }
+  })
+
+  it('decorator does not match method', () => {
+    
+    @State({
+      name: 'test'
+    })
+    @Injectable()
+    class TestClass {
+      @Action(ActionString) // $ExpectError
+      singleActionWithStateContextAndWrongPayloadArg(context: StateContext<any>, payload: ActionNumber) {}
+
+      @Action([ActionString]) // $ExpectError
+      singleActionListWithStateContextAndWrongPayloadArg(context: StateContext<any>, payload: ActionNumber) {}
+
+      @Action([ActionString, ActionNumber]) // $ExpectError
+      multipleActionListWithStateContextAndOnePayloadArg(context: StateContext<any>, payload: ActionNumber) {}
+
+      @Action(ActionNone) // $ExpectError
+      noArgsWithPayload(context: StateContext<any>, payload: { a: string }) {}
+    }
+  })
+})

--- a/packages/store/types/tests/dispatch.lint.ts
+++ b/packages/store/types/tests/dispatch.lint.ts
@@ -28,13 +28,13 @@ describe('[TEST]: Action Types', () => {
   });
 
   it('should be correct type in action decorator', () => {
-    assertType(() => Action(UpdateState)); // $ExpectType MethodDecorator
-    assertType(() => Action(new FooAction('payload'))); // $ExpectType MethodDecorator
-    assertType(() => Action({ type: 'foo' })); // $ExpectType MethodDecorator
-    assertType(() => Action([])); // $ExpectType MethodDecorator
-    assertType(() => Action(BarAction)); // $ExpectType MethodDecorator
-    assertType(() => Action([InitState, UpdateState])); // $ExpectType MethodDecorator
-    assertType(() => Action([InitState], { cancelUncompleted: true })); // $ExpectType MethodDecorator
+    assertType(() => Action(UpdateState)); // $ExpectType ActionDecorator<typeof UpdateState>
+    assertType(() => Action(new FooAction('payload'))); // $ExpectType ActionDecorator<FooAction>
+    assertType(() => Action({ type: 'foo' })); // $ExpectType ActionDecorator<{ type: string; }>
+    assertType(() => Action([])); // $ExpectType ActionDecorator<never[]>
+    assertType(() => Action(BarAction)); // $ExpectType ActionDecorator<typeof BarAction>
+    assertType(() => Action([InitState, UpdateState])); // $ExpectType ActionDecorator<(typeof UpdateState | typeof InitState)[]>
+    assertType(() => Action([InitState], { cancelUncompleted: true })); // $ExpectType ActionDecorator<(typeof InitState)[]>
     assertType(() => Action(new BarAction('foo'))); // $ExpectError
     assertType(() => Action([{ foo: 'bar' }])); // $ExpectError
     assertType(() => Action([InitState, UpdateState], { foo: 'bar' })); // $ExpectError
@@ -50,7 +50,7 @@ describe('[TEST]: Action Types', () => {
     class MyAction {
       static type = 'MY_ACTION';
     }
-    assertType(() => Action([MyAction])); // $ExpectType MethodDecorator
+    assertType(() => Action([MyAction])); // $ExpectType ActionDecorator<(typeof MyAction)[]>
 
     class RequiredOnlyStaticType {
       type = 'anything';


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The `@Action` decorator does not enforce that the actions passed to the decorator match the payloads expected by the method it decorates.

A simple example is the following—the below action has a payload `{ value: string }` but the handler expects `{ value: number }` incorrectly. This does not produce an error.
```
class ActionString {
  static type = 'action1';
  constructor(public value: string) {}
}

...

@Action(ActionString)
handler(context: StateContext<any>, payload: { value: number }) {}
```

Issue Number: N/A

## What is the new behavior?

In the above example, a type error occurs. The case of multiple actions is also handled, requiring that a union of the payloads is accepted by the method.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

This change is likely to introduce type errors, but it is not intended to impact runtime behavior.