### PR TITLE
refactor(store): pull less RxJS symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ $ npm install @ngxs/store@dev
 
 - Refactor: Replace `ngOnDestroy` with `DestroyRef` [#2289](https://github.com/ngxs/store/pull/2289)
 - Refactor: Reduce RxJS dependency [#2292](https://github.com/ngxs/store/pull/2292)
-- Refactor: Pull less RxJS symbols [#2309](https://github.com/ngxs/store/pull/2309)
+- Refactor: Pull less RxJS symbols [#2309](https://github.com/ngxs/store/pull/2309) [#2310](https://github.com/ngxs/store/pull/2310)
 - Fix(store): Add root store initializer guard [#2278](https://github.com/ngxs/store/pull/2278)
 - Fix(store): Reduce change detection cycles with pending tasks [#2280](https://github.com/ngxs/store/pull/2280)
 - Fix(store): Complete action results on destroy [#2282](https://github.com/ngxs/store/pull/2282)

--- a/packages/devtools-plugin/src/devtools.plugin.ts
+++ b/packages/devtools-plugin/src/devtools.plugin.ts
@@ -6,7 +6,7 @@ import {
   NgxsNextPluginFn,
   NgxsPlugin
 } from '@ngxs/store/plugins';
-import { tap, catchError } from 'rxjs/operators';
+import { tap, catchError } from 'rxjs';
 
 import { NGXS_DEVTOOLS_OPTIONS, NgxsDevtoolsAction, NgxsDevtoolsExtension } from './symbols';
 

--- a/packages/storage-plugin/src/storage.plugin.ts
+++ b/packages/storage-plugin/src/storage.plugin.ts
@@ -14,7 +14,7 @@ import {
   ɵALL_STATES_PERSISTED,
   ɵNGXS_STORAGE_PLUGIN_OPTIONS
 } from '@ngxs/storage-plugin/internals';
-import { tap } from 'rxjs/operators';
+import { tap } from 'rxjs';
 
 import { getStorageKey } from './internals';
 import { ɵNgxsStoragePluginKeysManager } from './keys-manager';

--- a/packages/store/src/internal/dispatcher.ts
+++ b/packages/store/src/internal/dispatcher.ts
@@ -1,6 +1,15 @@
 import { inject, Injectable, Injector, NgZone, runInInjectionContext } from '@angular/core';
-import { EMPTY, forkJoin, Observable, throwError } from 'rxjs';
-import { filter, map, mergeMap, shareReplay, take } from 'rxjs/operators';
+import {
+  EMPTY,
+  forkJoin,
+  Observable,
+  throwError,
+  filter,
+  map,
+  mergeMap,
+  shareReplay,
+  take
+} from 'rxjs';
 
 import { getActionTypeFromInstance } from '@ngxs/store/plugins';
 import { ɵPlainObject, ɵStateStream, ɵof } from '@ngxs/store/internals';
@@ -97,7 +106,7 @@ export class InternalDispatcher {
             // state, as its result is used by plugins.
             return ɵof(this._stateStream.getValue());
           case ActionStatus.Errored:
-            return throwError(() => ctx.error);
+            throw ctx.error;
           default:
             // Once dispatched or canceled, we complete it immediately because
             // `dispatch()` should emit (or error, or complete) as soon as it succeeds or fails.

--- a/packages/store/src/operators/of-action.ts
+++ b/packages/store/src/operators/of-action.ts
@@ -1,6 +1,5 @@
 import { getActionTypeFromInstance } from '@ngxs/store/plugins';
-import { OperatorFunction, Observable } from 'rxjs';
-import { map, filter } from 'rxjs/operators';
+import { type OperatorFunction, type Observable, map, filter } from 'rxjs';
 
 import { ActionType } from '../actions/symbols';
 import { ActionContext, ActionStatus } from '../actions-stream';

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -1,7 +1,7 @@
 import { computed, inject, Injectable, Signal } from '@angular/core';
 import {
-  Observable,
-  Subscription,
+  type Observable,
+  type Subscription,
   throwError,
   catchError,
   distinctUntilChanged,
@@ -80,7 +80,7 @@ export class Store {
         }
 
         // rethrow other errors
-        return throwError(error);
+        throw error;
       }),
       distinctUntilChanged(),
       leaveNgxs(this._internalExecutionStrategy)


### PR DESCRIPTION
In this commit, we import everything from `rxjs` instead of importing from `rxjs/operators`.