### PR TITLE
fix(store): memoize selectors which return NaN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ $ npm install @ngxs/store@dev
 
 ### To become next patch version
 
-- Fix(store): allow selector utils usage within state class [#2210](https://github.com/ngxs/store/pull/2210)
-- Fix(store): register feature plugins correctly [#2228](https://github.com/ngxs/store/pull/2228)
+- Fix(store): Allow selector utils usage within state class [#2210](https://github.com/ngxs/store/pull/2210)
+- Fix(store): Register feature plugins correctly [#2228](https://github.com/ngxs/store/pull/2228)
+- Fix(store): Memoize selectors which return NaN [#2230](https://github.com/ngxs/store/pull/2230)
 - Performance(store): Avoid going over states list every time action is dispatched [#2219](https://github.com/ngxs/store/pull/2219)
 - Refactor(store): Add action registry [#2224](https://github.com/ngxs/store/pull/2224)
 

--- a/packages/store/internals/src/memoize.ts
+++ b/packages/store/internals/src/memoize.ts
@@ -1,5 +1,17 @@
+const isNaN = Number.isNaN;
 function defaultEqualityCheck(a: any, b: any) {
-  return a === b;
+  if (a === b) {
+    return true;
+  }
+
+  // Special case for `NaN` (NaN !== NaN).
+  // According to the IEEE 754 standard, `NaN` is not equal to any value,
+  // including itself.
+  if (isNaN(a) && isNaN(b)) {
+    return true;
+  }
+
+  return false;
 }
 
 function areArgumentsShallowlyEqual(
@@ -11,7 +23,8 @@ function areArgumentsShallowlyEqual(
     return false;
   }
 
-  // Do this in a for loop (and not a `forEach` or an `every`) so we can determine equality as fast as possible.
+  // Do this in a for loop (and not a `forEach` or an `every`) so we can
+  // determine equality as fast as possible.
   const length = prev.length;
   for (let i = 0; i < length; i++) {
     if (!equalityCheck(prev[i], next[i])) {

--- a/packages/store/tests/issues/issue-2229-memoize-nan.spec.ts
+++ b/packages/store/tests/issues/issue-2229-memoize-nan.spec.ts
@@ -1,0 +1,92 @@
+import { Injectable } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  Action,
+  createPropertySelectors,
+  createSelector,
+  provideStore,
+  State,
+  StateContext,
+  Store
+} from '@ngxs/store';
+
+describe('Selector returns NaN (https://github.com/ngxs/store/issues/2229)', () => {
+  interface CounterStateModel {
+    countA: number;
+  }
+
+  class AddToA {
+    static readonly type = 'Add to A';
+    constructor(readonly amount: number) {}
+  }
+
+  @State<CounterStateModel>({
+    name: 'count',
+    defaults: {
+      countA: 0
+    }
+  })
+  @Injectable()
+  class CounterState {
+    @Action(AddToA)
+    addToA(ctx: StateContext<CounterStateModel>, action: AddToA) {
+      const state = ctx.getState();
+      ctx.patchState({ countA: state.countA + action.amount });
+    }
+  }
+
+  const recalculations = {
+    selectorReturningNaN: 0,
+    selectorDependingOnNaN: 0
+  };
+
+  const { countA } = createPropertySelectors<CounterStateModel>(CounterState);
+
+  const selectorReturningNaN = createSelector([countA], () => {
+    recalculations.selectorReturningNaN++;
+    return Number.NaN;
+  });
+
+  const selectorDependingOnNaN = createSelector([selectorReturningNaN], () => {
+    recalculations.selectorDependingOnNaN++;
+    return 'Hello world';
+  });
+
+  const testSetup = () => {
+    TestBed.configureTestingModule({
+      providers: [provideStore([CounterState])]
+    });
+
+    return TestBed.inject(Store);
+  };
+
+  it('should not recalculate selector which depends on the selector returning NaN', () => {
+    // Arrange
+    const store = testSetup();
+
+    // Assert
+    expect(recalculations).toEqual({
+      selectorReturningNaN: 0,
+      selectorDependingOnNaN: 0
+    });
+
+    // Act
+    store.select(selectorReturningNaN).subscribe();
+    store.select(selectorDependingOnNaN).subscribe();
+
+    // Assert
+    expect(recalculations).toEqual({
+      selectorReturningNaN: 1,
+      selectorDependingOnNaN: 1
+    });
+
+    // Act
+    store.dispatch(new AddToA(1));
+    store.dispatch(new AddToA(1));
+
+    expect(recalculations).toEqual({
+      selectorReturningNaN: 3,
+      selectorDependingOnNaN: 1
+    });
+  });
+});


### PR DESCRIPTION
In this commit, we update the memoize equality function to correctly check for `NaN`
values because we can't use the default `===` comparison operator, as `NaN` is not equal
to itself (`NaN === NaN` is false). Additionally, we have added a check using `Number.isNaN`.