### PR TITLE
refactor(form-plugin): replace `takeUntil` with `takeUntilDestroyed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ $ npm install @ngxs/store@dev
 
 - Fix(store): Add root store initializer guard [#2278](https://github.com/ngxs/store/pull/2278)
 - Fix(store): Complete action results on destroy [#2282](https://github.com/ngxs/store/pull/2282)
+- Refactor(form-plugin): Replace `takeUntil` with `takeUntilDestroyed` [#2283](https://github.com/ngxs/store/pull/2283)
 
 ### 19.0.0 2024-12-3
 


### PR DESCRIPTION
In this commit, we replace `takeUntil` with `takeUntilDestroyed` and remove `ngOnDestroy`
in favor of using `DestroyRef`.