### PR TITLE
feat: deprecate NgModule-based APIs in favor of standalone providers

### DIFF
--- a/packages/devtools-plugin/src/devtools.module.ts
+++ b/packages/devtools-plugin/src/devtools.module.ts
@@ -19,8 +19,14 @@ export function devtoolsOptionsFactory(options: NgxsDevtoolsOptions) {
 
 export const USER_OPTIONS = new InjectionToken('USER_OPTIONS');
 
+/**
+ * @deprecated Use `withNgxsReduxDevtoolsPlugin()` instead.
+ */
 @NgModule()
 export class NgxsReduxDevtoolsPluginModule {
+  /**
+   * @deprecated Use `withNgxsReduxDevtoolsPlugin()` instead.
+   */
   static forRoot(
     options?: NgxsDevtoolsOptions
   ): ModuleWithProviders<NgxsReduxDevtoolsPluginModule> {

--- a/packages/form-plugin/src/form.module.ts
+++ b/packages/form-plugin/src/form.module.ts
@@ -4,11 +4,17 @@ import { withNgxsPlugin } from '@ngxs/store';
 import { NgxsFormPlugin } from './form.plugin';
 import { NgxsFormDirective } from './directive';
 
+/**
+ * @deprecated Use `withNgxsFormPlugin()` instead.
+ */
 @NgModule({
   imports: [NgxsFormDirective],
   exports: [NgxsFormDirective]
 })
 export class NgxsFormPluginModule {
+  /**
+   * @deprecated Use `withNgxsFormPlugin()` instead.
+   */
   static forRoot(): ModuleWithProviders<NgxsFormPluginModule> {
     return {
       ngModule: NgxsFormPluginModule,

--- a/packages/logger-plugin/src/logger.module.ts
+++ b/packages/logger-plugin/src/logger.module.ts
@@ -26,8 +26,14 @@ export function loggerOptionsFactory(options: NgxsLoggerPluginOptions) {
   };
 }
 
+/**
+ * @deprecated Use `withNgxsLoggerPlugin()` instead.
+ */
 @NgModule()
 export class NgxsLoggerPluginModule {
+  /**
+   * @deprecated Use `withNgxsLoggerPlugin()` instead.
+   */
   static forRoot(
     options?: NgxsLoggerPluginOptions
   ): ModuleWithProviders<NgxsLoggerPluginModule> {

--- a/packages/router-plugin/src/router.module.ts
+++ b/packages/router-plugin/src/router.module.ts
@@ -15,10 +15,16 @@ import {
 import { RouterState } from './router.state';
 import { DefaultRouterStateSerializer, RouterStateSerializer } from './serializer';
 
+/**
+ * @deprecated Use `withNgxsRouterPlugin()` instead.
+ */
 @NgModule({
   imports: [NgxsModule.forFeature([RouterState])]
 })
 export class NgxsRouterPluginModule {
+  /**
+   * @deprecated Use `withNgxsRouterPlugin()` instead.
+   */
   static forRoot(
     options?: NgxsRouterPluginOptions
   ): ModuleWithProviders<NgxsRouterPluginModule> {

--- a/packages/storage-plugin/src/storage.module.ts
+++ b/packages/storage-plugin/src/storage.module.ts
@@ -16,8 +16,14 @@ import { NgxsStoragePlugin } from './storage.plugin';
 import { engineFactory, storageOptionsFactory } from './internals';
 import { ɵNgxsStoragePluginKeysManager } from './keys-manager';
 
+/**
+ * @deprecated Use `withNgxsStoragePlugin()` instead.
+ */
 @NgModule()
 export class NgxsStoragePluginModule {
+  /**
+   * @deprecated Use `withNgxsStoragePlugin()` instead.
+   */
   static forRoot(
     options: NgxsStoragePluginOptions
   ): ModuleWithProviders<NgxsStoragePluginModule> {

--- a/packages/store/src/dev-features/ngxs-development.module.ts
+++ b/packages/store/src/dev-features/ngxs-development.module.ts
@@ -3,8 +3,14 @@ import { ModuleWithProviders, NgModule, makeEnvironmentProviders } from '@angula
 import { NgxsDevelopmentOptions, NGXS_DEVELOPMENT_OPTIONS } from './symbols';
 import { NgxsUnhandledActionsLogger } from './ngxs-unhandled-actions-logger';
 
+/**
+ * @deprecated Use `withNgxsDevelopmentOptions()` instead.
+ */
 @NgModule()
 export class NgxsDevelopmentModule {
+  /**
+   * @deprecated Use `withNgxsDevelopmentOptions()` instead.
+   */
   static forRoot(options: NgxsDevelopmentOptions): ModuleWithProviders<NgxsDevelopmentModule> {
     return {
       ngModule: NgxsDevelopmentModule,

--- a/packages/store/src/module.ts
+++ b/packages/store/src/module.ts
@@ -7,8 +7,14 @@ import { NgxsFeatureModule } from './modules/ngxs-feature.module';
 import { getRootProviders } from './standalone-features/root-providers';
 import { getFeatureProviders } from './standalone-features/feature-providers';
 
+/**
+ * @deprecated Use `provideStore()` and `provideStates()` instead.
+ */
 @NgModule()
 export class NgxsModule {
+  /**
+   * @deprecated Use `provideStore()` instead.
+   */
   static forRoot(
     states: ɵStateClass[] = [],
     options: NgxsModuleOptions = {}
@@ -19,6 +25,9 @@ export class NgxsModule {
     };
   }
 
+  /**
+   * @deprecated Use `provideStates()` instead.
+   */
   static forFeature(states: ɵStateClass[] = []): ModuleWithProviders<NgxsFeatureModule> {
     return {
       ngModule: NgxsFeatureModule,

--- a/packages/websocket-plugin/src/websocket.module.ts
+++ b/packages/websocket-plugin/src/websocket.module.ts
@@ -8,8 +8,14 @@ import {
 import { ɵgetProviders } from './providers';
 import { NgxsWebSocketPluginOptions } from './symbols';
 
+/**
+ * @deprecated Use `withNgxsWebSocketPlugin()` instead.
+ */
 @NgModule()
 export class NgxsWebSocketPluginModule {
+  /**
+   * @deprecated Use `withNgxsWebSocketPlugin()` instead.
+   */
   static forRoot(
     options?: NgxsWebSocketPluginOptions
   ): ModuleWithProviders<NgxsWebSocketPluginModule> {


### PR DESCRIPTION
Marks all NgModule classes across packages as @deprecated in favor of their standalone equivalents. The NgModule-based bootstrapping pattern (forRoot/forFeature) is superseded by the provideStore(), provideStates(), and withNgxs*() functions introduced for standalone Angular applications.

No behavior changes — deprecated symbols remain functional.