### PR TITLE
fix: allow selector utils usage within state class

### DIFF
--- a/packages/store/internals/testing/src/index.ts
+++ b/packages/store/internals/testing/src/index.ts
@@ -1,4 +1,9 @@
 export { freshPlatform } from './fresh-platform';
 export { NgxsTestBed } from './ngxs.setup';
-export { skipConsoleLogging } from './skip-console-logging';
+export {
+  skipConsoleLogging,
+  ConsoleRecord,
+  ConsoleRecorder,
+  loggedError
+} from './skip-console-logging';
 export { NgxsTesting } from './symbol';

--- a/packages/store/internals/testing/src/skip-console-logging.ts
+++ b/packages/store/internals/testing/src/skip-console-logging.ts
@@ -1,11 +1,27 @@
-/// <reference types="jest" />
+export type ConsoleRecord = [string, any[]];
+export type ConsoleRecorder = ConsoleRecord[];
 
-export function skipConsoleLogging<T extends (...args: any[]) => any>(fn: T): ReturnType<T> {
+export function loggedError(message: string): ConsoleRecord {
+  return ['error', [expect.objectContaining({ message })]];
+}
+
+export function skipConsoleLogging<T extends (...args: any[]) => any>(
+  fn: T,
+  consoleRecorder: ConsoleRecorder = []
+): ReturnType<T> {
   const consoleSpies = [
-    jest.spyOn(console, 'log').mockImplementation(() => {}),
-    jest.spyOn(console, 'warn').mockImplementation(() => {}),
-    jest.spyOn(console, 'error').mockImplementation(() => {}),
-    jest.spyOn(console, 'info').mockImplementation(() => {})
+    jest.spyOn(console, 'log').mockImplementation((...args) => {
+      consoleRecorder.push(['log', args]);
+    }),
+    jest.spyOn(console, 'warn').mockImplementation((...args) => {
+      consoleRecorder.push(['warn', args]);
+    }),
+    jest.spyOn(console, 'error').mockImplementation((...args) => {
+      consoleRecorder.push(['error', args]);
+    }),
+    jest.spyOn(console, 'info').mockImplementation((...args) => {
+      consoleRecorder.push(['info', args]);
+    })
   ];
   function restoreSpies() {
     consoleSpies.forEach(spy => spy.mockRestore());

--- a/packages/store/src/selectors/selector-checks.util.ts
+++ b/packages/store/src/selectors/selector-checks.util.ts
@@ -26,7 +26,11 @@ export function ensureValidSelector(
     // If we have used this utility within a state class, we may be
     //  before the @State or @Selector decorators have been applied.
     //  wait until the next microtask to verify.
-    Promise.resolve().then(() => {
+const isNgZoneEnabled = typeof Zone !== 'undefined';
+const runOutsideAngular = isNgZoneEnabled ? (fn) => Zone.root.run(fn) : fn => fn();
+
+    runOutsideAngular(() => {
+      Promise.resolve().then(() => {   
       const errorAgain = getMissingMetaDataError(selector, { noun, prefix });
       if (errorAgain) {
         // Throw the originally captured error so that the stack trace shows the

--- a/packages/store/src/selectors/selector-checks.util.ts
+++ b/packages/store/src/selectors/selector-checks.util.ts
@@ -1,5 +1,6 @@
 import { ɵgetSelectorMetadata, ɵgetStoreMetadata } from '@ngxs/store/internals';
 import { ɵSelectorDef } from './selector-types.util';
+import { NgZone } from '@angular/core';
 
 function getMissingMetaDataError(
   selector: ɵSelectorDef<any>,
@@ -26,18 +27,20 @@ export function ensureValidSelector(
     // If we have used this utility within a state class, we may be
     //  before the @State or @Selector decorators have been applied.
     //  wait until the next microtask to verify.
-const isNgZoneEnabled = typeof Zone !== 'undefined';
-const runOutsideAngular = isNgZoneEnabled ? (fn) => Zone.root.run(fn) : fn => fn();
-
-    runOutsideAngular(() => {
-      Promise.resolve().then(() => {   
-      const errorAgain = getMissingMetaDataError(selector, { noun, prefix });
-      if (errorAgain) {
-        // Throw the originally captured error so that the stack trace shows the
-        // original utility call site.
-        console.error(error);
-      }
-    });
+    // Theoretically this situation is only encountered when the javascript
+    //  files are being loaded and we are outside the angular zone.
+    if (!NgZone.isInAngularZone()) {
+      Promise.resolve().then(() => {
+        const errorAgain = getMissingMetaDataError(selector, { noun, prefix });
+        if (errorAgain) {
+          // Throw the originally captured error so that the stack trace shows the
+          // original utility call site.
+          console.error(error);
+        }
+      });
+    } else {
+      throw error;
+    }
   }
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

The `createPropertySelectors` utility checks that the provided selector is a valid selector.
This is great, but if the utility is used within a state class it fails this check (during `ngDevMode`) because the `@State` decorator has not yet added the selector metadata.
A similar issue exists if a `@Selector` decorated selector is used within the same state class.

Issue Number: #2209

## What is the new behavior?

These usages are allowed. This was achieved by delaying the "valid selector" check in the dev mode.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
