### PR TITLE
refactor(store): move registry to internals

### DIFF
--- a/packages/store/internals/src/action-registry.ts
+++ b/packages/store/internals/src/action-registry.ts
@@ -4,7 +4,7 @@ import type { Observable } from 'rxjs';
 export type ActionHandlerFn = (action: any) => Observable<unknown>;
 
 @Injectable({ providedIn: 'root' })
-export class NgxsActionRegistry {
+export class ɵNgxsActionRegistry {
   // Instead of going over the states list every time an action is dispatched,
   // we are constructing a map of action types to lists of action metadata.
   // If the `@@Init` action is handled in two different states, the action

--- a/packages/store/internals/src/index.ts
+++ b/packages/store/internals/src/index.ts
@@ -10,3 +10,4 @@ export { ɵwrapObserverCalls } from './custom-rxjs-operators';
 export { ɵStateStream } from './state-stream';
 export { ɵof } from './rxjs';
 export { ɵhasOwnProperty, ɵdefineProperty } from './object-utils';
+export { ɵNgxsActionRegistry } from './action-registry';

--- a/packages/store/src/internal/state-factory.ts
+++ b/packages/store/src/internal/state-factory.ts
@@ -8,7 +8,8 @@ import {
   ɵStateClassInternal,
   ɵINITIAL_STATE_TOKEN,
   ɵSharedSelectorOptions,
-  ɵRuntimeSelectorContext
+  ɵRuntimeSelectorContext,
+  ɵNgxsActionRegistry
 } from '@ngxs/store/internals';
 import { getActionTypeFromInstance, getValue, setValue } from '@ngxs/store/plugins';
 import { ɵof } from '@ngxs/store/internals';
@@ -40,7 +41,6 @@ import {
   StatesByName,
   topologicalSort
 } from './internals';
-import { NgxsActionRegistry } from '../actions/action-registry';
 import { ActionContext, ActionStatus, InternalActions } from '../actions-stream';
 import { InternalDispatchedActionResults } from '../internal/action-results';
 import { ensureStateNameIsUnique, ensureStatesAreDecorated } from '../utils/store-validators';
@@ -84,7 +84,7 @@ export class StateFactory {
   private readonly _actions = inject(InternalActions);
   private readonly _actionResults = inject(InternalDispatchedActionResults);
   private readonly _initialState = inject(ɵINITIAL_STATE_TOKEN, { optional: true });
-  private readonly _actionRegistry = inject(NgxsActionRegistry);
+  private readonly _actionRegistry = inject(ɵNgxsActionRegistry);
   private readonly _propGetter = inject(ɵPROP_GETTER);
 
   private _actionsSubscription: Subscription | null = null;


### PR DESCRIPTION
In this commit, we move the registry from the core to the internals package to prepare for attaching action functionality.