### PR TITLE
feat(storage-plugin): support factory functions as engine in KeyWithExplicitEngine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ $ npm install @ngxs/store@dev
 - Feature(store): Expose `ɵgetTypedNgxsStateFactory` for internal third-party usage [#2426](https://github.com/ngxs/store/pull/2426)
 - Feature(store): Error in dev mode when `selectSignal` selector returns new reference with identical value [#2441](https://github.com/ngxs/store/pull/2441)
 - Feature(store): add `warnOnNewReferenceWithIdenticalValue` to `NgxsDevelopmentOptions` [#2442](https://github.com/ngxs/store/pull/2442)
+- Feature(storage-plugin): Support factory functions as `engine` in `KeyWithExplicitEngine` [#2444](https://github.com/ngxs/store/pull/2444)
 - Fix(store): Cleanup observers once subjects complete [#2401](https://github.com/ngxs/store/pull/2401)
 - Fix(store): Skip state mutations when injector is destroyed mid-action [#2406](https://github.com/ngxs/store/pull/2406)
 - Fix(store): Warn when state is mutated after injector destruction [#2407](https://github.com/ngxs/store/pull/2407)

--- a/docs/plugins/storage.md
+++ b/docs/plugins/storage.md
@@ -233,6 +233,38 @@ export const appConfig: ApplicationConfig = {
 };
 ```
 
+The `engine` property also accepts a factory function `() => StorageEngine`. The function runs in an Angular injection context, so `inject()` is available inside it. This is useful when the same engine class needs different construction arguments for different keys:
+
+```ts
+import { inject } from '@angular/core';
+import { withNgxsStoragePlugin, StorageEngine } from '@ngxs/storage-plugin';
+
+export class MyCustomStorageEngine implements StorageEngine {
+  constructor(private readonly fallback: StorageEngine | null) {}
+  // ...
+}
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideStore(
+      [NovelsState, DetectivesState],
+      withNgxsStoragePlugin({
+        keys: [
+          {
+            key: 'novels',
+            engine: () => new MyCustomStorageEngine(inject(SESSION_STORAGE_ENGINE))
+          },
+          {
+            key: 'detectives',
+            engine: () => new MyCustomStorageEngine(null) // no fallback storage
+          }
+        ]
+      })
+    )
+  ]
+};
+```
+
 ### Namespace Option
 
 The namespace option should be provided when the storage plugin is used in micro frontend applications. The namespace may equal the app name and will prefix keys for state slices:

--- a/packages/storage-plugin/internals/src/storage-key.ts
+++ b/packages/storage-plugin/internals/src/storage-key.ts
@@ -7,12 +7,19 @@ import { StorageEngine } from './symbols';
 /** This enables the user to provide a storage engine per individual key. */
 export interface KeyWithExplicitEngine {
   key: string | ɵStateClass | StateToken<any>;
-  engine: Type<StorageEngine> | InjectionToken<StorageEngine>;
+  engine: Type<StorageEngine> | InjectionToken<StorageEngine> | (() => StorageEngine);
 }
 
 /** Determines whether the provided key has the following structure. */
 export function ɵisKeyWithExplicitEngine(key: any): key is KeyWithExplicitEngine {
   return !!key?.engine;
+}
+
+/** Determines whether the engine is a factory function rather than a class or InjectionToken. */
+export function ɵisEngineFactory(
+  engine: Type<StorageEngine> | InjectionToken<StorageEngine> | (() => StorageEngine)
+): engine is () => StorageEngine {
+  return !(engine instanceof InjectionToken) && !engine.toString().startsWith('class');
 }
 
 /**

--- a/packages/storage-plugin/internals/src/symbols.ts
+++ b/packages/storage-plugin/internals/src/symbols.ts
@@ -93,7 +93,6 @@ export const ɵUSER_OPTIONS = new InjectionToken<NgxsStoragePluginOptions>(
 export const ɵALL_STATES_PERSISTED = new InjectionToken<boolean>(
   typeof ngDevMode !== 'undefined' && ngDevMode ? 'ALL_STATES_PERSISTED' : '',
   {
-    providedIn: 'root',
     factory: () => inject(ɵUSER_OPTIONS).keys === '*'
   }
 );

--- a/packages/storage-plugin/src/engines.ts
+++ b/packages/storage-plugin/src/engines.ts
@@ -7,7 +7,6 @@ declare const ngServerMode: boolean;
 export const LOCAL_STORAGE_ENGINE = /* @__PURE__ */ new InjectionToken<StorageEngine | null>(
   typeof ngDevMode !== 'undefined' && ngDevMode ? 'LOCAL_STORAGE_ENGINE' : '',
   {
-    providedIn: 'root',
     factory: () => (typeof ngServerMode !== 'undefined' && ngServerMode ? null : localStorage)
   }
 );
@@ -15,7 +14,6 @@ export const LOCAL_STORAGE_ENGINE = /* @__PURE__ */ new InjectionToken<StorageEn
 export const SESSION_STORAGE_ENGINE = /* @__PURE__ */ new InjectionToken<StorageEngine | null>(
   typeof ngDevMode !== 'undefined' && ngDevMode ? 'SESSION_STORAGE_ENGINE' : '',
   {
-    providedIn: 'root',
     factory: () =>
       typeof ngServerMode !== 'undefined' && ngServerMode ? null : sessionStorage
   }

--- a/packages/storage-plugin/src/keys-manager.ts
+++ b/packages/storage-plugin/src/keys-manager.ts
@@ -1,9 +1,10 @@
-import { Injectable, Injector, inject } from '@angular/core';
+import { Injectable, Injector, inject, runInInjectionContext } from '@angular/core';
 import {
   STORAGE_ENGINE,
   StorageEngine,
   StorageKey,
   ɵextractStringKey,
+  ɵisEngineFactory,
   ɵisKeyWithExplicitEngine,
   ɵNGXS_STORAGE_PLUGIN_OPTIONS
 } from '@ngxs/storage-plugin/internals';
@@ -13,7 +14,7 @@ interface KeyWithEngine {
   engine: StorageEngine | null;
 }
 
-@Injectable({ providedIn: 'root' })
+@Injectable()
 export class ɵNgxsStoragePluginKeysManager {
   /** Store keys separately in a set so we're able to check if the key already exists. */
   private readonly _keys = new Set<string>();
@@ -49,7 +50,9 @@ export class ɵNgxsStoragePluginKeysManager {
       this._keys.add(key);
 
       const engine = ɵisKeyWithExplicitEngine(storageKey)
-        ? this._injector.get(storageKey.engine)
+        ? ɵisEngineFactory(storageKey.engine)
+          ? runInInjectionContext(this._injector, storageKey.engine)
+          : this._injector.get(storageKey.engine)
         : this._injector.get(STORAGE_ENGINE);
 
       this._keysWithEngines.push({ key, engine });

--- a/packages/storage-plugin/src/storage.module.ts
+++ b/packages/storage-plugin/src/storage.module.ts
@@ -14,6 +14,7 @@ import {
 
 import { NgxsStoragePlugin } from './storage.plugin';
 import { engineFactory, storageOptionsFactory } from './internals';
+import { ɵNgxsStoragePluginKeysManager } from './keys-manager';
 
 @NgModule()
 export class NgxsStoragePluginModule {
@@ -23,6 +24,7 @@ export class NgxsStoragePluginModule {
     return {
       ngModule: NgxsStoragePluginModule,
       providers: [
+        ɵNgxsStoragePluginKeysManager,
         withNgxsPlugin(NgxsStoragePlugin),
         {
           provide: ɵUSER_OPTIONS,
@@ -47,6 +49,7 @@ export function withNgxsStoragePlugin(
   options: NgxsStoragePluginOptions
 ): EnvironmentProviders {
   return makeEnvironmentProviders([
+    ɵNgxsStoragePluginKeysManager,
     withNgxsPlugin(NgxsStoragePlugin),
     {
       provide: ɵUSER_OPTIONS,

--- a/packages/storage-plugin/tests/storage-engine-factory.spec.ts
+++ b/packages/storage-plugin/tests/storage-engine-factory.spec.ts
@@ -1,0 +1,121 @@
+import { Component, Injectable, InjectionToken, NgModule, inject } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { NgxsModule, State, Store } from '@ngxs/store';
+import { freshPlatform, skipConsoleLogging } from '@ngxs/store/internals/testing';
+import { ɵisEngineFactory } from '@ngxs/storage-plugin/internals';
+
+import { NgxsStoragePluginModule, StorageEngine } from '../';
+
+describe('Engine factory function in KeyWithExplicitEngine', () => {
+  class InMemoryStorage implements StorageEngine {
+    private readonly store = new Map<string, any>();
+    getItem(key: string) {
+      return this.store.get(key) ?? null;
+    }
+    setItem(key: string, value: any) {
+      this.store.set(key, value);
+    }
+  }
+
+  @State({ name: 'blog', defaults: { name: null } })
+  @Injectable()
+  class BlogState {}
+
+  @Component({ selector: 'app-root', template: '', standalone: false })
+  class TestComponent {}
+
+  describe('ɵisEngineFactory', () => {
+    it('should return false for a class constructor', () => {
+      class MyEngine implements StorageEngine {
+        getItem(_key: string) {
+          return null;
+        }
+        setItem(_key: string, _value: any) {}
+      }
+      expect(ɵisEngineFactory(MyEngine)).toBe(false);
+    });
+
+    it('should return false for an InjectionToken', () => {
+      const token = new InjectionToken<StorageEngine>('test');
+      expect(ɵisEngineFactory(token)).toBe(false);
+    });
+
+    it('should return true for an arrow function', () => {
+      const storage = new InMemoryStorage();
+      expect(ɵisEngineFactory(() => storage)).toBe(true);
+    });
+
+    it('should return true for a regular function', () => {
+      const storage = new InMemoryStorage();
+      expect(
+        ɵisEngineFactory(function () {
+          return storage;
+        })
+      ).toBe(true);
+    });
+  });
+
+  it(
+    'should use the engine instance returned by a factory function',
+    freshPlatform(async () => {
+      // Arrange
+      const storage = new InMemoryStorage();
+      storage.setItem('blog', JSON.stringify({ name: 'Artur' }));
+
+      @NgModule({
+        imports: [
+          BrowserModule,
+          NgxsModule.forRoot([BlogState]),
+          NgxsStoragePluginModule.forRoot({
+            keys: [{ key: 'blog', engine: () => storage }]
+          })
+        ],
+        declarations: [TestComponent],
+        bootstrap: [TestComponent]
+      })
+      class TestModule {}
+
+      const { injector } = await skipConsoleLogging(() =>
+        platformBrowserDynamic().bootstrapModule(TestModule)
+      );
+
+      // Assert
+      expect(injector.get(Store).snapshot()).toEqual({ blog: { name: 'Artur' } });
+    })
+  );
+
+  it(
+    'should allow inject() to be called inside the factory function',
+    freshPlatform(async () => {
+      // Arrange
+      const storage = new InMemoryStorage();
+      storage.setItem('blog', JSON.stringify({ name: 'Mark' }));
+
+      const BLOG_STORAGE = new InjectionToken<StorageEngine>('BLOG_STORAGE', {
+        providedIn: 'root',
+        factory: () => storage
+      });
+
+      @NgModule({
+        imports: [
+          BrowserModule,
+          NgxsModule.forRoot([BlogState]),
+          NgxsStoragePluginModule.forRoot({
+            keys: [{ key: 'blog', engine: () => inject(BLOG_STORAGE) }]
+          })
+        ],
+        declarations: [TestComponent],
+        bootstrap: [TestComponent]
+      })
+      class TestModule {}
+
+      const { injector } = await skipConsoleLogging(() =>
+        platformBrowserDynamic().bootstrapModule(TestModule)
+      );
+
+      // Assert — verifies runInInjectionContext wires inject() correctly
+      expect(injector.get(Store).snapshot()).toEqual({ blog: { name: 'Mark' } });
+    })
+  );
+});


### PR DESCRIPTION
Extends the `engine` field in `KeyWithExplicitEngine` to accept `() => StorageEngine` in addition to `Type<StorageEngine>` and `InjectionToken<StorageEngine>`.

Factory functions are resolved via `runInInjectionContext`, so `inject()` works inside them. Detection uses an `instanceof InjectionToken` check combined with `fn.toString().startsWith('class')` to distinguish factories from DI-resolvable types without relying on fragile prototype heuristics.

This enables per-key engine configuration without requiring a separate `InjectionToken` per variant — useful when the same engine class needs different construction arguments for different keys.