### PR TITLE
perf(storage-plugin): replace closure-based action matcher with direct type comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ $ npm install @ngxs/store@dev
 - Fix(store): Guard against running state functions after injector is destroyed [#2366](https://github.com/ngxs/store/pull/2366)
 - Refactor(store): Clear `_states` on destroy to aid GC under high load [#2365](https://github.com/ngxs/store/pull/2365)
 - Fix(storage-plugin): Guard against `engine` may be falsy [#2367](https://github.com/ngxs/store/pull/2367) [#2368](https://github.com/ngxs/store/pull/2368)
+- Peformance(storage-plugin): Replace closure-based action matcher with direct type comparison [#2369](https://github.com/ngxs/store/pull/2369)
 
 ### 20.1.0 2025-07-16
 

--- a/packages/storage-plugin/src/storage.plugin.ts
+++ b/packages/storage-plugin/src/storage.plugin.ts
@@ -7,7 +7,8 @@ import {
   InitState,
   UpdateState,
   actionMatcher,
-  NgxsNextPluginFn
+  NgxsNextPluginFn,
+  getActionTypeFromInstance
 } from '@ngxs/store/plugins';
 import {
   ɵDEFAULT_STATE_KEY,
@@ -33,9 +34,9 @@ export class NgxsStoragePlugin implements NgxsPlugin {
       return next(state, event);
     }
 
-    const matches = actionMatcher(event);
-    const isInitAction = matches(InitState);
-    const isUpdateAction = matches(UpdateState);
+    const type = getActionTypeFromInstance(event);
+    const isInitAction = type === InitState.type;
+    const isUpdateAction = type === UpdateState.type;
     const isInitOrUpdateAction = isInitAction || isUpdateAction;
     let hasMigration = false;
 


### PR DESCRIPTION
Switched from a closure-returning `actionMatcher` function to a direct type comparison approach. This removes the intermediate function allocation and makes the intent clearer by directly checking `getActionTypeFromInstance(event)` against known action types (`InitState.type` and `UpdateState.type`).