### PR TITLE
build(store): use `ngServerMode` to check whether we are in SSR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ $ npm install @ngxs/store@dev
 - Fix(store): Reduce change detection cycles with pending tasks [#2280](https://github.com/ngxs/store/pull/2280)
 - Fix(store): Complete action results on destroy [#2282](https://github.com/ngxs/store/pull/2282)
 - Fix(store): Complete `dispatched$` in internal actions [#2285](https://github.com/ngxs/store/pull/2285)
+- Build(store): Use `ngServerMode` to check whether we are in SSR [#2287](https://github.com/ngxs/store/pull/2287)
 - Refactor(form-plugin): Replace `takeUntil` with `takeUntilDestroyed` [#2283](https://github.com/ngxs/store/pull/2283)
 
 ### 19.0.0 2024-12-3

--- a/packages/store/src/execution/dispatch-outside-zone-ngxs-execution-strategy.ts
+++ b/packages/store/src/execution/dispatch-outside-zone-ngxs-execution-strategy.ts
@@ -1,5 +1,4 @@
-import { inject, Injectable, NgZone, PLATFORM_ID } from '@angular/core';
-import { isPlatformServer } from '@angular/common';
+import { inject, Injectable, NgZone } from '@angular/core';
 
 import { NgxsExecutionStrategy } from './symbols';
 import { getZoneWarningMessage } from '../configs/messages.config';
@@ -7,7 +6,6 @@ import { getZoneWarningMessage } from '../configs/messages.config';
 @Injectable({ providedIn: 'root' })
 export class DispatchOutsideZoneNgxsExecutionStrategy implements NgxsExecutionStrategy {
   private _ngZone = inject(NgZone);
-  private _isServer = isPlatformServer(inject(PLATFORM_ID));
 
   constructor() {
     if (typeof ngDevMode !== 'undefined' && ngDevMode) {
@@ -16,7 +14,7 @@ export class DispatchOutsideZoneNgxsExecutionStrategy implements NgxsExecutionSt
   }
 
   enter<T>(func: () => T): T {
-    if (this._isServer) {
+    if (typeof ngServerMode !== 'undefined' && ngServerMode) {
       return this.runInsideAngular(func);
     }
     return this.runOutsideAngular(func);

--- a/packages/store/src/symbols.ts
+++ b/packages/store/src/symbols.ts
@@ -156,4 +156,8 @@ export type NgxsModuleOptions = Partial<NgxsConfig>;
 /** @internal */
 declare global {
   const ngDevMode: boolean;
+  // Indicates whether the application is operating in server-rendering mode.
+  // `ngServerMode` is a global flag set by Angular CLI.
+  // https://github.com/angular/angular-cli/blob/b4e9a2af9e50e7b65167d0fdbd4012023135e875/packages/angular/build/src/tools/vite/utils.ts#L102
+  const ngServerMode: boolean;
 }


### PR DESCRIPTION
In this commit, we replace `isPlatformServer` in the store with the new built-in variable
`ngServerMode`, available starting from Angular 19.
This compile-time variable allows the code to be tree-shakable.