### PR TITLE
feat(store): error in dev mode when selectSignal selector returns new reference with identical value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ $ npm install @ngxs/store@dev
 - Feature(store): Add `updateItems` operator [#2413](https://github.com/ngxs/store/pull/2413)
 - Feature(store): Add `removeItems` operator [#2414](https://github.com/ngxs/store/pull/2414)
 - Feature(store): Expose `ɵgetTypedNgxsStateFactory` for internal third-party usage [#2426](https://github.com/ngxs/store/pull/2426)
+- Feature(store): Error in dev mode when `selectSignal` selector returns new reference with identical value [#2441](https://github.com/ngxs/store/pull/2441)
 - Fix(store): Cleanup observers once subjects complete [#2401](https://github.com/ngxs/store/pull/2401)
 - Fix(store): Skip state mutations when injector is destroyed mid-action [#2406](https://github.com/ngxs/store/pull/2406)
 - Fix(store): Warn when state is mutated after injector destruction [#2407](https://github.com/ngxs/store/pull/2407)

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -109,6 +109,22 @@ export class Store {
     const selectorFn = this.getStoreBoundSelectorFn(selector);
     if (typeof ngDevMode !== 'undefined' && ngDevMode) {
       return computed<T>(() => selectorFn(this._stateStream.state()), {
+        equal: (a, b) => {
+          if (!Object.is(a, b)) {
+            try {
+              if (JSON.stringify(a) === JSON.stringify(b)) {
+                console.error(
+                  'The selector returned the same value shape as it was before triggering signal recomputation. Selector function: ',
+                  selectorFn
+                );
+              }
+            } catch {
+              // Swallow silently.
+            }
+          }
+          return false;
+        },
+
         debugName: 'NGXS selectSignal'
       });
     } else {


### PR DESCRIPTION
In dev mode, `selectSignal` now logs a `console.error` when a selector returns a new object reference with the same JSON value as the previous result. This usually means the selector is missing memoization and is causing unnecessary downstream recomputations.

The check uses `Object.is(a, b)` to avoid warning for properly memoized selectors that already return the same reference.

The `equal` function still always returns `false` so recomputation continues to propagate normally, keeping the warning accurate for all state updates.