### PR TITLE
refactor(storage-plugin): mark engine tokens as pure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ $ npm install @ngxs/store@dev
 - Performance(store): Replace `instanceof Function` with `typeof` [#2247](https://github.com/ngxs/store/pull/2247)
 - Refactor(store): Use `Object.is` as default equality check [#2245](https://github.com/ngxs/store/pull/2245)
 - Refactor(router-plugin): Mark selectors as pure [#2248](https://github.com/ngxs/store/pull/2248)
+- Refactor(storage-plugin): Mark engine tokens as pure [#2249](https://github.com/ngxs/store/pull/2249)
 
 ### 18.1.4 2024-10-23
 

--- a/packages/storage-plugin/src/engines.ts
+++ b/packages/storage-plugin/src/engines.ts
@@ -6,7 +6,7 @@ declare const ngDevMode: boolean;
 
 const NG_DEV_MODE = typeof ngDevMode !== 'undefined' && ngDevMode;
 
-export const LOCAL_STORAGE_ENGINE = new InjectionToken<StorageEngine | null>(
+export const LOCAL_STORAGE_ENGINE = /* @__PURE__ */ new InjectionToken<StorageEngine | null>(
   NG_DEV_MODE ? 'LOCAL_STORAGE_ENGINE' : '',
   {
     providedIn: 'root',
@@ -14,7 +14,7 @@ export const LOCAL_STORAGE_ENGINE = new InjectionToken<StorageEngine | null>(
   }
 );
 
-export const SESSION_STORAGE_ENGINE = new InjectionToken<StorageEngine | null>(
+export const SESSION_STORAGE_ENGINE = /* @__PURE__ */ new InjectionToken<StorageEngine | null>(
   NG_DEV_MODE ? 'SESSION_STORAGE_ENGINE' : '',
   {
     providedIn: 'root',


### PR DESCRIPTION
`new` expressions are considered side-effectful. The `/* @__PURE__ */` hint tells the bundler that `new InjectionToken` has no side effects and that the output of this expression can be safely removed if unused. Therefore, if `LOCAL_STORAGE_ENGINE` is never used, it can be dropped.