### PR TITLE
fix(router-plugin): avoid redundant NGXS state updates for identical router snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ $ npm install @ngxs/store@dev
 - Refactor(store): Drop `ɵwrapObserverCalls` [#2371](https://github.com/ngxs/store/pull/2371)
 - Fix(storage-plugin): Guard against `engine` may be falsy [#2367](https://github.com/ngxs/store/pull/2367) [#2368](https://github.com/ngxs/store/pull/2368)
 - Peformance(storage-plugin): Replace closure-based action matcher with direct type comparison [#2369](https://github.com/ngxs/store/pull/2369)
+- Fix(router-plugin): Avoid redundant NGXS state updates for identical router snapshots [#2372](https://github.com/ngxs/store/pull/2372)
 
 ### 20.1.0 2025-07-16
 


### PR DESCRIPTION
Previously, the router plugin always patched NGXS state on every router event, even if the new router snapshot was identical to the current one. This caused unnecessary updates to the internal NGXS state signal, triggering recomputations of `selectSignal` selectors and extra Angular change detection cycles.

With this change, we now compare the current and incoming router state (trigger, navigationId, and serialized snapshot). If they are equal, the state update is skipped. This avoids redundant signal emissions, leading to fewer recomputations and improved performance in large apps.