### PR TITLE
fix(store): guard against running state functions after injector is destroyed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ $ npm install @ngxs/store@dev
 ### To become next patch version
 
 - Feature(store): Expose `AbortSignal` on the state context [#2244](https://github.com/ngxs/store/pull/2244)
+- Fix(store): Guard against running state functions after injector is destroyed [#2366](https://github.com/ngxs/store/pull/2366)
 - Refactor(store): Clear `_states` on destroy to aid GC under high load [#2365](https://github.com/ngxs/store/pull/2365)
 
 ### 20.1.0 2025-07-16

--- a/packages/store/src/internal/dispatcher.ts
+++ b/packages/store/src/internal/dispatcher.ts
@@ -1,11 +1,4 @@
-import {
-  DestroyRef,
-  inject,
-  Injectable,
-  Injector,
-  NgZone,
-  runInInjectionContext
-} from '@angular/core';
+import { inject, Injectable, Injector, NgZone, runInInjectionContext } from '@angular/core';
 import {
   EMPTY,
   forkJoin,
@@ -37,7 +30,6 @@ export class InternalDispatcher {
   private _stateStream = inject(ɵStateStream);
   private _ngxsExecutionStrategy = inject(InternalNgxsExecutionStrategy);
   private _injector = inject(Injector);
-  private _destroyRef = inject(DestroyRef);
 
   /**
    * Dispatches event(s).


### PR DESCRIPTION
Adds a defensive check in the `compose` helper to ensure that no state
functions are executed once the root `Injector` has been destroyed.

Although the `destroyed` flag on `Injector` is not part of the public API,
it is available on the root injector instance. Using a cast here avoids the
need to inject `ApplicationRef`, which could introduce cyclic dependencies
or breaking changes.

This prevents runtime errors and unintended behavior when actions are
dispatched or state pipelines are invoked after application teardown.
