### PR TITLE
fix(store): decouple state signal updates from synchronous changes

### DIFF
--- a/integration/app/app.component.html
+++ b/integration/app/app.component.html
@@ -3,7 +3,13 @@
     <h3>Reactive Form</h3>
     <p>(injected$) {{ injected$ | async }}</p>
     <p>(injected() signal) {{ injected() }}</p>
-    <form [formGroup]="pizzaForm" novalidate (ngSubmit)="onSubmit()" ngxsForm="todos.pizza">
+    <form
+      [formGroup]="pizzaForm"
+      novalidate
+      (ngSubmit)="onSubmit()"
+      ngxsForm="todos.pizza"
+      [ngxsFormDebounce]="debounce"
+    >
       Toppings: <input type="text" formControlName="toppings" /> <br />
       Crust <input type="text" formControlName="crust" /> <br />
       Extras

--- a/integration/app/app.component.ts
+++ b/integration/app/app.component.ts
@@ -32,6 +32,8 @@ export class AppComponent implements OnInit {
     { name: 'olives', selected: false }
   ];
 
+  readonly debounce = 100; // Default `ngxsFormDebounce` value.
+
   pizzaForm = this._fb.group({
     toppings: [''],
     crust: [{ value: 'thin', disabled: true }],

--- a/packages/store/internals/src/state-stream.ts
+++ b/packages/store/internals/src/state-stream.ts
@@ -12,7 +12,7 @@ import { ɵOrderedBehaviorSubject } from './custom-rxjs-subjects';
 @Injectable({ providedIn: 'root' })
 export class ɵStateStream extends ɵOrderedBehaviorSubject<ɵPlainObject> implements OnDestroy {
   readonly state: Signal<ɵPlainObject | undefined> = toSignal(
-    // https://github.com/ngxs/store/pull/2189
+    // https://github.com/ngxs/store/issues/2180
     // This is explicitly piped with the `asapScheduler` to prevent synchronous
     // signal updates. Signal updates occurring within effects can lead to errors
     // stating that signal writes are not permitted in effects. This approach helps

--- a/packages/store/internals/src/state-stream.ts
+++ b/packages/store/internals/src/state-stream.ts
@@ -12,11 +12,18 @@ import { ɵOrderedBehaviorSubject } from './custom-rxjs-subjects';
 @Injectable({ providedIn: 'root' })
 export class ɵStateStream extends ɵOrderedBehaviorSubject<ɵPlainObject> implements OnDestroy {
   readonly state: Signal<ɵPlainObject | undefined> = toSignal(
+    // https://github.com/ngxs/store/pull/2189
     // This is explicitly piped with the `asapScheduler` to prevent synchronous
     // signal updates. Signal updates occurring within effects can lead to errors
     // stating that signal writes are not permitted in effects. This approach helps
     // decouple signal updates from synchronous changes, ensuring compliance with
     // constraints on updates inside effects.
+    // Developers should never rely on manually reading the signal after the state
+    // has been updated, whether synchronously or asynchronously, since the expected
+    // result may not be immediately available. To retrieve the current slice of the
+    // state, use `selectSnapshot` instead of directly accessing the signal. Signals
+    // are intended for use in templates or effects, as they always guarantee
+    // consistency with the latest signal value.
     this.pipe(observeOn(asapScheduler)),
     {
       manualCleanup: true

--- a/packages/store/tests/create-maps.spec.ts
+++ b/packages/store/tests/create-maps.spec.ts
@@ -44,12 +44,34 @@ describe('create maps', () => {
       );
 
       // Assert
-      expect(selectors.number()).toEqual(0);
       expect(Object.keys(selectors)).toEqual(['number']);
+    });
+
+    it('should receive an asynchronous update and would throw an error if read too early', async () => {
+      // Arrange
+      testSetup();
+
+      // Act
+      const selectors = runInInjectionContext(TestBed, () =>
+        createSelectMap({
+          number: NumberState.getNumberState
+        })
+      );
+
+      // Assert
+      expect(() => selectors.number()).toThrow(
+        // The state signal has not received an update yet.
+        "Cannot read properties of undefined (reading 'number')"
+      );
+
+      await Promise.resolve();
+
+      // Assert
+      expect(selectors.number()).toEqual(0);
     });
   });
 
-  describe('createSelectMap', () => {
+  describe('createDispatchMap', () => {
     it('should allow listing properties through Object.keys', () => {
       // Arrange
       testSetup();

--- a/packages/store/tests/issues/issue-2180-dispatching-in-effect.spec.ts
+++ b/packages/store/tests/issues/issue-2180-dispatching-in-effect.spec.ts
@@ -1,0 +1,75 @@
+import {
+  Component,
+  Injectable,
+  effect,
+  provideExperimentalZonelessChangeDetection,
+  signal
+} from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Action, NgxsModule, Selector, State, StateContext, Store } from '@ngxs/store';
+
+describe('Dispatching actions in effects (https://github.com/ngxs/store/issues/2180)', () => {
+  class Set {
+    static readonly type = 'Set';
+
+    constructor(readonly value: number) {}
+  }
+
+  @State<number>({
+    name: 'number',
+    defaults: 0
+  })
+  @Injectable()
+  class NumberState {
+    @Selector()
+    static getNumber(number: number): number {
+      return number;
+    }
+
+    @Action(Set)
+    set(ctx: StateContext<number>, action: Set) {
+      ctx.setState(action.value);
+    }
+  }
+
+  @Component({
+    template: `
+      <h1>{{ value() }}</h1>
+      <button (click)="updateValue()">Click me</button>
+    `
+  })
+  class TestComponent {
+    value = signal(0);
+
+    constructor(store: Store) {
+      effect(() => {
+        const value = this.value();
+        store.dispatch(new Set(value));
+      });
+    }
+
+    updateValue() {
+      this.value.set(100);
+    }
+  }
+
+  it('should allow dispatching actions in effects', async () => {
+    // Arrange
+    TestBed.configureTestingModule({
+      declarations: [TestComponent],
+      imports: [NgxsModule.forRoot([NumberState])],
+      providers: [provideExperimentalZonelessChangeDetection()]
+    });
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    // Act
+    document.querySelector('button')!.click();
+    await fixture.whenStable();
+
+    // Assert
+    expect(document.querySelector('h1')!.innerHTML).toEqual('100');
+  });
+});


### PR DESCRIPTION
In this commit, we decouple state signal updates from synchronous changes to adhere to constraints on updates inside effects. Situations may arise where actions are dispatched within effects, and if these actions are synchronous, the state signal would also receive synchronous updates. This can lead to an error indicating that signal writes are not permitted within effects.

Resolves #2180 