### PR TITLE
feat(store): action status "PreHandler"

### DIFF
--- a/packages/store/src/actions-stream.ts
+++ b/packages/store/src/actions-stream.ts
@@ -9,6 +9,7 @@ import { InternalNgxsExecutionStrategy } from './execution/internal-ngxs-executi
  * Status of a dispatched action
  */
 export const enum ActionStatus {
+  PreHandler = 'PRE_HANDLER',
   Dispatched = 'DISPATCHED',
   Successful = 'SUCCESSFUL',
   Canceled = 'CANCELED',

--- a/packages/store/src/internal/dispatcher.ts
+++ b/packages/store/src/internal/dispatcher.ts
@@ -62,6 +62,8 @@ export class InternalDispatcher {
     const prevState = this._stateStream.getValue();
     const plugins = this._pluginManager.plugins;
 
+    this._actions.next({ action, status: ActionStatus.PreHandler });
+
     return compose(this._injector, [
       ...plugins,
       (nextState: any, nextAction: any) => {

--- a/packages/store/src/operators/of-action.ts
+++ b/packages/store/src/operators/of-action.ts
@@ -41,6 +41,20 @@ export function ofAction<T extends ActionType[]>(
 /**
  * RxJS operator for selecting out specific actions.
  *
+ * This will ONLY grab actions before being handled
+ */
+export function ofActionPreHandler<T extends ActionType[]>(
+  ...allowedTypes: T
+): OperatorFunction<
+  ActionContext<Constructed<T[TupleKeys<T>]>>,
+  Constructed<T[TupleKeys<T>]>
+> {
+  return ofActionOperator(allowedTypes, [ActionStatus.PreHandler]);
+}
+
+/**
+ * RxJS operator for selecting out specific actions.
+ *
  * This will ONLY grab actions that have just been dispatched
  */
 export function ofActionDispatched<T extends ActionType[]>(

--- a/packages/store/src/pending-tasks.ts
+++ b/packages/store/src/pending-tasks.ts
@@ -38,6 +38,7 @@ export function withNgxsPendingTasks() {
 
     actions$
       .pipe(
+        filter(context => context.status !== ActionStatus.PreHandler),
         filter(context => {
           if (context.status === ActionStatus.Dispatched) {
             executedActions.add(context.action);

--- a/packages/store/tests/action.spec.ts
+++ b/packages/store/tests/action.spec.ts
@@ -20,6 +20,7 @@ import { Observable, of, Subject, throwError } from 'rxjs';
 import { delay, map, take, tap } from 'rxjs/operators';
 
 import { NoopErrorHandler } from './helpers/utils';
+import { ofActionPreHandler } from '../src/operators/of-action';
 
 describe('Action', () => {
   class Action1 {
@@ -92,8 +93,13 @@ describe('Action', () => {
       // Arrange
       const { store, actions } = setup();
       const callbacksCalled: string[] = [];
+
       actions.pipe(ofAction(Action1)).subscribe(() => {
         callbacksCalled.push('ofAction');
+      });
+
+      actions.pipe(ofActionPreHandler(Action1)).subscribe(() => {
+        callbacksCalled.push('ofActionPreHandler');
       });
 
       actions.pipe(ofActionDispatched(Action1)).subscribe(() => {
@@ -103,6 +109,8 @@ describe('Action', () => {
       actions.pipe(ofActionSuccessful(Action1)).subscribe(() => {
         callbacksCalled.push('ofActionSuccessful');
         expect(callbacksCalled).toEqual([
+          'ofAction',
+          'ofActionPreHandler',
           'ofAction',
           'ofActionDispatched',
           'ofAction',
@@ -123,6 +131,8 @@ describe('Action', () => {
       store.dispatch(new Action1()).subscribe(() => {
         expect(callbacksCalled).toEqual([
           'ofAction',
+          'ofActionPreHandler',
+          'ofAction',
           'ofActionDispatched',
           'ofAction',
           'ofActionSuccessful',
@@ -133,6 +143,8 @@ describe('Action', () => {
       tick(1);
       expect(callbacksCalled).toEqual([
         'ofAction',
+        'ofActionPreHandler',
+        'ofAction',
         'ofActionDispatched',
         'ofAction',
         'ofActionSuccessful',
@@ -140,7 +152,7 @@ describe('Action', () => {
       ]);
     }));
 
-    it('calls only the dispatched and error action', fakeAsync(() => {
+    it('calls only the preHandler, dispatched and error action', fakeAsync(() => {
       // Arrange
       const { store, actions } = setup();
       const callbacksCalled: string[] = [];
@@ -148,8 +160,13 @@ describe('Action', () => {
       actions.pipe(ofAction(Action1)).subscribe(() => {
         callbacksCalled.push('ofAction[Action1]');
       });
+
       actions.pipe(ofAction(ErrorAction)).subscribe(() => {
         callbacksCalled.push('ofAction');
+      });
+
+      actions.pipe(ofActionPreHandler(ErrorAction)).subscribe(() => {
+        callbacksCalled.push('ofActionPreHandler');
       });
 
       actions.pipe(ofActionDispatched(ErrorAction)).subscribe(() => {
@@ -163,6 +180,8 @@ describe('Action', () => {
       actions.pipe(ofActionErrored(ErrorAction)).subscribe(() => {
         callbacksCalled.push('ofActionErrored');
         expect(callbacksCalled).toEqual([
+          'ofAction',
+          'ofActionPreHandler',
           'ofAction',
           'ofActionDispatched',
           'ofAction',
@@ -184,6 +203,8 @@ describe('Action', () => {
         error: () =>
           expect(callbacksCalled).toEqual([
             'ofAction',
+            'ofActionPreHandler',
+            'ofAction',
             'ofActionDispatched',
             'ofAction',
             'ofActionErrored',
@@ -193,6 +214,8 @@ describe('Action', () => {
 
       tick(1);
       expect(callbacksCalled).toEqual([
+        'ofAction',
+        'ofActionPreHandler',
         'ofAction',
         'ofActionDispatched',
         'ofAction',
@@ -234,6 +257,12 @@ describe('Action', () => {
       });
 
       actions
+        .pipe(ofActionPreHandler(CancelingAction))
+        .subscribe(({ id }: CancelingAction) => {
+          callbacksCalled.push('ofActionPreHandler ' + id);
+        });
+
+      actions
         .pipe(ofActionDispatched(CancelingAction))
         .subscribe(({ id }: CancelingAction) => {
           callbacksCalled.push('ofActionDispatched ' + id);
@@ -251,7 +280,11 @@ describe('Action', () => {
           callbacksCalled.push('ofActionSuccessful ' + id);
           expect(callbacksCalled).toEqual([
             'ofAction 1',
+            'ofActionPreHandler 1',
+            'ofAction 1',
             'ofActionDispatched 1',
+            'ofAction 2',
+            'ofActionPreHandler 2',
             'ofAction 2',
             'ofActionDispatched 2',
             'ofAction 1',
@@ -265,7 +298,11 @@ describe('Action', () => {
         callbacksCalled.push('ofActionCanceled ' + id);
         expect(callbacksCalled).toEqual([
           'ofAction 1',
+          'ofActionPreHandler 1',
+          'ofAction 1',
           'ofActionDispatched 1',
+          'ofAction 2',
+          'ofActionPreHandler 2',
           'ofAction 2',
           'ofActionDispatched 2',
           'ofAction 1',
@@ -278,7 +315,11 @@ describe('Action', () => {
         complete: () => {
           expect(callbacksCalled).toEqual([
             'ofAction 1',
+            'ofActionPreHandler 1',
+            'ofAction 1',
             'ofActionDispatched 1',
+            'ofAction 2',
+            'ofActionPreHandler 2',
             'ofAction 2',
             'ofActionDispatched 2',
             'ofAction 1',
@@ -291,7 +332,11 @@ describe('Action', () => {
       // Assert
       expect(callbacksCalled).toEqual([
         'ofAction 1',
+        'ofActionPreHandler 1',
+        'ofAction 1',
         'ofActionDispatched 1',
+        'ofAction 2',
+        'ofActionPreHandler 2',
         'ofAction 2',
         'ofActionDispatched 2',
         'ofAction 1',

--- a/packages/store/tests/execution/dispatch-outside-zone-ngxs-execution-strategy.spec.ts
+++ b/packages/store/tests/execution/dispatch-outside-zone-ngxs-execution-strategy.spec.ts
@@ -234,7 +234,7 @@ describe('DispatchOutsideZoneNgxsExecutionStrategy', () => {
 
       // Assert
       zoneCounter.assert({
-        inside: 4,
+        inside: 6,
         outside: 0
       });
     });
@@ -256,7 +256,7 @@ describe('DispatchOutsideZoneNgxsExecutionStrategy', () => {
 
       // Assert
       zoneCounter.assert({
-        inside: 4,
+        inside: 6,
         outside: 0
       });
     });

--- a/packages/store/tests/execution/noop-ngxs-execution-strategy.spec.ts
+++ b/packages/store/tests/execution/noop-ngxs-execution-strategy.spec.ts
@@ -276,7 +276,7 @@ describe('NoopNgxsExecutionStrategy', () => {
       // Assert
       zoneCounter.assert({
         inside: 0,
-        outside: 4
+        outside: 6
       });
     });
 
@@ -297,7 +297,7 @@ describe('NoopNgxsExecutionStrategy', () => {
 
       // Assert
       zoneCounter.assert({
-        inside: 4,
+        inside: 6,
         outside: 0
       });
     });

--- a/packages/store/tests/issues/issue-1568-return-empty.spec.ts
+++ b/packages/store/tests/issues/issue-1568-return-empty.spec.ts
@@ -48,6 +48,10 @@ describe('https://github.com/ngxs/store/issues/1568', () => {
     expect(contexts).toEqual([
       {
         action: {},
+        status: 'PRE_HANDLER'
+      },
+      {
+        action: {},
         status: 'DISPATCHED'
       },
       {


### PR DESCRIPTION
Before this change, it was not possible to prepare for an action before it was processed by NGXS.

This is because the DISPATCHED event is emitted only after the action handlers have been executed, which is unclear from the documentation: ofActionDispatched: This will ONLY grab actions that have just been dispatched

Since changing this behavior would break the public API, this update introduces a new event, PreHandler, which allows reacting to an action before any handler is executed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Doc will be adapted if the PR is accepted (page to update is https://www.ngxs.io/concepts/actions/action-handlers)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently, it was not possible to prepare for an action before it was processed by NGXS.

## What is the new behavior?

The action PreHandler is emitted before NGXS executes any handler.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No (except if triggering more ofAction(MyAction) is a breaking change?
```
