### PR TITLE
refactor: replace `ENVIRONMENT_INITIALIZER`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ $ npm install @ngxs/store@dev
 - Refactor: Replace `ngOnDestroy` with `DestroyRef` [#2289](https://github.com/ngxs/store/pull/2289)
 - Refactor: Reduce RxJS dependency [#2292](https://github.com/ngxs/store/pull/2292)
 - Refactor: Pull less RxJS symbols [#2309](https://github.com/ngxs/store/pull/2309) [#2310](https://github.com/ngxs/store/pull/2310)
+- Refactor: Replace `ENVIRONMENT_INITIALIZER` [#2314](https://github.com/ngxs/store/pull/2314)
 - Fix(store): Add root store initializer guard [#2278](https://github.com/ngxs/store/pull/2278)
 - Fix(store): Reduce change detection cycles with pending tasks [#2280](https://github.com/ngxs/store/pull/2280)
 - Fix(store): Complete action results on destroy [#2282](https://github.com/ngxs/store/pull/2282)

--- a/packages/storage-plugin/src/with-storage-feature.ts
+++ b/packages/storage-plugin/src/with-storage-feature.ts
@@ -1,9 +1,4 @@
-import {
-  inject,
-  EnvironmentProviders,
-  ENVIRONMENT_INITIALIZER,
-  makeEnvironmentProviders
-} from '@angular/core';
+import { inject, EnvironmentProviders, provideEnvironmentInitializer } from '@angular/core';
 import { StorageKey, ɵALL_STATES_PERSISTED } from '@ngxs/storage-plugin/internals';
 
 import { ɵNgxsStoragePluginKeysManager } from './keys-manager';
@@ -11,32 +6,26 @@ import { ɵNgxsStoragePluginKeysManager } from './keys-manager';
 declare const ngDevMode: boolean;
 
 export function withStorageFeature(storageKeys: StorageKey[]): EnvironmentProviders {
-  return makeEnvironmentProviders([
-    {
-      provide: ENVIRONMENT_INITIALIZER,
-      multi: true,
-      useValue: () => {
-        const allStatesPersisted = inject(ɵALL_STATES_PERSISTED);
+  return provideEnvironmentInitializer(() => {
+    const allStatesPersisted = inject(ɵALL_STATES_PERSISTED);
 
-        if (allStatesPersisted) {
-          if (typeof ngDevMode !== 'undefined' && ngDevMode) {
-            const message =
-              'The NGXS storage plugin is currently persisting all states because the `keys` ' +
-              'option was explicitly set to `*` at the root level. To selectively persist states, ' +
-              'consider explicitly specifying them, allowing for addition at the feature level.';
+    if (allStatesPersisted) {
+      if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+        const message =
+          'The NGXS storage plugin is currently persisting all states because the `keys` ' +
+          'option was explicitly set to `*` at the root level. To selectively persist states, ' +
+          'consider explicitly specifying them, allowing for addition at the feature level.';
 
-            console.error(message);
-          }
-
-          // We should prevent the addition of any feature states to persistence
-          // if the `keys` property is set to `*`, as this could disrupt the algorithm
-          // used in the storage plugin. Instead, we should log an error in development
-          // mode. In production, it should continue to function, but act as a no-op.
-          return;
-        }
-
-        inject(ɵNgxsStoragePluginKeysManager).addKeys(storageKeys);
+        console.error(message);
       }
+
+      // We should prevent the addition of any feature states to persistence
+      // if the `keys` property is set to `*`, as this could disrupt the algorithm
+      // used in the storage plugin. Instead, we should log an error in development
+      // mode. In production, it should continue to function, but act as a no-op.
+      return;
     }
-  ]);
+
+    inject(ɵNgxsStoragePluginKeysManager).addKeys(storageKeys);
+  });
 }

--- a/packages/store/src/standalone-features/initializers.ts
+++ b/packages/store/src/standalone-features/initializers.ts
@@ -1,4 +1,9 @@
-import { ENVIRONMENT_INITIALIZER, InjectionToken, Provider, inject } from '@angular/core';
+import {
+  InjectionToken,
+  Provider,
+  inject,
+  provideEnvironmentInitializer
+} from '@angular/core';
 import { ɵStateClassInternal } from '@ngxs/store/internals';
 
 import { Store } from '../store';
@@ -98,15 +103,9 @@ export const NGXS_FEATURE_STORE_INITIALIZER = new InjectionToken<void>(
   typeof ngDevMode !== 'undefined' && ngDevMode ? 'NGXS_FEATURE_STORE_INITIALIZER' : ''
 );
 
-export const NGXS_ROOT_ENVIRONMENT_INITIALIZER: Provider[] = [
+export const NGXS_ROOT_ENVIRONMENT_INITIALIZER: Provider = [
   { provide: NGXS_ROOT_STORE_INITIALIZER, useFactory: rootStoreInitializer },
-  {
-    provide: ENVIRONMENT_INITIALIZER,
-    multi: true,
-    useFactory() {
-      return () => inject(NGXS_ROOT_STORE_INITIALIZER);
-    }
-  }
+  provideEnvironmentInitializer(() => inject(NGXS_ROOT_STORE_INITIALIZER))
 ];
 
 /**
@@ -115,13 +114,7 @@ export const NGXS_ROOT_ENVIRONMENT_INITIALIZER: Provider[] = [
  * matched route where navigation occurs. The injector is created once, ensuring that
  * the feature states initialization only happens once as well.
  */
-export const NGXS_FEATURE_ENVIRONMENT_INITIALIZER: Provider[] = [
+export const NGXS_FEATURE_ENVIRONMENT_INITIALIZER: Provider = [
   { provide: NGXS_FEATURE_STORE_INITIALIZER, useFactory: featureStatesInitializer },
-  {
-    provide: ENVIRONMENT_INITIALIZER,
-    multi: true,
-    useFactory() {
-      return () => inject(NGXS_FEATURE_STORE_INITIALIZER);
-    }
-  }
+  provideEnvironmentInitializer(() => inject(NGXS_FEATURE_STORE_INITIALIZER))
 ];

--- a/packages/store/src/standalone-features/plugin.ts
+++ b/packages/store/src/standalone-features/plugin.ts
@@ -1,9 +1,9 @@
 import {
-  ENVIRONMENT_INITIALIZER,
   EnvironmentProviders,
   Type,
   inject,
-  makeEnvironmentProviders
+  makeEnvironmentProviders,
+  provideEnvironmentInitializer
 } from '@angular/core';
 import { NGXS_PLUGINS, NgxsPlugin, NgxsPluginFn, ɵisPluginClass } from '@ngxs/store/plugins';
 
@@ -31,10 +31,6 @@ export function withNgxsPlugin(plugin: Type<NgxsPlugin> | NgxsPluginFn): Environ
     // We should inject the `PluginManager` to retrieve `NGXS_PLUGINS` and
     // register those plugins. The plugin can be added from inside the child
     // route, so the plugin manager should be re-injected.
-    {
-      provide: ENVIRONMENT_INITIALIZER,
-      useValue: () => inject(PluginManager),
-      multi: true
-    }
+    provideEnvironmentInitializer(() => inject(PluginManager))
   ]);
 }


### PR DESCRIPTION
The `ENVIRONMENT_INITIALIZER` is unavailable in newer Angular versions.