### PR TITLE
refactor: reduce RxJS dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ $ npm install @ngxs/store@dev
 ### To become next patch version
 
 - Refactor: Replace `ngOnDestroy` with `DestroyRef` [#2289](https://github.com/ngxs/store/pull/2289)
+- Refactor: Reduce RxJS dependency [#2292](https://github.com/ngxs/store/pull/2292)
 - Fix(store): Add root store initializer guard [#2278](https://github.com/ngxs/store/pull/2278)
 - Fix(store): Reduce change detection cycles with pending tasks [#2280](https://github.com/ngxs/store/pull/2280)
 - Fix(store): Complete action results on destroy [#2282](https://github.com/ngxs/store/pull/2282)

--- a/packages/hmr-plugin/src/internal/hmr-lifecycle.ts
+++ b/packages/hmr-plugin/src/internal/hmr-lifecycle.ts
@@ -54,7 +54,8 @@ export class HmrLifecycle<T extends Partial<NgxsHmrLifeCycle<S>>, S> {
 
     const state$: Observable<any> = this.context.store.select(state => state);
 
-    this.appBootstrappedState.subscribe(() => {
+    this.appBootstrappedState.subscribe(bootstrapped => {
+      if (!bootstrapped) return;
       let eventId: number;
       const storeEventId: Subscription = state$.subscribe(() => {
         // setTimeout used for zone detection after set hmr state

--- a/packages/store/internals/src/ngxs-app-bootstrapped-state.ts
+++ b/packages/store/internals/src/ngxs-app-bootstrapped-state.ts
@@ -1,14 +1,19 @@
-import { Injectable } from '@angular/core';
-import { ReplaySubject } from 'rxjs';
+import { DestroyRef, inject, Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
-export class ɵNgxsAppBootstrappedState extends ReplaySubject<boolean> {
+export class ɵNgxsAppBootstrappedState extends BehaviorSubject<boolean> {
   constructor() {
-    super(1);
+    super(false);
+
+    const destroyRef = inject(DestroyRef);
+    // Complete the subject once the root injector is destroyed to ensure
+    // there are no active subscribers that would receive events or perform
+    // any actions after the application is destroyed.
+    destroyRef.onDestroy(() => this.complete());
   }
 
   bootstrap(): void {
     this.next(true);
-    this.complete();
   }
 }

--- a/packages/websocket-plugin/tests/websocket-handler-cleanup.spec.ts
+++ b/packages/websocket-plugin/tests/websocket-handler-cleanup.spec.ts
@@ -44,8 +44,8 @@ describe('WebSocketHandler cleanup', () => {
       );
       const store = ngModuleRef.injector.get(Store);
       const webSocketHandler = ngModuleRef.injector.get(WebSocketHandler);
-      const nextSpy = jest.fn();
-      webSocketHandler['_destroy$'].subscribe(nextSpy);
+      // @ts-expect-error private property.
+      const spy = jest.spyOn(webSocketHandler, '_closeConnection');
 
       store.dispatch(new ConnectWebSocket());
 
@@ -53,7 +53,7 @@ describe('WebSocketHandler cleanup', () => {
         server.on('close', () => {
           try {
             // Assert
-            expect(nextSpy).toHaveBeenCalled();
+            expect(spy).toHaveBeenCalledWith(/* forcelyCloseSocket */ true);
           } finally {
             server.stop(done);
           }


### PR DESCRIPTION
In this commit, we reduce the usage of RxJS utilities as they may be redundant. For example,
we replace the replay subject with a behavior subject and remove some unnecessary operators.