### PR TITLE
perf(store): avoid going over states list every time action is dispatched

### DIFF
--- a/.bundlemonrc.json
+++ b/.bundlemonrc.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "./fesm2022/ngxs-store.mjs",
-      "maxSize": "100kB",
+      "maxSize": "101kB",
       "maxPercentIncrease": 0.5
     }
   ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ $ npm install @ngxs/store@dev
 ### To become next patch version
 
 - Fix(store): allow selector utils usage within state class [#2210](https://github.com/ngxs/store/pull/2210)
+- Performance(store): Avoid going over states list every time action is dispatched [#2219](https://github.com/ngxs/store/pull/2219)
 
 ### 18.1.1 2024-08-06
 

--- a/packages/store/src/internal/lifecycle-state-manager.ts
+++ b/packages/store/src/internal/lifecycle-state-manager.ts
@@ -99,6 +99,6 @@ export class LifecycleStateManager implements OnDestroy {
   }
 
   private _getStateContext(mappedStore: MappedStore): StateContext<any> {
-    return this._stateContextFactory.createStateContext(mappedStore);
+    return this._stateContextFactory.createStateContext(mappedStore.path);
   }
 }

--- a/packages/store/src/internal/state-context-factory.ts
+++ b/packages/store/src/internal/state-context-factory.ts
@@ -4,7 +4,7 @@ import { ExistingState, StateOperator, isStateOperator } from '@ngxs/store/opera
 import { Observable } from 'rxjs';
 
 import { StateContext } from '../symbols';
-import { MappedStore, StateOperations } from '../internal/internals';
+import { StateOperations } from '../internal/internals';
 import { InternalStateOperations } from '../internal/state-operations';
 import { simplePatch } from './state-operators';
 
@@ -19,25 +19,25 @@ export class StateContextFactory {
   /**
    * Create the state context
    */
-  createStateContext<T>(mappedStore: MappedStore): StateContext<T> {
+  createStateContext<T>(path: string): StateContext<T> {
     const root = this._internalStateOperations.getRootStateOperations();
 
     return {
       getState(): T {
         const currentAppState = root.getState();
-        return getState(currentAppState, mappedStore.path);
+        return getState(currentAppState, path);
       },
       patchState(val: Partial<T>): void {
         const currentAppState = root.getState();
         const patchOperator = simplePatch<T>(val);
-        setStateFromOperator(root, currentAppState, patchOperator, mappedStore.path);
+        setStateFromOperator(root, currentAppState, patchOperator, path);
       },
       setState(val: T | StateOperator<T>): void {
         const currentAppState = root.getState();
         if (isStateOperator(val)) {
-          setStateFromOperator(root, currentAppState, val, mappedStore.path);
+          setStateFromOperator(root, currentAppState, val, path);
         } else {
-          setStateValue(root, currentAppState, val, mappedStore.path);
+          setStateValue(root, currentAppState, val, path);
         }
       },
       dispatch(actions: any | any[]): Observable<void> {


### PR DESCRIPTION
In this commit, I'm working on optimizing how we handle action dispatches by avoiding repeated traversal of the `states` list. Instead, we prepare a map each time a new state is added, allowing us to perform O(1) lookups by action type in the future. This approach reduces complexity and improves performance.

I've tested it with benchmark.js, and here are the results:

```ts
class Increment {
  static readonly type = 'Increment';
}

const states = Array.from({ length: 50 }).map((_, index) => {
  @State({
    name: `counter_${index + 1}`,
    defaults: 0,
  })
  @Injectable()
  class CounterState {
    @Action(Increment)
    increment(ctx: StateContext<number>) {
      ctx.setState((counter) => counter + 1);
    }
  }

  return CounterState;
});
```

```
store.dispatch() before changes x 3,435 ops/sec ±0.45% (65 runs sampled)
store.dispatch() after changes x 3,942 ops/sec ±1.21% (25 runs sampled)
```