### PR TITLE
perf(store): replace map/defaultIfEmpty/catchError with manual Observable in connectActionHandlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ $ npm install @ngxs/store@dev
 - Fix(store): Return original reference from `updateItems` when no elements match [#2424](https://github.com/ngxs/store/pull/2424)
 - Fix(store): Silence `console.warn` in `withNgxsPendingTasks` for browser [#2425](https://github.com/ngxs/store/pull/2425)
 - Performance(store): Reduce operator allocations on action dispatch hot path [#2435](https://github.com/ngxs/store/pull/2435)
+- Performance(store): Replace `map/defaultIfEmpty/catchError` with manual `Observable` in `connectActionHandlers` [#2437](https://github.com/ngxs/store/pull/2435)
 - Fix(storage-plugin): Guard against environments that do not provide `ngServerMode` [#2400](https://github.com/ngxs/store/pull/2400)
 - Fix(storage-plugin): Improve dependency ranges for security fixes [#2404](https://github.com/ngxs/store/pull/2404)
 - Fix(storage-plugin): Treat missing version key as 0 when matching migrations [#2422](https://github.com/ngxs/store/pull/2422)

--- a/packages/store/src/internal/state-factory.ts
+++ b/packages/store/src/internal/state-factory.ts
@@ -12,17 +12,7 @@ import {
   ɵNgxsActionRegistry
 } from '@ngxs/store/internals';
 import { getActionTypeFromInstance, getValue, setValue } from '@ngxs/store/plugins';
-import {
-  forkJoin,
-  catchError,
-  defaultIfEmpty,
-  map,
-  Observable,
-  of,
-  type Unsubscribable,
-  mergeMap,
-  EMPTY
-} from 'rxjs';
+import { forkJoin, Observable, of, type Unsubscribable, mergeMap, EMPTY } from 'rxjs';
 
 import { NgxsConfig, StateContext } from '../symbols';
 import {
@@ -209,20 +199,31 @@ export class StateFactory {
           }
 
           const action = ctx.action;
-          return this.invokeActions(action).pipe(
-            map(() => <ActionContext>{ action, status: ActionStatus.Successful }),
-            defaultIfEmpty(<ActionContext>{ action, status: ActionStatus.Canceled }),
-            catchError(error => {
-              const ngxsUnhandledErrorHandler = (this._ngxsUnhandledErrorHandler ||=
-                this._injector.get(NgxsUnhandledErrorHandler));
-              const handleableError = assignUnhandledCallback(error, () =>
-                ngxsUnhandledErrorHandler.handleError(error, { action })
-              );
-              return of(<ActionContext>{
-                action,
-                status: ActionStatus.Errored,
-                error: handleableError
-              });
+
+          return new Observable<ActionContext>(subscriber =>
+            this.invokeActions(action).subscribe({
+              next: () => {
+                subscriber.next(<ActionContext>{ action, status: ActionStatus.Successful });
+                subscriber.complete();
+              },
+              error: error => {
+                const ngxsUnhandledErrorHandler = (this._ngxsUnhandledErrorHandler ||=
+                  this._injector.get(NgxsUnhandledErrorHandler));
+                const handleableError = assignUnhandledCallback(error, () =>
+                  ngxsUnhandledErrorHandler.handleError(error, { action })
+                );
+                subscriber.next(<ActionContext>{
+                  action,
+                  status: ActionStatus.Errored,
+                  error: handleableError
+                });
+                subscriber.complete();
+              },
+              complete: () => {
+                if (subscriber.closed) return;
+                subscriber.next(<ActionContext>{ action, status: ActionStatus.Canceled });
+                subscriber.complete();
+              }
             })
           );
         })


### PR DESCRIPTION
Remove three operator wrappers from the per-dispatch hot path. Replace with a manual Observable constructor that maps invokeActions outcomes inline:

- next  → Successful, then complete
- error → Errored (with unhandled callback), then complete
- complete when not yet closed → Canceled

subscriber.closed in the complete handler detects whether next already fired, replicating the defaultIfEmpty invariant without the operator allocation. The inner Subscription is returned implicitly from the arrow function, so mergeMap unsubscribes it correctly on teardown.