### PR TITLE
refactor(router-plugin): mark selectors as pure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ $ npm install @ngxs/store@dev
 - Fix(store): Prevent writing to state once action handler is unsubscribed [#2231](https://github.com/ngxs/store/pull/2231)
 - Performance(store): Replace `instanceof Function` with `typeof` [#2247](https://github.com/ngxs/store/pull/2247)
 - Refactor(store): Use `Object.is` as default equality check [#2245](https://github.com/ngxs/store/pull/2245)
+- Refactor(router-plugin): Mark selectors as pure [#2248](https://github.com/ngxs/store/pull/2248)
 
 ### 18.1.4 2024-10-23
 

--- a/packages/router-plugin/src/router.state.ts
+++ b/packages/router-plugin/src/router.state.ts
@@ -10,7 +10,7 @@ import {
   NavigationEnd,
   Event
 } from '@angular/router';
-import { Action, Selector, State, StateContext, StateToken, Store } from '@ngxs/store';
+import { Action, createSelector, State, StateContext, StateToken, Store } from '@ngxs/store';
 import {
   NavigationActionTiming,
   NgxsRouterPluginOptions,
@@ -81,17 +81,19 @@ export class RouterState implements OnDestroy {
 
   private _destroy$ = new ReplaySubject<void>(1);
 
-  @Selector()
-  static state<T = RouterStateSnapshot>(state: RouterStateModel<T>) {
-    // The `state` is optional if the selector is invoked before the router
-    // state is registered in NGXS.
-    return state?.state;
-  }
+  static state = /* @__PURE__ */ createSelector(
+    [ROUTER_STATE_TOKEN],
+    (state: RouterStateModel<RouterStateSnapshot>) => {
+      // The `state` is optional if the selector is invoked before the router
+      // state is registered in NGXS.
+      return state?.state;
+    }
+  );
 
-  @Selector()
-  static url(state: RouterStateModel): string | undefined {
-    return state?.state?.url;
-  }
+  static url = /* @__PURE__ */ createSelector(
+    [ROUTER_STATE_TOKEN],
+    state => state?.state?.url
+  );
 
   constructor(
     private _store: Store,


### PR DESCRIPTION
In this commit, we first remove the `@Selector()` decorator because we can use `createSelector` directly. This also removes `__decorate` calls for the `state` and `url` properties. Secondly, we mark these properties as 'pure.' The `/* @__PURE__ */` hint tells the bundler that `createSelector` has no side effects and that the output of this expression can be safely removed if unused. Therefore, if `state` or `url` is never accessed anywhere in our code, it can be tree-shaken.