### PR TITLE
refactor: replace `const enum`

### DIFF
--- a/packages/router-plugin/internals/src/symbols.ts
+++ b/packages/router-plugin/internals/src/symbols.ts
@@ -2,13 +2,10 @@ import { InjectionToken } from '@angular/core';
 
 declare const ngDevMode: boolean;
 
-export const NavigationActionTiming = {
-  PreActivation: 1,
-  PostActivation: 2
-} as const;
-
-export type NavigationActionTiming =
-  (typeof NavigationActionTiming)[keyof typeof NavigationActionTiming];
+export enum NavigationActionTiming {
+  PreActivation = 1,
+  PostActivation = 2
+}
 
 export interface NgxsRouterPluginOptions {
   navigationActionTiming?: NavigationActionTiming;

--- a/packages/storage-plugin/internals/src/symbols.ts
+++ b/packages/storage-plugin/internals/src/symbols.ts
@@ -10,12 +10,10 @@ export const ɵDEFAULT_STATE_KEY = '@@STATE';
 
 declare const ngDevMode: boolean;
 
-export const StorageOption = {
-  LocalStorage: 0,
-  SessionStorage: 1
-} as const;
-
-export type StorageOption = (typeof StorageOption)[keyof typeof StorageOption];
+export enum StorageOption {
+  LocalStorage,
+  SessionStorage
+}
 
 export interface NgxsStoragePluginOptions {
   /**

--- a/packages/store/src/actions-stream.ts
+++ b/packages/store/src/actions-stream.ts
@@ -8,14 +8,12 @@ import { InternalNgxsExecutionStrategy } from './execution/execution-strategy';
 /**
  * Status of a dispatched action
  */
-export const ActionStatus = {
-  Dispatched: 'DISPATCHED',
-  Successful: 'SUCCESSFUL',
-  Canceled: 'CANCELED',
-  Errored: 'ERRORED'
-} as const;
-
-export type ActionStatus = (typeof ActionStatus)[keyof typeof ActionStatus];
+export enum ActionStatus {
+  Dispatched = 'DISPATCHED',
+  Successful = 'SUCCESSFUL',
+  Canceled = 'CANCELED',
+  Errored = 'ERRORED'
+}
 
 export interface ActionContext<T = any> {
   status: ActionStatus;


### PR DESCRIPTION
Angular has a local compilation mode, intended for use with the TypeScript compiler option `isolatedModules`, which disallows importing `const enum`. In such cases, we replace it with an `enum` object.