### PR TITLE
fix(store): use Object.create(null) for plain lookup maps to prevent prototype pollution

### DIFF
--- a/packages/store/internals/src/metadata.ts
+++ b/packages/store/internals/src/metadata.ts
@@ -17,7 +17,7 @@ export function ɵensureStoreMetadata(target: ɵStateClassInternal): ɵMetaDataM
   if (!ɵhasOwnProperty(target, ɵMETA_KEY)) {
     const defaultMetadata: ɵMetaDataModel = {
       name: null,
-      actions: {},
+      actions: Object.create(null),
       defaults: {},
       path: null,
       makeRootSelector(context: ɵRuntimeSelectorContext) {

--- a/packages/store/src/internal/internals.ts
+++ b/packages/store/src/internal/internals.ts
@@ -126,7 +126,7 @@ export function buildGraph(stateClasses: ɵStateClassInternal[]): StateKeyGraph 
     const meta = stateClass[ɵMETA_KEY]!;
     graph[meta.name!] = (meta.children || []).map(findName);
     return graph;
-  }, {});
+  }, Object.create(null));
 }
 
 /**
@@ -148,7 +148,7 @@ export function nameToState(
       result[meta.name!] = stateClass;
       return result;
     },
-    {}
+    Object.create(null)
   );
 }
 
@@ -174,7 +174,7 @@ export function nameToState(
  */
 export function findFullParentPath(
   obj: StateKeyGraph,
-  out: ɵPlainObjectOf<string> = {}
+  out: ɵPlainObjectOf<string> = Object.create(null)
 ): ɵPlainObjectOf<string> {
   // Recursively find the full dotted parent path for a given key.
   const find = (graph: StateKeyGraph, target: string): string | null => {
@@ -217,7 +217,7 @@ export function findFullParentPath(
  */
 export function topologicalSort(graph: StateKeyGraph): string[] {
   const sorted: string[] = [];
-  const visited: ɵPlainObjectOf<boolean> = {};
+  const visited: ɵPlainObjectOf<boolean> = Object.create(null);
 
   // DFS (Depth-First Search) to visit each node and its dependencies.
   const visit = (name: string, ancestors: string[] = []) => {

--- a/packages/store/src/internal/state-factory.ts
+++ b/packages/store/src/internal/state-factory.ts
@@ -75,8 +75,8 @@ export class StateFactory {
   private _ngxsUnhandledErrorHandler: NgxsUnhandledErrorHandler = null!;
 
   private _states: MappedStore[] = [];
-  private _statesByName: StatesByName = {};
-  private _statePaths: ɵPlainObjectOf<string> = {};
+  private _statesByName: StatesByName = Object.create(null);
+  private _statePaths: ɵPlainObjectOf<string> = Object.create(null);
 
   getRuntimeSelectorContext = ɵmemoize(() => {
     // eslint-disable-next-line @typescript-eslint/no-this-alias

--- a/packages/store/src/operators/of-action.ts
+++ b/packages/store/src/operators/of-action.ts
@@ -165,7 +165,7 @@ function createAllowedActionTypesMap(types: ActionType[]): FilterMap {
       filterMap[getActionTypeFromInstance(klass)!] = true;
       return filterMap;
     },
-    <FilterMap>{}
+    Object.create(null) as FilterMap
   );
 }
 
@@ -175,6 +175,6 @@ function createAllowedStatusesMap(statuses: ActionStatus[]): FilterMap {
       filterMap[status] = true;
       return filterMap;
     },
-    <FilterMap>{}
+    Object.create(null) as FilterMap
   );
 }


### PR DESCRIPTION
Objects used as string-keyed dictionaries (state names, action types, status strings) were initialized with `{}`, inheriting Object.prototype. A key matching an inherited property (e.g. `constructor`, `hasOwnProperty`) would return a truthy prototype value instead of `undefined`, causing silent mismatch in lookups.

Replaced all such maps with Object.create(null) in:
- `ɵensureStoreMetadata` — actions map keyed by action type
- `StateFactory._statesByName` / `_statePaths`
- `buildGraph`, `nameToState`, `findFullParentPath`, `topologicalSort` in internals.ts
- `createAllowedActionTypesMap` / `createAllowedStatusesMap` in of-action.ts