### PR TITLE
fix(store): prevent deepFreeze from freezing non-state objects

### DIFF
--- a/packages/store/src/utils/freeze.ts
+++ b/packages/store/src/utils/freeze.ts
@@ -6,7 +6,7 @@ import { ɵhasOwnProperty } from '@ngxs/store/internals';
  */
 export const deepFreeze = (o: any) => {
 // Skip freezing for non-state objects
-if (o && typeof o === 'object' && !o.__isState) {
+if (o && typeof o === 'object' && o.constructor !== Object && !Array.isArray(o)) {
         return o;
     }
   


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/ngxs/store/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, the `deepFreeze` function freezes all objects, including non-state objects, which can cause issues with Angular-specific objects like `tView` and other non-state-related objects.

Issue Number: N/A

## What is the new behavior?

The `deepFreeze` function has been updated to freeze only objects explicitly marked as part of the state (using a hypothetical `__isState` property). This ensures that non-state objects are skipped, preventing errors caused by freezing Angular-specific objects.


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
