### PR TITLE
feat(store): expose ɵgetTypedNgxsStateFactory for internal third-party usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ $ npm install @ngxs/store@dev
 - Feature(store): Add `safePatch` operator [#2408](https://github.com/ngxs/store/pull/2408)
 - Feature(store): Add `updateItems` operator [#2413](https://github.com/ngxs/store/pull/2413)
 - Feature(store): Add `removeItems` operator [#2414](https://github.com/ngxs/store/pull/2414)
+- Feature(store): Expose `ɵgetTypedNgxsStateFactory` for internal third-party usage [#2426](https://github.com/ngxs/store/pull/2426)
 - Fix(store): Cleanup observers once subjects complete [#2401](https://github.com/ngxs/store/pull/2401)
 - Fix(store): Skip state mutations when injector is destroyed mid-action [#2406](https://github.com/ngxs/store/pull/2406)
 - Fix(store): Warn when state is mutated after injector destruction [#2407](https://github.com/ngxs/store/pull/2407)

--- a/packages/store/src/internal/provide-internal-tokens.ts
+++ b/packages/store/src/internal/provide-internal-tokens.ts
@@ -1,8 +1,13 @@
 import { makeEnvironmentProviders } from '@angular/core';
-import { ɵNGXS_STATE_CONTEXT_FACTORY, ɵNGXS_STATE_FACTORY } from '@ngxs/store/internals';
+import {
+  ɵNGXS_STATE_CONTEXT_FACTORY,
+  ɵNGXS_STATE_FACTORY,
+  type ɵPlainObjectOf
+} from '@ngxs/store/internals';
 
 import { StateFactory } from './state-factory';
 import { StateContextFactory } from './state-context-factory';
+import type { MappedStore, StatesByName } from './internals';
 
 // Backward compatibility is provided because these tokens are used by third-party
 // libraries. We expose a separate function to allow tree-shaking of these tokens
@@ -18,4 +23,22 @@ export function ɵprovideNgxsInternalStateTokens() {
       useExisting: StateFactory
     }
   ]);
+}
+
+// For internal third-party usage only.
+// Provides a type-safe accessor for `StateFactory`'s private fields so that
+// third-party consumers do not have to cast or use bracket notation themselves.
+export function ɵgetTypedNgxsStateFactory(stateFactory: any): {
+  states: MappedStore[];
+  statesByName: StatesByName;
+  statePaths: ɵPlainObjectOf<string>;
+} {
+  return {
+    // The flat list of all registered mapped stores.
+    states: stateFactory['_states'],
+    // A name-keyed map of all registered states.
+    statesByName: stateFactory['_statesByName'],
+    // A map of dot-separated state paths (e.g. "parent.child") to each state's name.
+    statePaths: stateFactory['_statePaths']
+  };
 }


### PR DESCRIPTION
Adds `ɵgetTypedNgxsStateFactory`, a type-safe accessor that surfaces `StateFactory`'s private fields (`_states`, `_statesByName`, `_statePaths`) without requiring consumers to cast or use bracket notation themselves.

The return type is declared explicitly on the function signature so that third-party libraries can rely on a stable, typed contract rather than the inferred shape of private internals.