### PR TITLE
fix(router-plugin): avoid re-serializing already-serialized state in equality check

### DIFF
--- a/packages/router-plugin/src/router.state.ts
+++ b/packages/router-plugin/src/router.state.ts
@@ -154,9 +154,7 @@ export class RouterState {
     if (state.trigger === newState.trigger && state.navigationId === newState.navigationId) {
       let equal = false;
       try {
-        equal =
-          JSON.stringify(this._serializer.serialize(state.state!)) ===
-          JSON.stringify(this._serializer.serialize(newState.state));
+        equal = JSON.stringify(state.state) === JSON.stringify(newState.state);
       } catch {
         // If serialization or stringify fails, assume not equal.
         equal = false;

--- a/packages/router-plugin/tests/router.plugin.spec.ts
+++ b/packages/router-plugin/tests/router.plugin.spec.ts
@@ -19,6 +19,7 @@ import {
 import {
   RouterState,
   RouterStateSerializer,
+  ROUTER_STATE_TOKEN,
   Navigate,
   RouterNavigation,
   withNgxsRouterPlugin
@@ -98,6 +99,63 @@ describe('NgxsRouterPlugin', () => {
       expect(routerState!.url).toEqual('/a-path?foo=bar');
       expect(routerState!.queryParams).toBeDefined();
       expect(routerState!.queryParams.foo).toEqual('bar');
+    })
+  );
+
+  it(
+    'should correctly dedupe equal router actions when using a custom serializer whose output has no `root` property',
+    freshPlatform(async () => {
+      // Arrange
+      // Unlike `DefaultRouterStateSerializer`, this serializer's output can't be fed back
+      // into `serialize()` a second time (it has no `root` property), which is exactly
+      // what `state.state`/`newState.state` already are by the time they reach the
+      // equality check in `angularRouterAction`.
+      interface FlatRouterState {
+        url: string;
+        queryParams: Params;
+      }
+
+      class FlatRouterStateSerializer implements RouterStateSerializer<FlatRouterState> {
+        serialize(state: RouterStateSnapshot): FlatRouterState {
+          const {
+            url,
+            root: { queryParams }
+          } = state;
+          return { url, queryParams };
+        }
+      }
+
+      const injector = await createTestModule({
+        providers: [{ provide: RouterStateSerializer, useClass: FlatRouterStateSerializer }]
+      });
+
+      const store = injector.get(Store);
+
+      let emissions = 0;
+      const subscription = store.select(ROUTER_STATE_TOKEN).subscribe(() => emissions++);
+
+      const flatState: FlatRouterState = { url: '/a-path', queryParams: {} };
+      const event = { id: 1 } as any;
+
+      // Act
+      // The first dispatch always calls `ctx.setState` because the `trigger` differs
+      // from the default state (`'none'`).
+      await store.dispatch(new RouterNavigation(flatState, event, 'router')).toPromise();
+      expect(emissions).toBe(2);
+
+      // The second dispatch has the same `trigger`/`navigationId` and structurally
+      // identical `routerState`, so it should hit the equality check. This must not
+      // throw (the pre-fix code re-invoked `serialize()` on the already-serialized
+      // state, which crashes for this serializer since there's no `.root`), and it
+      // should correctly skip `ctx.setState` since the states are equal.
+      await store
+        .dispatch(new RouterNavigation({ ...flatState }, { ...event }, 'router'))
+        .toPromise();
+
+      // Assert
+      expect(emissions).toBe(2);
+
+      subscription.unsubscribe();
     })
   );
 


### PR DESCRIPTION
`angularRouterAction()` compared router states by calling `this._serializer.serialize()` a second time on `state.state` and `newState.state`, but both are already serializer output by the time they reach this method (every dispatch site serializes the raw `RouterStateSnapshot` before constructing the action). This assumed `serialize()` is safe to call on its own output, which only holds by accident for `DefaultRouterStateSerializer`. Custom serializers that flatten the snapshot (e.g. dropping `root`) would silently fail the equality check, defeating the setState dedup and causing unnecessary state updates.

Compare the already-serialized values directly instead of re-serializing them.