### PR TITLE
perf(store): replace `instanceof Function` with `typeof`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ $ npm install @ngxs/store@dev
 ### To become next patch version
 
 - Fix(store): Prevent writing to state once action handler is unsubscribed [#2231](https://github.com/ngxs/store/pull/2231)
+- Performance(store): Replace `instanceof Function` with `typeof` [#2247](https://github.com/ngxs/store/pull/2247)
 
 ### 18.1.4 2024-10-23
 

--- a/packages/store/src/selectors/selector-utils.ts
+++ b/packages/store/src/selectors/selector-utils.ts
@@ -68,9 +68,10 @@ export function createMemoizedSelectorFn<T extends (...args: any[]) => any>(
   creationMetadata: Partial<CreationMetadata> | undefined
 ) {
   const containerClass = creationMetadata && creationMetadata.containerClass;
-  const wrappedFn = function wrappedSelectorFn(...args: any[]) {
-    const returnValue = originalFn.apply(containerClass, args);
-    if (returnValue instanceof Function) {
+  const wrappedFn = function wrappedSelectorFn() {
+    // eslint-disable-next-line prefer-rest-params
+    const returnValue = originalFn.apply(containerClass, <any>arguments);
+    if (typeof returnValue === 'function') {
       const innerMemoizedFn = ɵmemoize.apply(null, [returnValue]);
       return innerMemoizedFn;
     }


### PR DESCRIPTION
`typeof` avoids prototype chain checks and type coercion, which is faster:

```
instanceof Function x 104,665,819 ops/sec ±4.90% (44 runs sampled)
typeof function x 169,867,932 ops/sec ±6.42% (55 runs sampled)
```

Btw fastest benchmarked checks were:

```js
1.
const returnValueType = typeof returnValue;
returnValueType[0] === 'f'

2.
const F_CHAR_CODE = 102;
const returnValueType = typeof returnValue;
(returnValueType.charCodeAt(0) ^ F_CHAR_CODE) === 0;

3.
const F_CHAR_CODE = 102;
const returnValueType = typeof returnValue;
returnValueType.charCodeAt(0) === F_CHAR_CODE;
```