### PR TITLE
fix(store): reduce change detection cycles with pending tasks

### DIFF
--- a/.bundlemonrc.json
+++ b/.bundlemonrc.json
@@ -30,7 +30,7 @@
     },
     {
       "path": "./fesm2022/ngxs-store.mjs",
-      "maxSize": "103kB",
+      "maxSize": "105kB",
       "maxPercentIncrease": 0.5
     }
   ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ $ npm install @ngxs/store@dev
 ### To become next patch version
 
 - Fix(store): Add root store initializer guard [#2278](https://github.com/ngxs/store/pull/2278)
+- Fix(store): Reduce change detection cycles with pending tasks [#2280](https://github.com/ngxs/store/pull/2280)
 - Fix(store): Complete action results on destroy [#2282](https://github.com/ngxs/store/pull/2282)
 - Refactor(form-plugin): Replace `takeUntil` with `takeUntilDestroyed` [#2283](https://github.com/ngxs/store/pull/2283)
 


### PR DESCRIPTION
An `INFINITE_CHANGE_DETECTION` error has been logged to the error service multiple times,
occurring randomly depending on the number of actions dispatched in a row. This happens
because a pending task is added every time an action is dispatched. Removing a pending task
via the public API forces a scheduled tick, ensuring that stability is asynchronous and
delayed until there has been at least an opportunity to run app synchronization.

This change reduces the number of change detection cycles. For example, if 10 synchronous
actions are dispatched in a row, it may previously trigger 10 change detection cycles, as
tasks would be removed 10 times.

We listen to the actions stream, and every time a context with a `dispatched` status is
generated, we add a pending task only once and keep it until the action is completed.
If multiple actions are dispatched at the same time, we debounce them and use `buffer`
to collect them into a single list.