### PR TITLE
build(storage-plugin): use `ngServerMode` to check whether we are in SSR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ $ npm install @ngxs/store@dev
 - Fix(store): Complete action results on destroy [#2282](https://github.com/ngxs/store/pull/2282)
 - Fix(store): Complete `dispatched$` in internal actions [#2285](https://github.com/ngxs/store/pull/2285)
 - Build(store): Use `ngServerMode` to check whether we are in SSR [#2287](https://github.com/ngxs/store/pull/2287)
+- Build(storage-plugin): Use `ngServerMode` to check whether we are in SSR [#2288](https://github.com/ngxs/store/pull/2288)
 - Refactor(form-plugin): Replace `takeUntil` with `takeUntilDestroyed` [#2283](https://github.com/ngxs/store/pull/2283)
 
 ### 19.0.0 2024-12-3

--- a/packages/storage-plugin/src/engines.ts
+++ b/packages/storage-plugin/src/engines.ts
@@ -1,14 +1,14 @@
-import { InjectionToken, PLATFORM_ID, inject } from '@angular/core';
-import { isPlatformBrowser } from '@angular/common';
+import { InjectionToken } from '@angular/core';
 import { StorageEngine } from '@ngxs/storage-plugin/internals';
 
 declare const ngDevMode: boolean;
+declare const ngServerMode: boolean;
 
 export const LOCAL_STORAGE_ENGINE = /* @__PURE__ */ new InjectionToken<StorageEngine | null>(
   typeof ngDevMode !== 'undefined' && ngDevMode ? 'LOCAL_STORAGE_ENGINE' : '',
   {
     providedIn: 'root',
-    factory: () => (isPlatformBrowser(inject(PLATFORM_ID)) ? localStorage : null)
+    factory: () => (typeof ngServerMode !== 'undefined' && ngServerMode ? null : localStorage)
   }
 );
 
@@ -16,6 +16,7 @@ export const SESSION_STORAGE_ENGINE = /* @__PURE__ */ new InjectionToken<Storage
   typeof ngDevMode !== 'undefined' && ngDevMode ? 'SESSION_STORAGE_ENGINE' : '',
   {
     providedIn: 'root',
-    factory: () => (isPlatformBrowser(inject(PLATFORM_ID)) ? sessionStorage : null)
+    factory: () =>
+      typeof ngServerMode !== 'undefined' && ngServerMode ? null : sessionStorage
   }
 );

--- a/packages/storage-plugin/src/internals.ts
+++ b/packages/storage-plugin/src/internals.ts
@@ -1,4 +1,3 @@
-import { isPlatformServer } from '@angular/common';
 import {
   ɵDEFAULT_STATE_KEY,
   StorageOption,
@@ -6,6 +5,8 @@ import {
   NgxsStoragePluginOptions,
   ɵNgxsTransformedStoragePluginOptions
 } from '@ngxs/storage-plugin/internals';
+
+declare const ngServerMode: boolean;
 
 export function storageOptionsFactory(
   options: NgxsStoragePluginOptions
@@ -21,11 +22,8 @@ export function storageOptionsFactory(
   };
 }
 
-export function engineFactory(
-  options: NgxsStoragePluginOptions,
-  platformId: string
-): StorageEngine | null {
-  if (isPlatformServer(platformId)) {
+export function engineFactory(options: NgxsStoragePluginOptions): StorageEngine | null {
+  if (typeof ngServerMode !== 'undefined' && ngServerMode) {
     return null;
   }
 

--- a/packages/storage-plugin/src/storage.module.ts
+++ b/packages/storage-plugin/src/storage.module.ts
@@ -1,7 +1,6 @@
 import {
   NgModule,
   ModuleWithProviders,
-  PLATFORM_ID,
   EnvironmentProviders,
   makeEnvironmentProviders
 } from '@angular/core';
@@ -37,7 +36,7 @@ export class NgxsStoragePluginModule {
         {
           provide: STORAGE_ENGINE,
           useFactory: engineFactory,
-          deps: [ɵNGXS_STORAGE_PLUGIN_OPTIONS, PLATFORM_ID]
+          deps: [ɵNGXS_STORAGE_PLUGIN_OPTIONS]
         }
       ]
     };
@@ -61,7 +60,7 @@ export function withNgxsStoragePlugin(
     {
       provide: STORAGE_ENGINE,
       useFactory: engineFactory,
-      deps: [ɵNGXS_STORAGE_PLUGIN_OPTIONS, PLATFORM_ID]
+      deps: [ɵNGXS_STORAGE_PLUGIN_OPTIONS]
     }
   ]);
 }

--- a/packages/storage-plugin/src/storage.plugin.ts
+++ b/packages/storage-plugin/src/storage.plugin.ts
@@ -1,5 +1,4 @@
-import { PLATFORM_ID, Injectable, inject } from '@angular/core';
-import { isPlatformServer } from '@angular/common';
+import { Injectable, inject } from '@angular/core';
 import { ɵPlainObject } from '@ngxs/store/internals';
 import {
   NgxsPlugin,
@@ -21,16 +20,16 @@ import { getStorageKey } from './internals';
 import { ɵNgxsStoragePluginKeysManager } from './keys-manager';
 
 declare const ngDevMode: boolean;
+declare const ngServerMode: boolean;
 
 @Injectable()
 export class NgxsStoragePlugin implements NgxsPlugin {
   private _keysManager = inject(ɵNgxsStoragePluginKeysManager);
   private _options = inject(ɵNGXS_STORAGE_PLUGIN_OPTIONS);
   private _allStatesPersisted = inject(ɵALL_STATES_PERSISTED);
-  private _isServer = isPlatformServer(inject(PLATFORM_ID));
 
   handle(state: any, event: any, next: NgxsNextPluginFn) {
-    if (this._isServer) {
+    if (typeof ngServerMode !== 'undefined' && ngServerMode) {
       return next(state, event);
     }
 


### PR DESCRIPTION
In this commit, we replace `isPlatformServer` in the storage plugin with the new built-in variable
`ngServerMode`, available starting from Angular 19.
This compile-time variable allows the code to be tree-shakable.