### PR TITLE
fix(store): return original reference from updateItems when no elements match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ $ npm install @ngxs/store@dev
 - Fix(store): Warn when state is mutated after injector destruction [#2407](https://github.com/ngxs/store/pull/2407)
 - Fix(store): Report destroyed injector errors via `ErrorHandler` [#2409](https://github.com/ngxs/store/pull/2409)
 - Fix(store): Include state path in `StateContextDestroyedError` production message [#2421](https://github.com/ngxs/store/pull/2421)
+- Fix(store): Return original reference from `updateItems` when no elements match [#2424](https://github.com/ngxs/store/pull/2424)
 - Fix(storage-plugin): Guard against environments that do not provide `ngServerMode` [#2400](https://github.com/ngxs/store/pull/2400)
 - Fix(storage-plugin): Improve dependency ranges for security fixes [#2404](https://github.com/ngxs/store/pull/2404)
 - Fix(storage-plugin): Treat missing version key as 0 when matching migrations [#2422](https://github.com/ngxs/store/pull/2422)

--- a/packages/store/operators/src/update-items.ts
+++ b/packages/store/operators/src/update-items.ts
@@ -40,6 +40,7 @@ export function updateItems<T>(
     }
 
     const clone = existing.slice();
+    let updated = false;
     for (let index = 0; index < clone.length; index++) {
       let value = clone[index];
       if (selector(value)) {
@@ -50,8 +51,11 @@ export function updateItems<T>(
           value = theOperatorOrValue;
         }
         clone[index] = value;
+        updated = true;
       }
     }
-    return clone;
+    // Return the original reference when nothing was updated to avoid
+    // invalidating memoized selectors on a no-op call.
+    return updated ? clone : existing;
   };
 }


### PR DESCRIPTION
updateItems always returned a new array clone, even when no element matched the predicate. This caused memoized selectors to see a changed reference and re-evaluate on every no-op call.

Track whether any element was actually updated and return the original array reference unchanged when the predicate matched nothing.