### PR TITLE
fix(store): prevent writing to state once action handler is unsubscribed

### DIFF
--- a/.bundlemonrc.json
+++ b/.bundlemonrc.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "./fesm2022/ngxs-store.mjs",
-      "maxSize": "102kB",
+      "maxSize": "103kB",
       "maxPercentIncrease": 0.5
     }
   ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ $ npm install @ngxs/store@dev
 
 ### To become next patch version
 
-- ...
+- Fix(store): Prevent writing to state once action handler is unsubscribed [#2231](https://github.com/ngxs/store/pull/2231)
 
 ### 18.1.4 2024-10-23
 

--- a/packages/store/src/actions/action-registry.ts
+++ b/packages/store/src/actions/action-registry.ts
@@ -1,8 +1,7 @@
 import { Injectable, type OnDestroy } from '@angular/core';
 import type { Observable } from 'rxjs';
 
-// action: Instance<ActionType>.
-export type ActionHandlerFn = (action: any) => void | Promise<void> | Observable<unknown>;
+export type ActionHandlerFn = (action: any) => Observable<unknown>;
 
 @Injectable({ providedIn: 'root' })
 export class NgxsActionRegistry implements OnDestroy {

--- a/packages/store/tests/helpers/promise-test-helper.ts
+++ b/packages/store/tests/helpers/promise-test-helper.ts
@@ -1,0 +1,22 @@
+export function createPromiseTestHelper<T = void>() {
+  type MarkResolvedFn = (result: T | PromiseLike<T>) => void;
+  type MarkRejectedFn = (reason?: any) => void;
+  let resolveFn: MarkResolvedFn = () => {};
+  let rejectFn: MarkRejectedFn = () => {};
+
+  const promise = new Promise<T>((resolve, reject) => {
+    resolveFn = resolve;
+    rejectFn = reject;
+  });
+  return {
+    promise,
+    markPromiseResolved(...args: Parameters<MarkResolvedFn>) {
+      resolveFn(...args);
+      resolveFn = () => {};
+    },
+    markPromiseRejected(reason?: any) {
+      rejectFn(reason);
+      rejectFn = () => {};
+    }
+  };
+}

--- a/packages/store/tests/issues/canceling-promises.spec.ts
+++ b/packages/store/tests/issues/canceling-promises.spec.ts
@@ -1,0 +1,128 @@
+import { Injectable } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { State, Action, Store, provideStore, StateContext } from '@ngxs/store';
+
+import { createPromiseTestHelper } from '../helpers/promise-test-helper';
+
+describe('Canceling promises (preventing state writes)', () => {
+  const recorder: string[] = [];
+
+  class IncrementWithAwait {
+    static readonly type = 'Increment with await';
+  }
+
+  class IncrementWithThen {
+    static readonly type = 'Increment with then';
+  }
+
+  const { promise: promiseAwaitReady, markPromiseResolved: markPromiseAwaitReady } =
+    createPromiseTestHelper();
+
+  const { promise: promiseThenReady, markPromiseResolved: markPromiseThenReady } =
+    createPromiseTestHelper();
+
+  @State<number>({
+    name: 'counter',
+    defaults: 0
+  })
+  @Injectable()
+  class CounterState {
+    @Action(IncrementWithAwait, { cancelUncompleted: true })
+    async incrementWithAwait(ctx: StateContext<number>) {
+      recorder.push('before promise await ready');
+      await promiseAwaitReady;
+      recorder.push('after promise await ready');
+      ctx.setState(value => value + 1);
+      recorder.push(`value: ${ctx.getState()}`);
+    }
+
+    @Action(IncrementWithThen, { cancelUncompleted: true })
+    incrementWithThen(ctx: StateContext<number>) {
+      recorder.push('before promise then ready');
+      return promiseThenReady.then(() => {
+        recorder.push('after promise then ready');
+        ctx.setState(value => value + 1);
+        recorder.push(`value: ${ctx.getState()}`);
+      });
+    }
+  }
+
+  beforeEach(() => {
+    recorder.length = 0;
+
+    TestBed.configureTestingModule({
+      providers: [provideStore([CounterState])]
+    });
+  });
+
+  it('canceling promises using `await`', async () => {
+    // Arrange
+    const store = TestBed.inject(Store);
+
+    // Act
+    store.dispatch(new IncrementWithAwait());
+
+    // Assert
+    expect(recorder).toEqual(['before promise await ready']);
+
+    // Act (dispatch another action to cancel the previous one)
+    // The promise is not resolved yet, as thus `await` is not executed.
+    store.dispatch(new IncrementWithAwait());
+
+    // Assert
+    expect(recorder).toEqual(['before promise await ready', 'before promise await ready']);
+
+    // Act
+    markPromiseAwaitReady();
+    await promiseAwaitReady;
+
+    // Assert
+    expect(store.snapshot()).toEqual({ counter: 1 });
+    expect(recorder).toEqual([
+      'before promise await ready',
+      'before promise await ready',
+      // Note that once the promise is resolved, the await has been executed,
+      // and both microtasks have also been executed (`recorder.push(...)` is a
+      // microtask because it is created by `await`).
+      'after promise await ready',
+      // Value has not been updated in the state.
+      'value: 0',
+      'after promise await ready',
+      'value: 1'
+    ]);
+  });
+
+  it('canceling promises using `then(...)`', async () => {
+    // Arrange
+    const store = TestBed.inject(Store);
+
+    // Act
+    store.dispatch(new IncrementWithThen());
+
+    // Assert
+    expect(recorder).toEqual(['before promise then ready']);
+
+    // Act (dispatch another action to cancel the previous one)
+    // The promise is not resolved yet, as thus `then(...)` is not executed.
+    store.dispatch(new IncrementWithThen());
+
+    // Assert
+    expect(recorder).toEqual(['before promise then ready', 'before promise then ready']);
+
+    // Act
+    markPromiseThenReady();
+    await promiseThenReady;
+
+    // Assert
+    expect(store.snapshot()).toEqual({ counter: 1 });
+    expect(recorder).toEqual([
+      'before promise then ready',
+      'before promise then ready',
+      'after promise then ready',
+      // Value has not been updated in the state.
+      'value: 0',
+      'after promise then ready',
+      'value: 1'
+    ]);
+  });
+});


### PR DESCRIPTION
In this commit, we update the implementation of action invocation. The key addition is that
we now prevent writing to the state whenever an action handler is unsubscribed (completed or
cancelled). Since we have a "unique" state context object for each action being invoked, we
can set its `setState` and `patchState` functions to no-ops, essentially making them do
nothing when invoked.