### PR TITLE
refactor(store): clear `_states` on destroy to aid GC under high load

### DIFF
--- a/packages/store/src/internal/state-factory.ts
+++ b/packages/store/src/internal/state-factory.ts
@@ -127,7 +127,12 @@ export class StateFactory {
   });
 
   constructor() {
-    inject(DestroyRef).onDestroy(() => this._actionsSubscription?.unsubscribe());
+    inject(DestroyRef).onDestroy(() => {
+      // Clear state references to help the garbage collector in SSR
+      // environments under high load, preventing memory leaks.
+      this._states = [];
+      this._actionsSubscription?.unsubscribe();
+    });
   }
 
   /**


### PR DESCRIPTION
Prior to this change, the internal _states array in StateFactory could retain references after the request completes in SSR environments. While this does not affect client-side SPAs, it can prevent the garbage collector from freeing memory efficiently under high-concurrency SSR load.

This commit clears _states when the StateFactory is destroyed, helping reduce memory usage and prevent leaks in server-side rendering scenarios.