### PR TITLE
perf(store): prevent StateFactory retention via unhandled error callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ $ npm install @ngxs/store@dev
 - Fix(store): Silence `console.warn` in `withNgxsPendingTasks` for browser [#2425](https://github.com/ngxs/store/pull/2425)
 - Performance(store): Reduce operator allocations on action dispatch hot path [#2435](https://github.com/ngxs/store/pull/2435)
 - Performance(store): Replace `map/defaultIfEmpty/catchError` with manual `Observable` in `connectActionHandlers` [#2437](https://github.com/ngxs/store/pull/2435)
+- Performance(store): Prevent `StateFactory` retention via unhandled error callback [#2438](https://github.com/ngxs/store/pull/2438)
 - Fix(storage-plugin): Guard against environments that do not provide `ngServerMode` [#2400](https://github.com/ngxs/store/pull/2400)
 - Fix(storage-plugin): Improve dependency ranges for security fixes [#2404](https://github.com/ngxs/store/pull/2404)
 - Fix(storage-plugin): Treat missing version key as 0 when matching migrations [#2422](https://github.com/ngxs/store/pull/2422)

--- a/packages/store/src/internal/state-factory.ts
+++ b/packages/store/src/internal/state-factory.ts
@@ -209,9 +209,20 @@ export class StateFactory {
               error: error => {
                 const ngxsUnhandledErrorHandler = (this._ngxsUnhandledErrorHandler ||=
                   this._injector.get(NgxsUnhandledErrorHandler));
-                const handleableError = assignUnhandledCallback(error, () =>
-                  ngxsUnhandledErrorHandler.handleError(error, { action })
-                );
+                function callback() {
+                  ngxsUnhandledErrorHandler.handleError(error, { action });
+                }
+                // An arrow function here would share the `[[Context]]` of the enclosing `error =>`
+                // arrow function, which captures `this` (StateFactory), causing the error object to
+                // retain the entire instance. A named function declaration creates its own context and
+                // V8 only captures variables it actually references — `ngxsUnhandledErrorHandler`,
+                // `error`, `action` — so `this` is never captured. `.bind(null)` goes one step further:
+                // a JSBoundFunction has no `[[Context]]` slot at all, fully severing the retention chain.
+                // This matters because the callback is stored as a value in the
+                // `ɵɵunhandledRxjsErrorCallbacks` WeakMap, keyed by the error object. The error may be
+                // held by third-party code (e.g. error trackers, logging) for an indeterminate duration,
+                // and we have no control over when that key is released.
+                const handleableError = assignUnhandledCallback(error, callback.bind(null));
                 subscriber.next(<ActionContext>{
                   action,
                   status: ActionStatus.Errored,


### PR DESCRIPTION
An arrow function passed directly to `assignUnhandledCallback` would share the `[[Context]]` of the enclosing arrow function, which captures `this` (StateFactory). If the error is held by third-party code (e.g. error trackers) through the `ɵɵunhandledRxjsErrorCallbacks` WeakMap, the entire StateFactory instance would be retained for an indeterminate duration.

Using a named function declaration ensures V8 only captures the variables actually referenced (`ngxsUnhandledErrorHandler`, `error`, `action`), excluding `this`. Binding it to `null` produces a JSBoundFunction with no `[[Context]]` slot, fully severing the retention chain.