### PR TITLE
refactor(store): use `Object.is` as default equality check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ $ npm install @ngxs/store@dev
 
 - Fix(store): Prevent writing to state once action handler is unsubscribed [#2231](https://github.com/ngxs/store/pull/2231)
 - Performance(store): Replace `instanceof Function` with `typeof` [#2247](https://github.com/ngxs/store/pull/2247)
+- Refactor(store): Use `Object.is` as default equality check [#2245](https://github.com/ngxs/store/pull/2245)
 
 ### 18.1.4 2024-10-23
 

--- a/packages/store/internals/src/memoize.ts
+++ b/packages/store/internals/src/memoize.ts
@@ -43,5 +43,10 @@ export function ɵmemoize<T extends (...args: any[]) => any>(
     lastArgs = arguments;
     return lastResult;
   }
+  (<any>memoized).reset = function () {
+    // The hidden (for now) ability to reset the memoization
+    lastArgs = null;
+    lastResult = null;
+  };
   return memoized as T;
 }

--- a/packages/store/internals/src/memoize.ts
+++ b/packages/store/internals/src/memoize.ts
@@ -1,19 +1,3 @@
-const isNaN = Number.isNaN;
-function defaultEqualityCheck(a: any, b: any) {
-  if (a === b) {
-    return true;
-  }
-
-  // Special case for `NaN` (NaN !== NaN).
-  // According to the IEEE 754 standard, `NaN` is not equal to any value,
-  // including itself.
-  if (isNaN(a) && isNaN(b)) {
-    return true;
-  }
-
-  return false;
-}
-
 function areArgumentsShallowlyEqual(
   equalityCheck: (a: any, b: any) => boolean,
   prev: IArguments | null,
@@ -43,7 +27,7 @@ function areArgumentsShallowlyEqual(
  */
 export function ɵmemoize<T extends (...args: any[]) => any>(
   func: T,
-  equalityCheck = defaultEqualityCheck
+  equalityCheck = Object.is
 ): T {
   let lastArgs: IArguments | null = null;
   let lastResult: any = null;
@@ -59,10 +43,5 @@ export function ɵmemoize<T extends (...args: any[]) => any>(
     lastArgs = arguments;
     return lastResult;
   }
-  (<any>memoized).reset = function () {
-    // The hidden (for now) ability to reset the memoization
-    lastArgs = null;
-    lastResult = null;
-  };
   return memoized as T;
 }


### PR DESCRIPTION
In this commit, we default to using `Object.is` as the equality check function (this function is also used by other frameworks). `Object.is` supports checking for `NaN` values internally. We have also removed the reset function, as it was unused. If needed in the future, it can be re-added.