### PR TITLE
refactor(store): pull less RxJS symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ $ npm install @ngxs/store@dev
 
 - Refactor: Replace `ngOnDestroy` with `DestroyRef` [#2289](https://github.com/ngxs/store/pull/2289)
 - Refactor: Reduce RxJS dependency [#2292](https://github.com/ngxs/store/pull/2292)
+- Refactor: Pull less RxJS symbols [#2309](https://github.com/ngxs/store/pull/2309)
 - Fix(store): Add root store initializer guard [#2278](https://github.com/ngxs/store/pull/2278)
 - Fix(store): Reduce change detection cycles with pending tasks [#2280](https://github.com/ngxs/store/pull/2280)
 - Fix(store): Complete action results on destroy [#2282](https://github.com/ngxs/store/pull/2282)

--- a/packages/store/internals/src/index.ts
+++ b/packages/store/internals/src/index.ts
@@ -8,3 +8,4 @@ export { ɵNGXS_STATE_CONTEXT_FACTORY, ɵNGXS_STATE_FACTORY } from './internal-t
 export { ɵOrderedSubject, ɵOrderedBehaviorSubject } from './custom-rxjs-subjects';
 export { ɵwrapObserverCalls } from './custom-rxjs-operators';
 export { ɵStateStream } from './state-stream';
+export { ɵof } from './rxjs';

--- a/packages/store/internals/src/rxjs.ts
+++ b/packages/store/internals/src/rxjs.ts
@@ -1,0 +1,9 @@
+import { Observable } from 'rxjs';
+
+export function ɵof<T>(value: T) {
+  // Manually creating the observable pulls less symbols from RxJS than `of(value)`.
+  return new Observable<T>(subscriber => {
+    subscriber.next(value);
+    subscriber.complete();
+  });
+}

--- a/packages/store/src/actions-stream.ts
+++ b/packages/store/src/actions-stream.ts
@@ -1,6 +1,6 @@
 import { DestroyRef, inject, Injectable } from '@angular/core';
 import { ɵOrderedSubject } from '@ngxs/store/internals';
-import { Observable, Subject, filter, share } from 'rxjs';
+import { Observable, Subject, share } from 'rxjs';
 
 import { leaveNgxs } from './operators/leave-ngxs';
 import { InternalNgxsExecutionStrategy } from './execution/internal-ngxs-execution-strategy';
@@ -33,8 +33,10 @@ export class InternalActions extends ɵOrderedSubject<ActionContext> {
   constructor() {
     super();
 
-    this.pipe(filter(ctx => ctx.status === ActionStatus.Dispatched)).subscribe(ctx => {
-      this.dispatched$.next(ctx);
+    this.subscribe(ctx => {
+      if (ctx.status === ActionStatus.Dispatched) {
+        this.dispatched$.next(ctx);
+      }
     });
 
     const destroyRef = inject(DestroyRef);

--- a/packages/store/src/internal/dispatcher.ts
+++ b/packages/store/src/internal/dispatcher.ts
@@ -1,9 +1,9 @@
 import { inject, Injectable, Injector, NgZone, runInInjectionContext } from '@angular/core';
-import { forkJoin, Observable, of, throwError } from 'rxjs';
+import { EMPTY, forkJoin, Observable, throwError } from 'rxjs';
 import { filter, map, mergeMap, shareReplay, take } from 'rxjs/operators';
 
 import { getActionTypeFromInstance } from '@ngxs/store/plugins';
-import { ɵPlainObject, ɵStateStream } from '@ngxs/store/internals';
+import { ɵPlainObject, ɵStateStream, ɵof } from '@ngxs/store/internals';
 
 import { PluginManager } from '../plugin-manager';
 import { leaveNgxs } from '../operators/leave-ngxs';
@@ -38,7 +38,7 @@ export class InternalDispatcher {
 
   private dispatchByEvents(actionOrActions: any | any[]): Observable<void> {
     if (Array.isArray(actionOrActions)) {
-      if (actionOrActions.length === 0) return of(undefined);
+      if (actionOrActions.length === 0) return ɵof(undefined);
 
       return forkJoin(actionOrActions.map(action => this.dispatchSingle(action))).pipe(
         map(() => undefined)
@@ -95,13 +95,13 @@ export class InternalDispatcher {
           case ActionStatus.Successful:
             // The `createDispatchObservable` function should return the
             // state, as its result is used by plugins.
-            return of(this._stateStream.getValue());
+            return ɵof(this._stateStream.getValue());
           case ActionStatus.Errored:
             return throwError(() => ctx.error);
           default:
             // Once dispatched or canceled, we complete it immediately because
             // `dispatch()` should emit (or error, or complete) as soon as it succeeds or fails.
-            return of();
+            return EMPTY;
         }
       }),
       shareReplay()

--- a/packages/store/src/internal/state-factory.ts
+++ b/packages/store/src/internal/state-factory.ts
@@ -11,11 +11,11 @@ import {
   ɵRuntimeSelectorContext
 } from '@ngxs/store/internals';
 import { getActionTypeFromInstance, getValue, setValue } from '@ngxs/store/plugins';
+import { ɵof } from '@ngxs/store/internals';
 import {
   forkJoin,
   from,
   isObservable,
-  of,
   Subscription,
   throwError,
   catchError,
@@ -221,7 +221,7 @@ export class StateFactory {
               const handleableError = assignUnhandledCallback(error, () =>
                 ngxsUnhandledErrorHandler.handleError(error, { action })
               );
-              return of(<ActionContext>{
+              return ɵof(<ActionContext>{
                 action,
                 status: ActionStatus.Errored,
                 error: handleableError
@@ -273,7 +273,7 @@ export class StateFactory {
     }
 
     if (!results.length) {
-      results.push(of(undefined));
+      results.push(ɵof(undefined));
     }
 
     return forkJoin(results);
@@ -340,12 +340,10 @@ export class StateFactory {
           if (isObservable(result)) {
             result = result.pipe(
               mergeMap((value: any) => {
-                if (ɵisPromise(value)) {
-                  return from(value);
-                } else if (isObservable(value)) {
+                if (ɵisPromise(value) || isObservable(value)) {
                   return value;
                 } else {
-                  return of(value);
+                  return ɵof(value);
                 }
               }),
               // If this observable has completed without emitting any values,
@@ -379,7 +377,7 @@ export class StateFactory {
           } else {
             // If the action handler is synchronous and returns nothing (`void`), we
             // still have to convert the result to a synchronous observable.
-            result = of(undefined);
+            result = ɵof(undefined);
           }
 
           return result;

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -1,7 +1,6 @@
 import { computed, inject, Injectable, Signal } from '@angular/core';
 import {
   Observable,
-  of,
   Subscription,
   throwError,
   catchError,
@@ -10,7 +9,7 @@ import {
   shareReplay,
   take
 } from 'rxjs';
-import { ɵINITIAL_STATE_TOKEN, ɵStateStream } from '@ngxs/store/internals';
+import { ɵINITIAL_STATE_TOKEN, ɵStateStream, ɵof } from '@ngxs/store/internals';
 
 import { InternalNgxsExecutionStrategy } from './execution/internal-ngxs-execution-strategy';
 import { InternalStateOperations } from './internal/state-operations';
@@ -77,7 +76,7 @@ export class Store {
       catchError((error: Error): Observable<never> | Observable<undefined> => {
         // if error is TypeError we swallow it to prevent usual errors with property access
         if (this._config.selectorOptions.suppressErrors && error instanceof TypeError) {
-          return of(undefined);
+          return ɵof(undefined);
         }
 
         // rethrow other errors


### PR DESCRIPTION
In this commit, we reduce the number of imported symbols from RxJS by removing the `pairwise()`
operator (since users consuming the NGXS library may not use it) and replacing RxJS `of()`
with a custom function that instantly returns an observable.