### PR TITLE
feat(store): add warnOnNewReferenceWithIdenticalValue to NgxsDevelopmentOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ $ npm install @ngxs/store@dev
 - Feature(store): Add `removeItems` operator [#2414](https://github.com/ngxs/store/pull/2414)
 - Feature(store): Expose `ɵgetTypedNgxsStateFactory` for internal third-party usage [#2426](https://github.com/ngxs/store/pull/2426)
 - Feature(store): Error in dev mode when `selectSignal` selector returns new reference with identical value [#2441](https://github.com/ngxs/store/pull/2441)
+- Feature(store): add `warnOnNewReferenceWithIdenticalValue` to `NgxsDevelopmentOptions` [#2442](https://github.com/ngxs/store/pull/2442)
 - Fix(store): Cleanup observers once subjects complete [#2401](https://github.com/ngxs/store/pull/2401)
 - Fix(store): Skip state mutations when injector is destroyed mid-action [#2406](https://github.com/ngxs/store/pull/2406)
 - Fix(store): Warn when state is mutated after injector destruction [#2407](https://github.com/ngxs/store/pull/2407)

--- a/packages/store/src/dev-features/symbols.ts
+++ b/packages/store/src/dev-features/symbols.ts
@@ -3,6 +3,9 @@ import { InjectionToken } from '@angular/core';
 import { ActionType } from '../actions/symbols';
 
 export interface NgxsDevelopmentOptions {
+  warnOnNewReferenceWithIdenticalValue?: {
+    isEqual: (a: unknown, b: unknown) => boolean;
+  };
   // This allows setting only `true` because there's no reason to set `false`.
   // Developers may just skip importing the development module at all.
   warnOnUnhandledActions:
@@ -16,7 +19,6 @@ export const NGXS_DEVELOPMENT_OPTIONS =
   /* @__PURE__ */ new InjectionToken<NgxsDevelopmentOptions>(
     typeof ngDevMode !== 'undefined' && ngDevMode ? 'NGXS_DEVELOPMENT_OPTIONS' : '',
     {
-      providedIn: 'root',
       factory: () => ({ warnOnUnhandledActions: true })
     }
   );

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -1,4 +1,4 @@
-import { computed, inject, Injectable, Signal } from '@angular/core';
+import { computed, inject, Injectable, Injector, Signal } from '@angular/core';
 import {
   type Subscription,
   catchError,
@@ -18,6 +18,7 @@ import { NgxsConfig } from './symbols';
 import { StateFactory } from './internal/state-factory';
 import { TypedSelector } from './selectors';
 import { InternalNgxsExecutionStrategy } from './execution/execution-strategy';
+import { NGXS_DEVELOPMENT_OPTIONS } from './dev-features/symbols';
 
 // We need to check whether the provided `T` type extends an array in order to
 // apply the `NonNullable[]` type to its elements. This is because, for
@@ -27,6 +28,7 @@ type ActionOrArrayOfActions<T> = T extends (infer U)[] ? NonNullable<U>[] : NonN
 
 @Injectable({ providedIn: 'root' })
 export class Store {
+  private _injector?: Injector;
   private _stateStream = inject(ɵStateStream);
   private _internalStateOperations = inject(InternalStateOperations);
   private _config = inject(NgxsConfig);
@@ -45,6 +47,10 @@ export class Store {
 
   constructor() {
     this.initStateStream();
+
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+      this._injector = inject(Injector);
+    }
   }
 
   /**
@@ -110,9 +116,13 @@ export class Store {
     if (typeof ngDevMode !== 'undefined' && ngDevMode) {
       return computed<T>(() => selectorFn(this._stateStream.state()), {
         equal: (a, b) => {
-          if (!Object.is(a, b)) {
+          const warnOption = this._injector?.get(
+            NGXS_DEVELOPMENT_OPTIONS,
+            null
+          )?.warnOnNewReferenceWithIdenticalValue;
+          if (warnOption && !Object.is(a, b)) {
             try {
-              if (JSON.stringify(a) === JSON.stringify(b)) {
+              if (warnOption.isEqual(a, b)) {
                 console.error(
                   'The selector returned the same value shape as it was before triggering signal recomputation. Selector function: ',
                   selector


### PR DESCRIPTION
Introduces a new `warnOnNewReferenceWithIdenticalValue` option to `NgxsDevelopmentOptions`. When configured, `selectSignal` will warn in dev mode if a selector returns a new reference whose value is considered equal by the provided `isEqual` function, indicating unnecessary signal recomputation.

The option requires a user-supplied `isEqual` implementation (e.g. lodash `isEqual`) rather than relying on `JSON.stringify`, which is prohibitively slow inside a signal equality check.