### PR TITLE
fix(logger-plugin): run `filter` function in injection context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ $ npm install @ngxs/store@dev
 
 ### To become next patch version
 
-- ...
+- Fix: Logger Plugin - Run `filter` function in injection context [#2236](https://github.com/ngxs/store/pull/2236)
 
 ### 18.1.3 2024-10-21
 

--- a/packages/logger-plugin/src/log-writer.ts
+++ b/packages/logger-plugin/src/log-writer.ts
@@ -1,4 +1,5 @@
 import { NgxsLoggerPluginOptions } from './symbols';
+
 export class LogWriter {
   private logger: any;
 
@@ -42,24 +43,6 @@ export class LogWriter {
   }
 
   log(title: string, color: string, payload: any) {
-    if (this.isIE()) {
-      this.logger.log(title, payload);
-    } else {
-      this.logger.log('%c ' + title, color, payload);
-    }
-  }
-
-  isIE(): boolean {
-    const ua =
-      typeof window !== 'undefined' && window.navigator.userAgent
-        ? window.navigator.userAgent
-        : '';
-    let msIE = false;
-    const oldIE = ua.indexOf('MSIE ');
-    const newIE = ua.indexOf('Trident/');
-    if (oldIE > -1 || newIE > -1) {
-      msIE = true;
-    }
-    return msIE;
+    this.logger.log('%c ' + title, color, payload);
   }
 }

--- a/packages/logger-plugin/src/logger.plugin.ts
+++ b/packages/logger-plugin/src/logger.plugin.ts
@@ -1,30 +1,28 @@
-import { Inject, Injectable, Injector } from '@angular/core';
+import { inject, Injectable, Injector, runInInjectionContext } from '@angular/core';
 import { Store } from '@ngxs/store';
 import { NgxsNextPluginFn, NgxsPlugin } from '@ngxs/store/plugins';
-import { catchError, tap } from 'rxjs/operators';
+import { catchError, tap } from 'rxjs';
 
-import { ActionLogger } from './action-logger';
 import { LogWriter } from './log-writer';
-import { NgxsLoggerPluginOptions, NGXS_LOGGER_PLUGIN_OPTIONS } from './symbols';
+import { ActionLogger } from './action-logger';
+import { NGXS_LOGGER_PLUGIN_OPTIONS } from './symbols';
 
 @Injectable()
 export class NgxsLoggerPlugin implements NgxsPlugin {
   private _store: Store;
   private _logWriter: LogWriter;
 
-  constructor(
-    @Inject(NGXS_LOGGER_PLUGIN_OPTIONS) private _options: NgxsLoggerPluginOptions,
-    private _injector: Injector
-  ) {}
+  private _options = inject(NGXS_LOGGER_PLUGIN_OPTIONS);
+  private _injector = inject(Injector);
 
   handle(state: any, event: any, next: NgxsNextPluginFn) {
-    if (this._options.disabled || !this._options.filter!(event, state)) {
+    if (this._options.disabled || this._skipLogging(state, event)) {
       return next(state, event);
     }
 
-    this._logWriter = this._logWriter || new LogWriter(this._options);
+    this._logWriter ||= new LogWriter(this._options);
     // Retrieve lazily to avoid cyclic dependency exception
-    this._store = this._store || this._injector.get<Store>(Store);
+    this._store ||= this._injector.get(Store);
 
     const actionLogger = new ActionLogger(event, this._store, this._logWriter);
 
@@ -39,5 +37,16 @@ export class NgxsLoggerPlugin implements NgxsPlugin {
         throw error;
       })
     );
+  }
+
+  private _skipLogging(state: any, event: any) {
+    // Run the `filter: () => ...` function within the injection context so
+    // that the user can access the dependency injection and inject services
+    // to retrieve properties. This will help determine whether or not to log the action.
+    const allowLogging = runInInjectionContext(this._injector, () =>
+      this._options.filter!(event, state)
+    );
+
+    return !allowLogging;
   }
 }

--- a/packages/logger-plugin/src/symbols.ts
+++ b/packages/logger-plugin/src/symbols.ts
@@ -14,4 +14,6 @@ export interface NgxsLoggerPluginOptions {
   filter?: (action: any, state: any) => boolean;
 }
 
-export const NGXS_LOGGER_PLUGIN_OPTIONS = new InjectionToken('NGXS_LOGGER_PLUGIN_OPTIONS');
+export const NGXS_LOGGER_PLUGIN_OPTIONS = new InjectionToken<NgxsLoggerPluginOptions>(
+  'NGXS_LOGGER_PLUGIN_OPTIONS'
+);

--- a/packages/logger-plugin/tests/issues/filter-function-injection-context.spec.ts
+++ b/packages/logger-plugin/tests/issues/filter-function-injection-context.spec.ts
@@ -1,0 +1,105 @@
+import {
+  APP_BOOTSTRAP_LISTENER,
+  APP_INITIALIZER,
+  Component,
+  inject,
+  Injectable
+} from '@angular/core';
+import { bootstrapApplication } from '@angular/platform-browser';
+import { Action, provideStore, State, StateContext, Store } from '@ngxs/store';
+import { withNgxsLoggerPlugin } from '@ngxs/logger-plugin';
+import { freshPlatform, skipConsoleLogging } from '@ngxs/store/internals/testing';
+
+import { LoggerSpy, formatActionCallStack } from '../helpers';
+
+describe('Running `filter: () => ...` function within the injection context', () => {
+  class Increment {
+    static readonly type = 'Increment';
+  }
+
+  interface CounterStateModel {
+    counter: number;
+  }
+
+  @State({ name: 'test', defaults: { counter: 0 } })
+  @Injectable()
+  class CounterState {
+    @Action(Increment)
+    increment(ctx: StateContext<CounterStateModel>) {
+      ctx.setState(state => ({ counter: state.counter + 1 }));
+    }
+  }
+
+  @Injectable({ providedIn: 'root' })
+  class BootstrapState {
+    bootstrapped = false;
+  }
+
+  const logger = new LoggerSpy();
+
+  const appConfig = {
+    providers: [
+      {
+        provide: APP_INITIALIZER,
+        useFactory: () => {
+          const store = inject(Store);
+          return () => store.dispatch(new Increment());
+        },
+        multi: true
+      },
+
+      {
+        provide: APP_BOOTSTRAP_LISTENER,
+        useFactory: () => {
+          const bootstrapState = inject(BootstrapState);
+          return () => {
+            bootstrapState.bootstrapped = true;
+          };
+        },
+        multi: true
+      },
+
+      provideStore(
+        [CounterState],
+        withNgxsLoggerPlugin({
+          logger,
+          filter: () => {
+            const bootstrapState = inject(BootstrapState);
+            return bootstrapState.bootstrapped;
+          }
+        })
+      )
+    ]
+  };
+
+  @Component({ selector: 'app-root', template: '', standalone: true })
+  class TestComponent {}
+
+  it(
+    'should not log actions until the bootstrap is done',
+    freshPlatform(async () => {
+      // Arrange
+      const { injector } = await skipConsoleLogging(() =>
+        bootstrapApplication(TestComponent, appConfig)
+      );
+      const store = injector.get(Store);
+
+      // Assert
+      expect(logger.callStack).toEqual(LoggerSpy.createCallStack([]));
+
+      // Act
+      store.dispatch(new Increment());
+
+      // Assert
+      expect(logger.callStack).toEqual(
+        LoggerSpy.createCallStack([
+          ...formatActionCallStack({
+            action: Increment.type,
+            prevState: { counter: 1 },
+            nextState: { counter: 2 }
+          })
+        ])
+      );
+    })
+  );
+});


### PR DESCRIPTION
In this commit, we wrap the `options.filter` function for the logger plugin to run within
the injection context, allowing the retrieval of any injectees that may have properties
required for filtering. For example, the user may want to skip logging actions until the
app's bootstrap is complete.

Additionally, the `isIE` check has been removed from the log writer, as Internet Explorer
is no longer supported by Angular.