### PR TITLE
feat(store): support async/await syntax for dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ $ npm install @ngxs/store@dev
 
 ### To become next version
 
-...
+- Feature(store): Support async/await syntax for dispatch [#2399](https://github.com/ngxs/store/pull/2399)
 
 ### 21.0.0 2025-12-17
 

--- a/docs/concepts/store/README.md
+++ b/docs/concepts/store/README.md
@@ -107,6 +107,53 @@ export class MyComponent {
 }
 ```
 
+The dispatched function returns a value that is both an `Observable` and a `PromiseLike`, so you can use either reactive or async/await patterns without any API change — the syntax at the call site determines the behavior.
+
+**Reactive (subscribe):**
+
+```ts
+export class MyComponent {
+  greet = dispatch(Greet);
+
+  onGreet() {
+    this.greet('Hello world!').subscribe(() => {
+      // action completed
+    });
+  }
+}
+```
+
+**Async/await:**
+
+```ts
+export class MyComponent {
+  greet = dispatch(Greet);
+
+  async onGreet() {
+    await this.greet('Hello world!');
+    // action completed
+  }
+}
+```
+
+**Error handling with async/await:**
+
+If the action throws, the rejection is propagated into the promise so a standard `try/catch` works as expected:
+
+```ts
+export class MyComponent {
+  greet = dispatch(Greet);
+
+  async onGreet() {
+    try {
+      await this.greet('Hello world!');
+    } catch (err) {
+      // handle error
+    }
+  }
+}
+```
+
 ### Snapshots
 
 You can get a snapshot of the state by calling `store.snapshot()`. This will return the entire value of the store for that point in time.

--- a/packages/store/src/utils/dispatch.ts
+++ b/packages/store/src/utils/dispatch.ts
@@ -1,9 +1,44 @@
 import { inject } from '@angular/core';
+import { Observable } from 'rxjs';
 
 import { Store } from '../store';
 import { ActionDef } from '../actions/symbols';
 
+// Extends Observable so callers can subscribe to emission updates (e.g. progress, intermediate states),
+// while implementing PromiseLike so the JS engine treats it as a thenable when `await` is used —
+// without this dual nature, callers would have to choose upfront between async/await and reactive patterns.
+class AsyncReturnType<T> extends Observable<T> implements PromiseLike<void> {
+  constructor(private dispatchResult$: Observable<T>) {
+    super(subscriber => dispatchResult$.subscribe(subscriber));
+  }
+
+  // Called automatically by the JS engine when `await dispatch(...)` is used.
+  // The PromiseLike contract requires full generics on TResult1/TResult2 to support
+  // promise chaining (e.g. `await dispatch(...).then(x => transform(x))`).
+  then<TResult1 = void, TResult2 = never>(
+    onfulfilled?: ((value: void) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null
+  ): PromiseLike<TResult1 | TResult2> {
+    return new Promise<void>((resolve, reject) => {
+      this.dispatchResult$.subscribe({
+        // Propagate observable errors into the promise rejection path so
+        // `try/catch` around `await dispatch(...)` works as expected.
+        error: reject,
+        // Resolve on complete rather than on next emission — dispatch returns void,
+        // so the caller cares about the action finishing, not any intermediate values.
+        complete: resolve
+      });
+    }).then(
+      // Bridge void → undefined because PromiseLike<void> resolves with no value,
+      // but `onfulfilled` still needs to be invoked to continue the chain correctly.
+      onfulfilled ? () => onfulfilled(undefined) : undefined,
+      // Normalize null to undefined since Promise.then doesn't accept null for rejection handler.
+      onrejected ?? undefined
+    );
+  }
+}
+
 export function dispatch<TArgs extends any[]>(ActionType: ActionDef<TArgs>) {
   const store = inject(Store);
-  return (...args: TArgs) => store.dispatch(new ActionType(...args));
+  return (...args: TArgs) => new AsyncReturnType(store.dispatch(new ActionType(...args)));
 }

--- a/packages/store/types/tests/dispatch.lint.ts
+++ b/packages/store/types/tests/dispatch.lint.ts
@@ -92,8 +92,8 @@ describe('[TEST]: Action Types', () => {
       dispatch(); // $ExpectError
       dispatch({}); // $ExpectError
       dispatch(FooAction); // $ExpectError
-      dispatch(OneArgumentAction); // $ExpectType (payload: string) => Observable<void>
-      dispatch(ManyArgumentsAction); // $ExpectType (arg_1: string, arg_2: number, arg_3: symbol) => Observable<void>
+      dispatch(OneArgumentAction); // $ExpectType (payload: string) => AsyncReturnType<void>
+      dispatch(ManyArgumentsAction); // $ExpectType (arg_1: string, arg_2: number, arg_3: symbol) => AsyncReturnType<void>
     });
   });
 


### PR DESCRIPTION
Wraps the result of `dispatch()` in a dual-natured return type that extends `Observable` and implements `PromiseLike<void>`. This allows callers to either subscribe reactively or use `await` without any API change — the dispatch function signature stays the same and the caller's syntax alone determines the behavior.