### PR TITLE
feat(store): warn on duplicate action types via warnOnDuplicateActionTypes

### DIFF
--- a/packages/store/internals/src/action-registry.ts
+++ b/packages/store/internals/src/action-registry.ts
@@ -1,6 +1,8 @@
 import { DestroyRef, inject, Injectable } from '@angular/core';
 import type { Observable } from 'rxjs';
 
+import { ɵNGXS_DEVELOPMENT_OPTIONS } from './dev-features';
+
 export type ActionHandlerFn = (action: any) => Observable<unknown>;
 
 @Injectable({ providedIn: 'root' })
@@ -11,16 +13,56 @@ export class ɵNgxsActionRegistry {
   // metadata list will contain two objects that have the state `instance` and
   // method names to be used as action handlers (decorated with `@Action(InitState)`).
   private readonly _actionTypeToHandlersMap = new Map<string, Set<ActionHandlerFn>>();
+  // Tracks which action class first claimed a given `type` string, so we can warn
+  // when two unrelated action classes are declared with the same type.
+  // Only allocated when `warnOnDuplicateActionTypes` is enabled.
+  private readonly _actionTypeToClass?: Map<string, unknown>;
 
   constructor() {
-    inject(DestroyRef).onDestroy(() => this._actionTypeToHandlersMap.clear());
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+      const warnOnDuplicateActionTypes = inject(ɵNGXS_DEVELOPMENT_OPTIONS, {
+        optional: true
+      })?.warnOnDuplicateActionTypes;
+
+      if (warnOnDuplicateActionTypes) {
+        this._actionTypeToClass = new Map<string, unknown>();
+      }
+    }
+
+    inject(DestroyRef).onDestroy(() => {
+      this._actionTypeToHandlersMap.clear();
+      if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+        this._actionTypeToClass?.clear();
+      }
+    });
   }
 
   get(type: string) {
     return this._actionTypeToHandlersMap.get(type);
   }
 
-  register(type: string, handler: ActionHandlerFn) {
+  register(type: string, handler: ActionHandlerFn, actionClass?: unknown) {
+    // Only track actual action classes, not the `{ type: string }` shorthand — a fresh
+    // object literal is intentionally passed on every `@Action({ type: '...' })` usage,
+    // even when multiple handlers legitimately share the same type.
+    if (
+      typeof ngDevMode !== 'undefined' &&
+      ngDevMode &&
+      this._actionTypeToClass &&
+      typeof actionClass === 'function'
+    ) {
+      const existingActionClass = this._actionTypeToClass.get(type);
+      if (existingActionClass && existingActionClass !== actionClass) {
+        console.error(
+          `Multiple action classes are using the same type "${type}". Every handler registered ` +
+            `for this type will run whenever either action is dispatched, even though their payloads ` +
+            `may differ. Action types must be unique.`
+        );
+      } else {
+        this._actionTypeToClass.set(type, actionClass);
+      }
+    }
+
     const handlers = this._actionTypeToHandlersMap.get(type) ?? new Set();
     handlers.add(handler);
     this._actionTypeToHandlersMap.set(type, handlers);

--- a/packages/store/internals/src/dev-features.ts
+++ b/packages/store/internals/src/dev-features.ts
@@ -1,8 +1,8 @@
 import { InjectionToken } from '@angular/core';
 
-import { ActionType } from '../actions/symbols';
+import { ActionType } from './symbols';
 
-export interface NgxsDevelopmentOptions {
+export interface ɵNgxsDevelopmentOptions {
   warnOnNewReferenceWithIdenticalValue?: {
     isEqual: (a: unknown, b: unknown) => boolean;
   };
@@ -13,10 +13,16 @@ export interface NgxsDevelopmentOptions {
     | {
         ignore: ActionType[];
       };
+  /**
+   * Warns when two different action classes are declared with the same `type` string.
+   * Since handlers are looked up by `type`, every handler registered for that type runs
+   * whenever either action is dispatched, even though their payloads may differ.
+   */
+  warnOnDuplicateActionTypes?: boolean;
 }
 
-export const NGXS_DEVELOPMENT_OPTIONS =
-  /* @__PURE__ */ new InjectionToken<NgxsDevelopmentOptions>(
+export const ɵNGXS_DEVELOPMENT_OPTIONS =
+  /* @__PURE__ */ new InjectionToken<ɵNgxsDevelopmentOptions>(
     typeof ngDevMode !== 'undefined' && ngDevMode ? 'NGXS_DEVELOPMENT_OPTIONS' : '',
     {
       factory: () => ({ warnOnUnhandledActions: true })

--- a/packages/store/internals/src/index.ts
+++ b/packages/store/internals/src/index.ts
@@ -10,3 +10,4 @@ export { ɵwrapObserverCalls } from './custom-rxjs-operators';
 export { ɵStateStream } from './state-stream';
 export { ɵhasOwnProperty, ɵdefineProperty } from './object-utils';
 export { ɵNgxsActionRegistry } from './action-registry';
+export { type ɵNgxsDevelopmentOptions, ɵNGXS_DEVELOPMENT_OPTIONS } from './dev-features';

--- a/packages/store/internals/src/symbols.ts
+++ b/packages/store/internals/src/symbols.ts
@@ -113,4 +113,14 @@ export interface ɵActionHandlerMetaData {
   fn: string | symbol;
   options: ɵActionOptions;
   type: string;
+  /** The action class this handler was registered for, used to detect `type` collisions in dev mode. */
+  actionClass: unknown;
 }
+
+export interface ActionDef<TArgs extends any[] = any[], TReturn = any> {
+  type: string;
+
+  new (...args: TArgs): TReturn;
+}
+
+export type ActionType = ActionDef | { type: string };

--- a/packages/store/src/actions/action-director.ts
+++ b/packages/store/src/actions/action-director.ts
@@ -29,7 +29,7 @@ export class ActionDirector {
       handlerFn,
       options
     );
-    const detach = this._registry.register(Action.type, actionHandler);
+    const detach = this._registry.register(Action.type, actionHandler, Action);
     return { detach };
   }
 }

--- a/packages/store/src/actions/symbols.ts
+++ b/packages/store/src/actions/symbols.ts
@@ -1,7 +1,1 @@
-export interface ActionDef<TArgs extends any[] = any[], TReturn = any> {
-  type: string;
-
-  new (...args: TArgs): TReturn;
-}
-
-export type ActionType = ActionDef | { type: string };
+export type { ActionDef, ActionType } from '@ngxs/store/internals';

--- a/packages/store/src/decorators/action.ts
+++ b/packages/store/src/decorators/action.ts
@@ -83,7 +83,8 @@ export function Action<ActionOrActions extends ActionType | ActionType[]>(
       meta.actions[type].push({
         fn: name,
         options: options || {},
-        type
+        type,
+        actionClass: action
       });
     }
   };

--- a/packages/store/src/dev-features/ngxs-development.module.ts
+++ b/packages/store/src/dev-features/ngxs-development.module.ts
@@ -1,6 +1,9 @@
 import { ModuleWithProviders, NgModule, makeEnvironmentProviders } from '@angular/core';
+import {
+  type ɵNgxsDevelopmentOptions,
+  ɵNGXS_DEVELOPMENT_OPTIONS
+} from '@ngxs/store/internals';
 
-import { NgxsDevelopmentOptions, NGXS_DEVELOPMENT_OPTIONS } from './symbols';
 import { NgxsUnhandledActionsLogger } from './ngxs-unhandled-actions-logger';
 
 /**
@@ -11,20 +14,22 @@ export class NgxsDevelopmentModule {
   /**
    * @deprecated Use `withNgxsDevelopmentOptions()` instead.
    */
-  static forRoot(options: NgxsDevelopmentOptions): ModuleWithProviders<NgxsDevelopmentModule> {
+  static forRoot(
+    options: ɵNgxsDevelopmentOptions
+  ): ModuleWithProviders<NgxsDevelopmentModule> {
     return {
       ngModule: NgxsDevelopmentModule,
       providers: [
         NgxsUnhandledActionsLogger,
-        { provide: NGXS_DEVELOPMENT_OPTIONS, useValue: options }
+        { provide: ɵNGXS_DEVELOPMENT_OPTIONS, useValue: options }
       ]
     };
   }
 }
 
-export function withNgxsDevelopmentOptions(options: NgxsDevelopmentOptions) {
+export function withNgxsDevelopmentOptions(options: ɵNgxsDevelopmentOptions) {
   return makeEnvironmentProviders([
     NgxsUnhandledActionsLogger,
-    { provide: NGXS_DEVELOPMENT_OPTIONS, useValue: options }
+    { provide: ɵNGXS_DEVELOPMENT_OPTIONS, useValue: options }
   ]);
 }

--- a/packages/store/src/dev-features/ngxs-unhandled-actions-logger.ts
+++ b/packages/store/src/dev-features/ngxs-unhandled-actions-logger.ts
@@ -1,8 +1,8 @@
 import { inject, Injectable } from '@angular/core';
 import { InitState, UpdateState, getActionTypeFromInstance } from '@ngxs/store/plugins';
+import { ɵNGXS_DEVELOPMENT_OPTIONS } from '@ngxs/store/internals';
 
 import { ActionType } from '../actions/symbols';
-import { NGXS_DEVELOPMENT_OPTIONS } from './symbols';
 
 @Injectable()
 export class NgxsUnhandledActionsLogger {
@@ -13,7 +13,7 @@ export class NgxsUnhandledActionsLogger {
   private _ignoredActions = new Set<string>([InitState.type, UpdateState.type]);
 
   constructor() {
-    const options = inject(NGXS_DEVELOPMENT_OPTIONS);
+    const options = inject(ɵNGXS_DEVELOPMENT_OPTIONS);
     if (typeof options.warnOnUnhandledActions === 'object') {
       this.ignoreActions(...options.warnOnUnhandledActions.ignore);
     }

--- a/packages/store/src/internal/state-context-factory.ts
+++ b/packages/store/src/internal/state-context-factory.ts
@@ -1,13 +1,13 @@
 import { EnvironmentInjector, ErrorHandler, inject, Injectable } from '@angular/core';
 import { getValue, setValue } from '@ngxs/store/plugins';
 import { ExistingState, StateOperator, isStateOperator } from '@ngxs/store/operators';
+import { ɵNGXS_DEVELOPMENT_OPTIONS } from '@ngxs/store/internals';
 import type { Observable } from 'rxjs';
 
 import { StateContext } from '../symbols';
 import { StateOperations } from '../internal/internals';
 import { InternalStateOperations } from '../internal/state-operations';
 import { simplePatch } from './state-operators';
-import { NGXS_DEVELOPMENT_OPTIONS } from '../dev-features/symbols';
 
 export class StateContextDestroyedError extends Error {
   override readonly name = 'StateContextDestroyedError';
@@ -151,7 +151,7 @@ function warnIfNewReferenceHasIdenticalValue(
   if (Object.is(oldValue, newValue) || injector.destroyed) return;
 
   const warnOption = injector.get(
-    NGXS_DEVELOPMENT_OPTIONS,
+    ɵNGXS_DEVELOPMENT_OPTIONS,
     null
   )?.warnOnNewReferenceWithIdenticalValue;
   if (!warnOption) return;

--- a/packages/store/src/internal/state-factory.ts
+++ b/packages/store/src/internal/state-factory.ts
@@ -325,19 +325,17 @@ export class StateFactory {
 
   private hydrateActionMetasMap({ path, actions, instance }: MappedStore): void {
     for (const actionType of Object.keys(actions)) {
-      const actionHandlers = actions[actionType].map(actionMeta => {
+      for (const actionMeta of actions[actionType]) {
         const handlerFn = (ctx: StateContext<any>, action: any) =>
           instance[actionMeta.fn](ctx, action);
 
-        return this._actionHandlerFactory.createActionHandler(
+        const actionHandler = this._actionHandlerFactory.createActionHandler(
           path,
           handlerFn,
           actionMeta.options
         );
-      });
 
-      for (const actionHandler of actionHandlers) {
-        this._actionRegistry.register(actionType, actionHandler);
+        this._actionRegistry.register(actionType, actionHandler, actionMeta.actionClass);
       }
     }
   }

--- a/packages/store/src/public_api.ts
+++ b/packages/store/src/public_api.ts
@@ -35,7 +35,6 @@ export {
   type NgxsUnhandledErrorContext
 } from './ngxs-unhandled-error-handler';
 
-export type { NgxsDevelopmentOptions } from './dev-features/symbols';
 export {
   NgxsDevelopmentModule,
   withNgxsDevelopmentOptions
@@ -63,5 +62,6 @@ export * from './utils/public_api';
 
 export { StateToken } from '@ngxs/store/internals';
 export type { ɵActionOptions as ActionOptions } from '@ngxs/store/internals';
+export type { ɵNgxsDevelopmentOptions as NgxsDevelopmentOptions } from '@ngxs/store/internals';
 
 export { getActionTypeFromInstance, actionMatcher } from '@ngxs/store/plugins';

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -9,7 +9,11 @@ import {
   take,
   of
 } from 'rxjs';
-import { ɵINITIAL_STATE_TOKEN, ɵStateStream } from '@ngxs/store/internals';
+import {
+  ɵINITIAL_STATE_TOKEN,
+  ɵNGXS_DEVELOPMENT_OPTIONS,
+  ɵStateStream
+} from '@ngxs/store/internals';
 
 import { InternalStateOperations } from './internal/state-operations';
 import { getRootSelectorFactory } from './selectors/selector-utils';
@@ -18,7 +22,6 @@ import { NgxsConfig } from './symbols';
 import { StateFactory } from './internal/state-factory';
 import { TypedSelector } from './selectors';
 import { InternalNgxsExecutionStrategy } from './execution/execution-strategy';
-import { NGXS_DEVELOPMENT_OPTIONS } from './dev-features/symbols';
 
 // We need to check whether the provided `T` type extends an array in order to
 // apply the `NonNullable[]` type to its elements. This is because, for
@@ -117,7 +120,7 @@ export class Store {
       return computed<T>(() => selectorFn(this._stateStream.state()), {
         equal: (a, b) => {
           const warnOption = this._injector?.get(
-            NGXS_DEVELOPMENT_OPTIONS,
+            ɵNGXS_DEVELOPMENT_OPTIONS,
             null
           )?.warnOnNewReferenceWithIdenticalValue;
           if (warnOption && !Object.is(a, b)) {

--- a/packages/store/tests/duplicate-action-type.spec.ts
+++ b/packages/store/tests/duplicate-action-type.spec.ts
@@ -1,0 +1,231 @@
+import { Injectable } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  Action,
+  State,
+  StateContext,
+  Store,
+  provideStore,
+  withNgxsDevelopmentOptions
+} from '@ngxs/store';
+
+describe('Duplicate action type warnings', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  it('should warn when two unrelated action classes share the same type', () => {
+    // Arrange
+    class FooA {
+      static type = '[Duplicate] Foo';
+      constructor(public a: number) {}
+    }
+    class FooB {
+      static type = '[Duplicate] Foo';
+      constructor(public b: string) {}
+    }
+
+    @State({ name: 'stateA', defaults: {} })
+    @Injectable()
+    class StateA {
+      @Action(FooA)
+      handle(_ctx: StateContext<any>, _action: FooA) {}
+    }
+
+    @State({ name: 'stateB', defaults: {} })
+    @Injectable()
+    class StateB {
+      @Action(FooB)
+      handle(_ctx: StateContext<any>, _action: FooB) {}
+    }
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideStore(
+          [StateA, StateB],
+          withNgxsDevelopmentOptions({
+            warnOnUnhandledActions: true,
+            warnOnDuplicateActionTypes: true
+          })
+        )
+      ]
+    });
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    try {
+      // Act
+      TestBed.inject(Store);
+
+      // Assert
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Multiple action classes are using the same type "[Duplicate] Foo". Every handler ' +
+          'registered for this type will run whenever either action is dispatched, even though ' +
+          'their payloads may differ. Action types must be unique.'
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('should not warn when warnOnDuplicateActionTypes is not enabled', () => {
+    // Arrange
+    class FooA {
+      static type = '[Duplicate] Foo';
+      constructor(public a: number) {}
+    }
+    class FooB {
+      static type = '[Duplicate] Foo';
+      constructor(public b: string) {}
+    }
+
+    @State({ name: 'stateA', defaults: {} })
+    @Injectable()
+    class StateA {
+      @Action(FooA)
+      handle(_ctx: StateContext<any>, _action: FooA) {}
+    }
+
+    @State({ name: 'stateB', defaults: {} })
+    @Injectable()
+    class StateB {
+      @Action(FooB)
+      handle(_ctx: StateContext<any>, _action: FooB) {}
+    }
+
+    TestBed.configureTestingModule({
+      providers: [provideStore([StateA, StateB])]
+    });
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    try {
+      // Act
+      TestBed.inject(Store);
+
+      // Assert
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('should not warn when the same action class is handled by multiple states', () => {
+    // Arrange
+    class Shared {
+      static type = '[Duplicate] Shared';
+    }
+
+    @State({ name: 'stateA', defaults: {} })
+    @Injectable()
+    class StateA {
+      @Action(Shared)
+      handle() {}
+    }
+
+    @State({ name: 'stateB', defaults: {} })
+    @Injectable()
+    class StateB {
+      @Action(Shared)
+      handle() {}
+    }
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideStore(
+          [StateA, StateB],
+          withNgxsDevelopmentOptions({
+            warnOnUnhandledActions: true,
+            warnOnDuplicateActionTypes: true
+          })
+        )
+      ]
+    });
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    try {
+      // Act
+      TestBed.inject(Store);
+
+      // Assert
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('should not warn when multiple handlers use the `{ type: string }` shorthand', () => {
+    // Arrange
+    @State({ name: 'stateA', defaults: {} })
+    @Injectable()
+    class StateA {
+      @Action({ type: '[Duplicate] Shorthand' })
+      handleOne() {}
+
+      @Action({ type: '[Duplicate] Shorthand' })
+      handleTwo() {}
+    }
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideStore(
+          [StateA],
+          withNgxsDevelopmentOptions({
+            warnOnUnhandledActions: true,
+            warnOnDuplicateActionTypes: true
+          })
+        )
+      ]
+    });
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    try {
+      // Act
+      TestBed.inject(Store);
+
+      // Assert
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('should not warn for unrelated action types', () => {
+    // Arrange
+    class FooA {
+      static type = '[Duplicate] FooA';
+    }
+    class FooB {
+      static type = '[Duplicate] FooB';
+    }
+
+    @State({ name: 'stateA', defaults: {} })
+    @Injectable()
+    class StateA {
+      @Action(FooA)
+      handleA() {}
+
+      @Action(FooB)
+      handleB() {}
+    }
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideStore(
+          [StateA],
+          withNgxsDevelopmentOptions({
+            warnOnUnhandledActions: true,
+            warnOnDuplicateActionTypes: true
+          })
+        )
+      ]
+    });
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    try {
+      // Act
+      TestBed.inject(Store);
+
+      // Assert
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});

--- a/packages/store/tests/ensure-store.spec.ts
+++ b/packages/store/tests/ensure-store.spec.ts
@@ -63,10 +63,27 @@ describe('Ensure metadata', () => {
         name: 'count',
         actions: {
           increment: [
-            { fn: 'addOne', options: {}, type: 'increment' },
-            { fn: 'addTwo', options: {}, type: 'increment' }
+            {
+              fn: 'addOne',
+              options: {},
+              type: 'increment',
+              actionClass: { type: 'increment' }
+            },
+            {
+              fn: 'addTwo',
+              options: {},
+              type: 'increment',
+              actionClass: { type: 'increment' }
+            }
           ],
-          decrement: [{ fn: 'decrement', options: {}, type: 'decrement' }]
+          decrement: [
+            {
+              fn: 'decrement',
+              options: {},
+              type: 'decrement',
+              actionClass: { type: 'decrement' }
+            }
+          ]
         },
         defaults: 0,
         path: null,
@@ -78,7 +95,16 @@ describe('Ensure metadata', () => {
     it('should get the meta data from the MyCounterState', () => {
       expect(ɵgetStoreMetadata(MyCounterState)).toEqual({
         name: 'myCounter',
-        actions: { decrement: [{ fn: 'decrement', options: {}, type: 'decrement' }] },
+        actions: {
+          decrement: [
+            {
+              fn: 'decrement',
+              options: {},
+              type: 'decrement',
+              actionClass: { type: 'decrement' }
+            }
+          ]
+        },
         defaults: 1,
         path: null,
         makeRootSelector: expect.any(Function),


### PR DESCRIPTION
Two unrelated action classes declared with the same `type` string both get invoked whenever either is dispatched, since ɵNgxsActionRegistry keys handlers by string type alone — confirmed by reproduction before this change. This is a common copy-paste bug (cloning an action file and forgetting to update `static readonly type`) that fails silently at runtime.

Adds an opt-in warnOnDuplicateActionTypes flag to NgxsDevelopmentOptions, following the same pattern as warnOnUnhandledActions and warnOnNewReferenceWithIdenticalValue. ɵNgxsActionRegistry.register() now accepts the action class alongside its handler and tracks the first class to claim each type, emitting a console.error on collision. Only the `@Action()` decorator's class-based form is tracked — the `{ type: string }` shorthand intentionally allows multiple handlers to share one type via fresh object literals, so it's excluded from the check. Everything is gated behind the literal `typeof ngDevMode !== 'undefined' && ngDevMode` check so it's fully tree-shaken from production builds.