### PR TITLE
fix(store): harden lookup maps against prototype pollution

### DIFF
--- a/packages/store/internals/src/object-utils.ts
+++ b/packages/store/internals/src/object-utils.ts
@@ -1,7 +1,5 @@
 // Property reads are not minified.
 // It's smaller to read it once and use a function.
-const _hasOwnProperty = Object.prototype.hasOwnProperty;
-export const ɵhasOwnProperty = (target: any, key: PropertyKey) =>
-  _hasOwnProperty.call(target, key);
+export const ɵhasOwnProperty = (target: any, key: PropertyKey) => Object.hasOwn(target, key);
 
 export const ɵdefineProperty = Object.defineProperty;


### PR DESCRIPTION
Objects used as string-keyed dictionaries were initialized with `{}`, inheriting Object.prototype. A key matching an inherited property (e.g. `constructor`, `hasOwnProperty`) would return a truthy prototype value instead of undefined, causing silent mismatches in lookups.

- Replace `{}` with Object.create(null) in all plain map initializations: state name/path maps in StateFactory, buildGraph, nameToState, findFullParentPath, topologicalSort, the actions metadata map, and the FilterMap seeds in ofAction operators
- Replace ɵhasOwnProperty helper with Object.hasOwn(), which is safe on null-prototype objects and removes the indirection