### PR TITLE
perf(store): prevent initializing state factory at feature levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ $ npm install @ngxs/store@dev
 - Fix(websocket-plugin): Do not dispatch action when root injector is destroyed [#2257](https://github.com/ngxs/store/pull/2257)
 - Refactor(store): Replace `exhaustMap` [#2254](https://github.com/ngxs/store/pull/2254)
 - Refactor(store): Tree-shake development options token [#2260](https://github.com/ngxs/store/pull/2260)
+- Performance(store): Prevent initializing state factory at feature levels [#2261](https://github.com/ngxs/store/pull/2261)
 
 ### 18.1.5 2024-11-12
 

--- a/packages/store/src/standalone-features/feature-providers.ts
+++ b/packages/store/src/standalone-features/feature-providers.ts
@@ -3,7 +3,6 @@ import { ɵStateClass } from '@ngxs/store/internals';
 
 import { FEATURE_STATE_TOKEN } from '../symbols';
 import { PluginManager } from '../plugin-manager';
-import { StateFactory } from '../internal/state-factory';
 
 /**
  * This function provides the required providers when calling `NgxsModule.forFeature`
@@ -11,7 +10,6 @@ import { StateFactory } from '../internal/state-factory';
  */
 export function getFeatureProviders(states: ɵStateClass[]): Provider[] {
   return [
-    StateFactory,
     PluginManager,
     ...states,
     {

--- a/packages/store/src/standalone-features/root-providers.ts
+++ b/packages/store/src/standalone-features/root-providers.ts
@@ -1,7 +1,6 @@
 import { APP_BOOTSTRAP_LISTENER, Provider, inject } from '@angular/core';
 import { ɵStateClass, ɵNgxsAppBootstrappedState } from '@ngxs/store/internals';
 
-import { StateFactory } from '../internal/state-factory';
 import { CUSTOM_NGXS_EXECUTION_STRATEGY } from '../execution/symbols';
 import { NgxsModuleOptions, ROOT_STATE_TOKEN, NGXS_OPTIONS } from '../symbols';
 
@@ -14,7 +13,6 @@ export function getRootProviders(
   options: NgxsModuleOptions
 ): Provider[] {
   return [
-    StateFactory,
     ...states,
     {
       provide: ROOT_STATE_TOKEN,


### PR DESCRIPTION
In this commit, we mark the state factory as a root provider to prevent its initialization
at feature levels when `provideStates` is called.

Previously, the state factory was initialized at feature levels because it needed to retrieve
the feature-level injector in order to call `injector.get(FeatureStateClass)`.
This was necessary because, when `NgxsModule.forFeature([BlogState])` was called, the `BlogState`
instance could only be retrieved from the feature injector hierarchy.

Now, since `addAndReturnDefaults` is called at the feature level inside the feature environment
initializer, it is executed within the feature injection context, allowing us to use the
`inject(...)` function directly.