### PR TITLE
feat(store): warn on setState/patchState producing a new reference with an identical value

### DIFF
--- a/packages/store/src/internal/state-context-factory.ts
+++ b/packages/store/src/internal/state-context-factory.ts
@@ -7,6 +7,7 @@ import { StateContext } from '../symbols';
 import { StateOperations } from '../internal/internals';
 import { InternalStateOperations } from '../internal/state-operations';
 import { simplePatch } from './state-operators';
+import { NGXS_DEVELOPMENT_OPTIONS } from '../dev-features/symbols';
 
 export class StateContextDestroyedError extends Error {
   override readonly name = 'StateContextDestroyedError';
@@ -68,7 +69,7 @@ export class StateContextFactory {
         }
         const currentAppState = root.getState();
         const patchOperator = simplePatch<T>(value);
-        setStateFromOperator(root, currentAppState, patchOperator, path);
+        setStateFromOperator(root, currentAppState, patchOperator, path, injector);
       },
       setState(value: T | StateOperator<T>): void {
         // Same guard as patchState — no-op if the injector is already destroyed.
@@ -78,9 +79,9 @@ export class StateContextFactory {
         }
         const currentAppState = root.getState();
         if (isStateOperator(value)) {
-          setStateFromOperator(root, currentAppState, value, path);
+          setStateFromOperator(root, currentAppState, value, path, injector);
         } else {
-          setStateValue(root, currentAppState, value, path);
+          setStateValue(root, currentAppState, value, path, injector);
         }
       },
       dispatch(actions: any | any[]): Observable<void> {
@@ -103,8 +104,17 @@ function setStateValue<T>(
   root: StateOperations<any>,
   currentAppState: any,
   newValue: T,
-  path: string
+  path: string,
+  injector: EnvironmentInjector
 ): any {
+  if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+    warnIfNewReferenceHasIdenticalValue(
+      injector,
+      getState(currentAppState, path),
+      newValue,
+      path
+    );
+  }
   const newAppState = setValue(currentAppState, path, newValue);
   root.setState(newAppState);
   // Note: this returns the full app state rather than just the patched slice.
@@ -117,13 +127,42 @@ function setStateFromOperator<T>(
   root: StateOperations<any>,
   currentAppState: any,
   stateOperator: StateOperator<T>,
-  path: string
+  path: string,
+  injector: EnvironmentInjector
 ) {
   const local = getState(currentAppState, path);
   const newValue = stateOperator(local as ExistingState<T>);
-  return setStateValue(root, currentAppState, newValue, path);
+  return setStateValue(root, currentAppState, newValue, path, injector);
 }
 
 function getState<T>(currentAppState: any, path: string): T {
   return getValue(currentAppState, path);
+}
+
+// Mirrors `warnOnNewReferenceWithIdenticalValue` in `Store#selectSignal`, but catches the
+// producer side: an action handler that sets a new reference with an identical value causes
+// unnecessary re-emissions for every `select()`/`selectSignal()` subscriber on this slice.
+function warnIfNewReferenceHasIdenticalValue(
+  injector: EnvironmentInjector,
+  oldValue: unknown,
+  newValue: unknown,
+  path: string
+): void {
+  if (Object.is(oldValue, newValue) || injector.destroyed) return;
+
+  const warnOption = injector.get(
+    NGXS_DEVELOPMENT_OPTIONS,
+    null
+  )?.warnOnNewReferenceWithIdenticalValue;
+  if (!warnOption) return;
+
+  try {
+    if (warnOption.isEqual(oldValue, newValue)) {
+      console.error(
+        `A new reference with an identical value was set on the "${path}" state slice. This will cause unnecessary re-emissions for subscribers relying on reference-based equality.`
+      );
+    }
+  } catch {
+    // Swallow silently.
+  }
 }

--- a/packages/store/tests/select-signal.spec.ts
+++ b/packages/store/tests/select-signal.spec.ts
@@ -1,7 +1,9 @@
 import { Injectable, runInInjectionContext } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import {
+  Action,
   State,
+  StateContext,
   createSelector,
   Store,
   NgxsModule,
@@ -904,6 +906,147 @@ describe('warnOnNewReferenceWithIdenticalValue', () => {
       // Change `value` — selector returns a genuinely different result.
       store.reset({ testWarn: { value: 2, counter: 0 } });
       signal();
+
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});
+
+describe('warnOnNewReferenceWithIdenticalValue (setState/patchState)', () => {
+  interface TodosStateModel {
+    items: string[];
+  }
+
+  class SetSameShape {
+    static type = '[Todos] SetSameShape';
+  }
+
+  class PatchSameShape {
+    static type = '[Todos] PatchSameShape';
+  }
+
+  class SetDifferentValue {
+    static type = '[Todos] SetDifferentValue';
+  }
+
+  class SetSameReference {
+    static type = '[Todos] SetSameReference';
+  }
+
+  @State<TodosStateModel>({
+    name: 'todos',
+    defaults: { items: [] }
+  })
+  @Injectable()
+  class TodosState {
+    // Always builds a brand-new array — same shape when the item list is unchanged.
+    @Action(SetSameShape)
+    setSameShape(ctx: StateContext<TodosStateModel>) {
+      ctx.setState({ items: [...ctx.getState().items] });
+    }
+
+    @Action(PatchSameShape)
+    patchSameShape(ctx: StateContext<TodosStateModel>) {
+      ctx.patchState({ items: [...ctx.getState().items] });
+    }
+
+    @Action(SetDifferentValue)
+    setDifferentValue(ctx: StateContext<TodosStateModel>) {
+      ctx.setState({ items: [...ctx.getState().items, 'new'] });
+    }
+
+    @Action(SetSameReference)
+    setSameReference(ctx: StateContext<TodosStateModel>) {
+      ctx.setState(ctx.getState());
+    }
+  }
+
+  beforeEach(() => TestBed.resetTestingModule());
+
+  function setup() {
+    TestBed.configureTestingModule({
+      providers: [
+        provideStore(
+          [TodosState],
+          withNgxsDevelopmentOptions({
+            warnOnUnhandledActions: true,
+            warnOnNewReferenceWithIdenticalValue: {
+              isEqual: (a, b) => JSON.stringify(a) === JSON.stringify(b)
+            }
+          })
+        )
+      ]
+    });
+    return TestBed.inject(Store);
+  }
+
+  it('should log console.error when setState sets a new reference with an identical value', () => {
+    const store = setup();
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    try {
+      store.dispatch(new SetSameShape());
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        'A new reference with an identical value was set on the "todos" state slice. This will cause unnecessary re-emissions for subscribers relying on reference-based equality.'
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('should log console.error when patchState sets a new reference with an identical value', () => {
+    const store = setup();
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    try {
+      store.dispatch(new PatchSameShape());
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        'A new reference with an identical value was set on the "todos" state slice. This will cause unnecessary re-emissions for subscribers relying on reference-based equality.'
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('should not log console.error when the value genuinely changes', () => {
+    const store = setup();
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    try {
+      store.dispatch(new SetDifferentValue());
+
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('should not log console.error when the same reference is set', () => {
+    const store = setup();
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    try {
+      store.dispatch(new SetSameReference());
+
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('should not log console.error when warnOnNewReferenceWithIdenticalValue is not configured', () => {
+    TestBed.configureTestingModule({
+      providers: [provideStore([TodosState])]
+    });
+    const store = TestBed.inject(Store);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    try {
+      store.dispatch(new SetSameShape());
 
       expect(errorSpy).not.toHaveBeenCalled();
     } finally {


### PR DESCRIPTION
Extends warnOnNewReferenceWithIdenticalValue to the producer side. Previously it only caught the symptom in selectSignal (a selector recomputing with a "same shape" value); the root cause is often an action handler that calls setState or patchState with a brand-new object/array that's deep-equal to the current slice, which also defeats select()'s reference-based distinctUntilChanged with no warning at all today.

Hooks the check into setStateValue, the single funnel for setState, setState(operator), and patchState, reusing the same NGXS_DEVELOPMENT_OPTIONS.warnOnNewReferenceWithIdenticalValue.isEqual config. Bails out on reference equality and on a destroyed injector before touching DI, mirroring the existing guards in this file.