### PR TITLE
refactor(store): tree-shake internal state tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ $ npm install @ngxs/store@dev
 - Fix(store): Prevent writing to state once action handler is unsubscribed [#2231](https://github.com/ngxs/store/pull/2231)
 - Performance(store): Replace `instanceof Function` with `typeof` [#2247](https://github.com/ngxs/store/pull/2247)
 - Refactor(store): Use `Object.is` as default equality check [#2245](https://github.com/ngxs/store/pull/2245)
+- Refactor(store): Tree-shake internal state tokens [#2246](https://github.com/ngxs/store/pull/2246)
 - Refactor(router-plugin): Mark selectors as pure [#2248](https://github.com/ngxs/store/pull/2248)
 - Refactor(storage-plugin): Mark engine tokens as pure [#2249](https://github.com/ngxs/store/pull/2249)
 

--- a/packages/store/internals/src/internal-tokens.ts
+++ b/packages/store/internals/src/internal-tokens.ts
@@ -6,10 +6,10 @@ const NG_DEV_MODE = typeof ngDevMode !== 'undefined' && ngDevMode;
 
 // These tokens are internal and can change at any point.
 
-export const ɵNGXS_STATE_FACTORY = new InjectionToken<any>(
+export const ɵNGXS_STATE_FACTORY = /* @__PURE__ */ new InjectionToken<any>(
   NG_DEV_MODE ? 'ɵNGXS_STATE_FACTORY' : ''
 );
 
-export const ɵNGXS_STATE_CONTEXT_FACTORY = new InjectionToken<any>(
+export const ɵNGXS_STATE_CONTEXT_FACTORY = /* @__PURE__ */ new InjectionToken<any>(
   NG_DEV_MODE ? 'ɵNGXS_STATE_CONTEXT_FACTORY' : ''
 );

--- a/packages/store/src/internal/provide-internal-tokens.ts
+++ b/packages/store/src/internal/provide-internal-tokens.ts
@@ -1,0 +1,21 @@
+import { makeEnvironmentProviders } from '@angular/core';
+import { ɵNGXS_STATE_CONTEXT_FACTORY, ɵNGXS_STATE_FACTORY } from '@ngxs/store/internals';
+
+import { StateFactory } from './state-factory';
+import { StateContextFactory } from './state-context-factory';
+
+// Backward compatibility is provided because these tokens are used by third-party
+// libraries. We expose a separate function to allow tree-shaking of these tokens
+// if they are not used in standard applications that do not rely on them.
+export function ɵprovideNgxsInternalStateTokens() {
+  return makeEnvironmentProviders([
+    {
+      provide: ɵNGXS_STATE_CONTEXT_FACTORY,
+      useExisting: StateContextFactory
+    },
+    {
+      provide: ɵNGXS_STATE_FACTORY,
+      useExisting: StateFactory
+    }
+  ]);
+}

--- a/packages/store/src/private_api.ts
+++ b/packages/store/src/private_api.ts
@@ -2,3 +2,5 @@ export { NgxsRootModule as ɵNgxsRootModule } from './modules/ngxs-root.module';
 export { NgxsFeatureModule as ɵNgxsFeatureModule } from './modules/ngxs-feature.module';
 
 export * from './selectors/private_api';
+
+export { ɵprovideNgxsInternalStateTokens } from './internal/provide-internal-tokens';

--- a/packages/store/src/standalone-features/root-providers.ts
+++ b/packages/store/src/standalone-features/root-providers.ts
@@ -1,15 +1,9 @@
 import { APP_BOOTSTRAP_LISTENER, Provider, inject } from '@angular/core';
-import {
-  ɵStateClass,
-  ɵNGXS_STATE_CONTEXT_FACTORY,
-  ɵNGXS_STATE_FACTORY,
-  ɵNgxsAppBootstrappedState
-} from '@ngxs/store/internals';
+import { ɵStateClass, ɵNgxsAppBootstrappedState } from '@ngxs/store/internals';
 
 import { PluginManager } from '../plugin-manager';
 import { StateFactory } from '../internal/state-factory';
 import { CUSTOM_NGXS_EXECUTION_STRATEGY } from '../execution/symbols';
-import { StateContextFactory } from '../internal/state-context-factory';
 import { NgxsModuleOptions, ROOT_STATE_TOKEN, NGXS_OPTIONS } from '../symbols';
 
 /**
@@ -43,14 +37,6 @@ export function getRootProviders(
     {
       provide: CUSTOM_NGXS_EXECUTION_STRATEGY,
       useValue: options.executionStrategy
-    },
-    {
-      provide: ɵNGXS_STATE_CONTEXT_FACTORY,
-      useExisting: StateContextFactory
-    },
-    {
-      provide: ɵNGXS_STATE_FACTORY,
-      useExisting: StateFactory
     }
   ];
 }


### PR DESCRIPTION
In this commit, we remove internal injection token providers from the root providers list. Instead, we expose a function that provides these tokens.