### PR TITLE
fix(store): register feature plugins correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ $ npm install @ngxs/store@dev
 ### To become next patch version
 
 - Fix(store): allow selector utils usage within state class [#2210](https://github.com/ngxs/store/pull/2210)
-- Fix(store): allow registering child plugins [#2228](https://github.com/ngxs/store/pull/2228)
+- Fix(store): register feature plugins correctly [#2228](https://github.com/ngxs/store/pull/2228)
 - Performance(store): Avoid going over states list every time action is dispatched [#2219](https://github.com/ngxs/store/pull/2219)
 
 ### 18.1.1 2024-08-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ $ npm install @ngxs/store@dev
 ### To become next patch version
 
 - Fix(store): allow selector utils usage within state class [#2210](https://github.com/ngxs/store/pull/2210)
+- Fix(store): allow registering child plugins [#2228](https://github.com/ngxs/store/pull/2228)
 - Performance(store): Avoid going over states list every time action is dispatched [#2219](https://github.com/ngxs/store/pull/2219)
 
 ### 18.1.1 2024-08-06

--- a/packages/store/src/plugin-manager.ts
+++ b/packages/store/src/plugin-manager.ts
@@ -1,28 +1,30 @@
-import { Inject, Injectable, Optional, SkipSelf } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { NGXS_PLUGINS, NgxsPlugin, NgxsPluginFn } from '@ngxs/store/plugins';
 
 @Injectable()
 export class PluginManager {
-  public plugins: NgxsPluginFn[] = [];
+  readonly plugins: NgxsPluginFn[] = [];
 
-  constructor(
-    @Optional()
-    @SkipSelf()
-    private _parentManager: PluginManager,
-    @Inject(NGXS_PLUGINS)
-    @Optional()
-    private _pluginHandlers: NgxsPlugin[]
-  ) {
+  private readonly _parentManager = inject(PluginManager, {
+    optional: true,
+    skipSelf: true
+  });
+
+  private readonly _pluginHandlers = inject<NgxsPlugin[]>(NGXS_PLUGINS, {
+    optional: true
+  });
+
+  constructor() {
     this.registerHandlers();
   }
 
-  private get rootPlugins(): NgxsPluginFn[] {
-    return (this._parentManager && this._parentManager.plugins) || this.plugins;
+  private get _rootPlugins(): NgxsPluginFn[] {
+    return this._parentManager?.plugins || this.plugins;
   }
 
   private registerHandlers(): void {
     const pluginHandlers: NgxsPluginFn[] = this.getPluginHandlers();
-    this.rootPlugins.push(...pluginHandlers);
+    this._rootPlugins.push(...pluginHandlers);
   }
 
   private getPluginHandlers(): NgxsPluginFn[] {

--- a/packages/store/src/standalone-features/plugin.ts
+++ b/packages/store/src/standalone-features/plugin.ts
@@ -1,5 +1,13 @@
-import { EnvironmentProviders, Type, makeEnvironmentProviders } from '@angular/core';
+import {
+  ENVIRONMENT_INITIALIZER,
+  EnvironmentProviders,
+  Type,
+  inject,
+  makeEnvironmentProviders
+} from '@angular/core';
 import { NGXS_PLUGINS, NgxsPlugin } from '@ngxs/store/plugins';
+
+import { PluginManager } from '../plugin-manager';
 
 /**
  * This function registers a custom global plugin for the state.
@@ -16,5 +24,11 @@ import { NGXS_PLUGINS, NgxsPlugin } from '@ngxs/store/plugins';
  * ```
  */
 export function withNgxsPlugin(plugin: Type<NgxsPlugin>): EnvironmentProviders {
-  return makeEnvironmentProviders([{ provide: NGXS_PLUGINS, useClass: plugin, multi: true }]);
+  return makeEnvironmentProviders([
+    { provide: NGXS_PLUGINS, useClass: plugin, multi: true },
+    // We should inject the `PluginManager` to retrieve `NGXS_PLUGINS` and
+    // register those plugins. The plugin can be added from inside the child
+    // route, so the plugin manager should be re-injected.
+    { provide: ENVIRONMENT_INITIALIZER, useValue: () => inject(PluginManager), multi: true }
+  ]);
 }

--- a/packages/store/tests/issues/issue-2227-feature-plugins.spec.ts
+++ b/packages/store/tests/issues/issue-2227-feature-plugins.spec.ts
@@ -1,0 +1,78 @@
+import { ChangeDetectionStrategy, Component, Injectable } from '@angular/core';
+import { bootstrapApplication } from '@angular/platform-browser';
+import {
+  provideRouter,
+  Router,
+  RouterOutlet,
+  Routes,
+  withEnabledBlockingInitialNavigation
+} from '@angular/router';
+import { provideStates, provideStore, withNgxsPlugin, Store } from '@ngxs/store';
+import { getActionTypeFromInstance, NgxsNextPluginFn, NgxsPlugin } from '@ngxs/store/plugins';
+import { freshPlatform, skipConsoleLogging } from '@ngxs/store/internals/testing';
+
+describe('Feature plugin initialization (https://github.com/ngxs/store/issues/2227)', () => {
+  const recorder: string[] = [];
+
+  @Component({
+    selector: 'app-root',
+    template: '<router-outlet />',
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    standalone: true,
+    imports: [RouterOutlet]
+  })
+  class TestComponent {}
+
+  @Component({
+    selector: 'app-child',
+    template: '',
+    standalone: true
+  })
+  class ChildComponent {}
+
+  @Injectable()
+  class ChildPlugin implements NgxsPlugin {
+    constructor() {
+      recorder.push('ChildPlugin constructor');
+    }
+
+    handle(state: any, action: any, next: NgxsNextPluginFn) {
+      recorder.push(`action dispatched: ${getActionTypeFromInstance(action)}`);
+      return next(state, action);
+    }
+  }
+
+  const routes: Routes = [
+    {
+      path: 'child',
+      loadComponent: async () => ChildComponent,
+      providers: [provideStates([], withNgxsPlugin(ChildPlugin))]
+    }
+  ];
+
+  const appConfig = {
+    providers: [provideRouter(routes, withEnabledBlockingInitialNavigation()), provideStore()]
+  };
+
+  it(
+    'should navigate to a child route and initializa the feature plugin',
+    freshPlatform(async () => {
+      // Arrange
+      const { injector } = await skipConsoleLogging(() =>
+        bootstrapApplication(TestComponent, appConfig)
+      );
+      const router = injector.get(Router);
+      const store = injector.get(Store);
+
+      // Act
+      await router.navigateByUrl('/child');
+      store.dispatch({ type: 'random_action' });
+
+      // Assert
+      expect(recorder).toEqual([
+        'ChildPlugin constructor',
+        'action dispatched: random_action'
+      ]);
+    })
+  );
+});


### PR DESCRIPTION
In this commit, we add an inject function for the plugin manager to register child plugins.
The plugin manager supports parent-child functionality, allowing it to be initialized at
the child level.

Resolves #2227 