### PR TITLE
perf(store): reduce operator allocations on action dispatch hot path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ $ npm install @ngxs/store@dev
 - Fix(store): Include state path in `StateContextDestroyedError` production message [#2421](https://github.com/ngxs/store/pull/2421)
 - Fix(store): Return original reference from `updateItems` when no elements match [#2424](https://github.com/ngxs/store/pull/2424)
 - Fix(store): Silence `console.warn` in `withNgxsPendingTasks` for browser [#2425](https://github.com/ngxs/store/pull/2425)
+- Performance(store): Reduce operator allocations on action dispatch hot path [#2435](https://github.com/ngxs/store/pull/2435)
 - Fix(storage-plugin): Guard against environments that do not provide `ngServerMode` [#2400](https://github.com/ngxs/store/pull/2400)
 - Fix(storage-plugin): Improve dependency ranges for security fixes [#2404](https://github.com/ngxs/store/pull/2404)
 - Fix(storage-plugin): Treat missing version key as 0 when matching migrations [#2422](https://github.com/ngxs/store/pull/2422)

--- a/packages/store/src/internal/dispatcher.ts
+++ b/packages/store/src/internal/dispatcher.ts
@@ -6,17 +6,7 @@ import {
   NgZone,
   runInInjectionContext
 } from '@angular/core';
-import {
-  EMPTY,
-  forkJoin,
-  Observable,
-  filter,
-  map,
-  mergeMap,
-  shareReplay,
-  take,
-  of
-} from 'rxjs';
+import { EMPTY, forkJoin, Observable, map, mergeMap, shareReplay, of } from 'rxjs';
 
 import { getActionTypeFromInstance } from '@ngxs/store/plugins';
 import { ɵPlainObject, ɵStateStream } from '@ngxs/store/internals';
@@ -94,13 +84,23 @@ export class InternalDispatcher {
   }
 
   private getActionResultStream(action: any): Observable<ActionContext> {
-    return this._actionResults.pipe(
-      filter(
-        (ctx: ActionContext) => ctx.action === action && ctx.status !== ActionStatus.Dispatched
-      ),
-      take(1),
-      shareReplay()
-    );
+    // Hot path: avoid allocating `filter` + `take(1)` operator subscriber wrappers on every
+    // dispatch. Instead, subscribe directly and complete inline — functionally identical but
+    // without the intermediate operator chain objects.
+    // `subscriber.complete()` triggers the outer subscription's teardown synchronously, which
+    // calls `.unsubscribe()` on the inner `_actionResults` subscription (the returned
+    // TeardownLogic), so there is no leak even though unsubscription fires mid-callback.
+    return new Observable<ActionContext>(subscriber => {
+      return this._actionResults.subscribe({
+        next: ctx => {
+          if (ctx.action === action && ctx.status !== ActionStatus.Dispatched) {
+            subscriber.next(ctx);
+            subscriber.complete();
+          }
+        },
+        complete: () => !subscriber.closed && subscriber.complete()
+      });
+    }).pipe(shareReplay());
   }
 
   private createDispatchObservable(

--- a/packages/store/src/internal/state-factory.ts
+++ b/packages/store/src/internal/state-factory.ts
@@ -1,4 +1,5 @@
 import { DestroyRef, Injectable, Injector, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
   ɵmemoize,
   ɵMETA_KEY,
@@ -12,17 +13,7 @@ import {
   ɵNgxsActionRegistry
 } from '@ngxs/store/internals';
 import { getActionTypeFromInstance, getValue, setValue } from '@ngxs/store/plugins';
-import {
-  forkJoin,
-  Subscription,
-  catchError,
-  defaultIfEmpty,
-  filter,
-  map,
-  mergeMap,
-  Observable,
-  of
-} from 'rxjs';
+import { forkJoin, catchError, defaultIfEmpty, map, Observable, of } from 'rxjs';
 
 import { NgxsConfig, StateContext } from '../symbols';
 import {
@@ -80,8 +71,7 @@ export class StateFactory {
   private readonly _initialState = inject(ɵINITIAL_STATE_TOKEN, { optional: true });
   private readonly _actionRegistry = inject(ɵNgxsActionRegistry);
   private readonly _propGetter = inject(ɵPROP_GETTER);
-
-  private _actionsSubscription: Subscription | null = null;
+  private readonly _destroyRef = inject(DestroyRef);
 
   private _ngxsUnhandledErrorHandler: NgxsUnhandledErrorHandler = null!;
 
@@ -127,11 +117,10 @@ export class StateFactory {
   });
 
   constructor() {
-    inject(DestroyRef).onDestroy(() => {
+    this._destroyRef.onDestroy(() => {
       // Clear state references to help the garbage collector in SSR
       // environments under high load, preventing memory leaks.
       this._states = [];
-      this._actionsSubscription?.unsubscribe();
     });
   }
 
@@ -202,36 +191,35 @@ export class StateFactory {
   }
 
   connectActionHandlers(): void {
-    this._actionsSubscription = this._actions
-      .pipe(
-        filter((ctx: ActionContext) => ctx.status === ActionStatus.Dispatched),
-        mergeMap(ctx => {
-          const action: any = ctx.action;
-          return this.invokeActions(action).pipe(
-            map(() => <ActionContext>{ action, status: ActionStatus.Successful }),
-            defaultIfEmpty(<ActionContext>{ action, status: ActionStatus.Canceled }),
-            catchError(error => {
-              const ngxsUnhandledErrorHandler = (this._ngxsUnhandledErrorHandler ||=
-                this._injector.get(NgxsUnhandledErrorHandler));
-              const handleableError = assignUnhandledCallback(error, () =>
-                ngxsUnhandledErrorHandler.handleError(error, { action })
-              );
-              return of(<ActionContext>{
-                action,
-                status: ActionStatus.Errored,
-                error: handleableError
-              });
-            })
-          );
-        })
-      )
-      .subscribe(ctx => this._actionResults.next(ctx));
+    this._actions.subscribe(ctx => {
+      if (ctx.status !== ActionStatus.Dispatched) return;
+      const action = ctx.action;
+      this.invokeActions(action)
+        .pipe(
+          map(() => <ActionContext>{ action, status: ActionStatus.Successful }),
+          defaultIfEmpty(<ActionContext>{ action, status: ActionStatus.Canceled }),
+          catchError(error => {
+            const ngxsUnhandledErrorHandler = (this._ngxsUnhandledErrorHandler ||=
+              this._injector.get(NgxsUnhandledErrorHandler));
+            const handleableError = assignUnhandledCallback(error, () =>
+              ngxsUnhandledErrorHandler.handleError(error, { action })
+            );
+            return of(<ActionContext>{
+              action,
+              status: ActionStatus.Errored,
+              error: handleableError
+            });
+          }),
+          takeUntilDestroyed(this._destroyRef)
+        )
+        .subscribe(ctx => this._actionResults.next(ctx));
+    });
   }
 
   /**
    * Invoke actions on the states.
    */
-  private invokeActions(action: any): Observable<unknown[]> {
+  private invokeActions(action: any): Observable<unknown> {
     const type = getActionTypeFromInstance(action)!;
     const results: Observable<unknown>[] = [];
 
@@ -267,11 +255,7 @@ export class StateFactory {
       unhandledActionsLogger?.warn(action);
     }
 
-    if (!results.length) {
-      results.push(of(undefined));
-    }
-
-    return forkJoin(results);
+    return results.length > 0 ? forkJoin(results) : of(undefined);
   }
 
   private addToStatesMap(stateClasses: ɵStateClassInternal[]): {


### PR DESCRIPTION
- Replace `filter` + `take(1)` in `getActionResultStream` with a manual Observable constructor, avoiding two operator wrapper allocations per dispatch

- Replace `filter` + `mergeMap` in `connectActionHandlers` with a direct subscribe and inline status check, removing two more operator wrappers from the per-dispatch path

- Drop `_actionsSubscription` — `InternalActions` completes with the root injector, so manual unsubscription is redundant; add `takeUntilDestroyed` to in-flight handler subscriptions for explicit cancellation on destroy

- Simplify the `invokeActions` no-handler fallback from an array mutation to a ternary: `results.length > 0 ? forkJoin(results) : of(undefined)`