### PR TITLE
feat(store): add `ignoreUncompleted` action option

### DIFF
--- a/docs/concepts/actions/cancellation.md
+++ b/docs/concepts/actions/cancellation.md
@@ -29,6 +29,34 @@ export class ZooState {
 }
 ```
 
+## Ignoring
+
+`cancelUncompleted` cancels the previous uncompleted invocation and lets the new dispatch proceed (similar to RxJS's `switchMap`). If instead you want to ignore new dispatches while the previous invocation is still uncompleted (similar to RxJS's `exhaustMap`), use the `ignoreUncompleted` option:
+
+```ts
+import { Injectable } from '@angular/core';
+import { State, Action } from '@ngxs/store';
+
+@State<ZooStateModel>({
+  defaults: {
+    animals: []
+  }
+})
+@Injectable()
+export class ZooState {
+  constructor(private animalService: AnimalService) {}
+
+  @Action(FeedAnimals, { ignoreUncompleted: true })
+  get(ctx: StateContext<ZooStateModel>, action: FeedAnimals) {
+    return this.animalService.get(action.payload).pipe(
+      tap((res) => ctx.setState(res))
+    ));
+  }
+}
+```
+
+`cancelUncompleted` and `ignoreUncompleted` are mutually exclusive - setting both on the same handler throws an error.
+
 ## Using AbortSignal
 
 Starting from NGXS v21, the `StateContext` includes an `abortSignal` property that provides a standardized way to handle cancellation of asynchronous operations. This is particularly useful when working with `cancelUncompleted` actions.

--- a/packages/store/internals/src/symbols.ts
+++ b/packages/store/internals/src/symbols.ts
@@ -107,7 +107,20 @@ export interface ɵActionOptions {
    * Cancel the previous uncompleted observable(s).
    */
   cancelUncompleted?: boolean;
+  /**
+   * Ignore this dispatch if the previous observable(s) haven't completed yet.
+   */
+  ignoreUncompleted?: boolean;
 }
+
+/**
+ * `cancelUncompleted` and `ignoreUncompleted` describe opposite flattening
+ * strategies (switchMap-like vs exhaustMap-like), so they cannot both be set
+ * on the same handler.
+ */
+export type ɵMutuallyExclusiveActionOptions =
+  | (ɵActionOptions & { ignoreUncompleted?: never })
+  | (ɵActionOptions & { cancelUncompleted?: never });
 
 export interface ɵActionHandlerMetaData {
   fn: string | symbol;

--- a/packages/store/src/actions/action-director.ts
+++ b/packages/store/src/actions/action-director.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import {
   type StateToken,
-  type ɵActionOptions,
+  type ɵMutuallyExclusiveActionOptions,
   ɵNgxsActionRegistry
 } from '@ngxs/store/internals';
 import type { Observable } from 'rxjs';
@@ -22,7 +22,7 @@ export class ActionDirector {
       ctx: StateContext<TStateModel>,
       action: InstanceType<TActionType>
     ) => void | Observable<unknown> | Promise<unknown>,
-    options: ɵActionOptions = {}
+    options: ɵMutuallyExclusiveActionOptions = {}
   ) {
     const actionHandler = this._actionHandlerFactory.createActionHandler(
       stateToken.getName(),

--- a/packages/store/src/configs/messages.config.ts
+++ b/packages/store/src/configs/messages.config.ts
@@ -26,6 +26,12 @@ export function throwActionDecoratorError(): never {
   throw new Error('@Action() decorator cannot be used with static methods.');
 }
 
+export function throwActionOptionsConflictError(): never {
+  throw new Error(
+    '`cancelUncompleted` and `ignoreUncompleted` are mutually exclusive action options.'
+  );
+}
+
 export function throwSelectorDecoratorError(): never {
   throw new Error('Selectors only work on methods.');
 }

--- a/packages/store/src/decorators/action.ts
+++ b/packages/store/src/decorators/action.ts
@@ -1,4 +1,8 @@
-import { ɵActionOptions, ɵensureStoreMetadata, ɵhasOwnProperty } from '@ngxs/store/internals';
+import {
+  ɵensureStoreMetadata,
+  ɵhasOwnProperty,
+  ɵMutuallyExclusiveActionOptions
+} from '@ngxs/store/internals';
 
 import { ActionDef, ActionType } from '../actions/symbols';
 import { throwActionDecoratorError } from '../configs/messages.config';
@@ -53,7 +57,7 @@ type ActionDecorator<ActionOrActions extends ActionType | ActionType[]> = (
  */
 export function Action<ActionOrActions extends ActionType | ActionType[]>(
   actions: ActionOrActions,
-  options?: ɵActionOptions
+  options?: ɵMutuallyExclusiveActionOptions
 ): ActionDecorator<ActionOrActions> {
   return (
     target: any,

--- a/packages/store/src/internal/action-handler-factory.ts
+++ b/packages/store/src/internal/action-handler-factory.ts
@@ -12,6 +12,7 @@ import {
 import type { ɵActionOptions } from '@ngxs/store/internals';
 
 import { InternalActions } from '../actions-stream';
+import { throwActionOptionsConflictError } from '../configs/messages.config';
 import { ofActionDispatched } from '../operators/of-action';
 import { StateContextFactory } from './state-context-factory';
 import type { StateContext } from '../symbols';
@@ -26,9 +27,22 @@ export class InternalActionHandlerFactory {
     handlerFn: (ctx: StateContext<any>, action: any) => any,
     options: ɵActionOptions
   ): (action: any) => Observable<any> {
+    if (typeof ngDevMode !== 'undefined' && ngDevMode) {
+      if (options.cancelUncompleted && options.ignoreUncompleted) {
+        throwActionOptionsConflictError();
+      }
+    }
+
     const { dispatched$ } = this._actions;
+    // Tracks whether a previously dispatched, still-uncompleted invocation of
+    // this exact handler is in flight. Only used for `ignoreUncompleted`.
+    let isUncompleted = false;
 
     return (action: any) => {
+      if (options.ignoreUncompleted && isUncompleted) {
+        return of(undefined);
+      }
+
       const abortController = new AbortController();
       const stateContext = this._stateContextFactory.createStateContext(
         path,
@@ -73,6 +87,15 @@ export class InternalActionHandlerFactory {
                 });
               })
             )
+          );
+        }
+
+        if (options.ignoreUncompleted) {
+          isUncompleted = true;
+          result = result.pipe(
+            finalize(() => {
+              isUncompleted = false;
+            })
           );
         }
 

--- a/packages/store/tests/action-handler.spec.ts
+++ b/packages/store/tests/action-handler.spec.ts
@@ -49,6 +49,33 @@ describe('Action handlers', () => {
       }
     });
 
+    it('should throw an exception if `cancelUncompleted` and `ignoreUncompleted` are both set', () => {
+      let errorMessage: string | null = null;
+
+      @State({
+        name: 'counter'
+      })
+      @Injectable()
+      class CounterState {
+        @Action(TestAction, { cancelUncompleted: true, ignoreUncompleted: true } as any)
+        increment() {}
+      }
+
+      try {
+        TestBed.configureTestingModule({
+          imports: [NgxsModule.forRoot([CounterState])]
+        });
+
+        TestBed.inject(Store);
+      } catch (e: any) {
+        errorMessage = e.message;
+      }
+
+      expect(errorMessage).toEqual(
+        '`cancelUncompleted` and `ignoreUncompleted` are mutually exclusive action options.'
+      );
+    });
+
     it(`should allow for retrieval of the current state`, () => {
       // Arrange
       let currentState: any = null;

--- a/packages/store/tests/dispatch.spec.ts
+++ b/packages/store/tests/dispatch.spec.ts
@@ -349,6 +349,54 @@ describe('Dispatch', () => {
     expect(await store.selectOnce(MyState).toPromise()).toEqual(1);
   }));
 
+  it('should correctly ignore new dispatches while the previous action is uncompleted', fakeAsync(async () => {
+    // Arrange
+    let actionInvokedTimes = 0;
+
+    @State<number>({
+      name: 'counter',
+      defaults: 0
+    })
+    @Injectable()
+    class MyState {
+      @Action(Increment, { ignoreUncompleted: true })
+      increment({ getState, setState }: StateContext<number>) {
+        actionInvokedTimes++;
+        return timer(0).pipe(
+          tap(() => {
+            const state = getState();
+
+            setState(state + 1);
+          })
+        );
+      }
+    }
+
+    TestBed.configureTestingModule({
+      imports: [NgxsModule.forRoot([MyState])]
+    });
+
+    const store = TestBed.inject(Store);
+
+    // Act
+    store.dispatch([
+      new Increment(),
+      new Increment(),
+      new Increment(),
+      new Increment(),
+      new Increment(),
+      new Increment()
+    ]);
+
+    store.dispatch([new Increment()]);
+
+    tick(0);
+
+    // Assert
+    expect(actionInvokedTimes).toEqual(1);
+    expect(await store.selectOnce(MyState).toPromise()).toEqual(1);
+  }));
+
   describe('returns an observable that', () => {
     describe('when the action handler is synchronous', () => {
       it('should notify of the completion of the action handler', () => {
@@ -829,6 +877,56 @@ describe('Dispatch', () => {
           'latest',
           'latest complete'
         ]);
+      }));
+    });
+
+    describe('when the action is ignored because the previous action is uncompleted', () => {
+      it('should not invoke the handler again, and should complete the ignored dispatch immediately', fakeAsync(() => {
+        // Arrange
+        const resolvers: (() => void)[] = [];
+        const subscriptionsCalled: string[] = [];
+
+        @State<number>({
+          name: 'counter',
+          defaults: 0
+        })
+        @Injectable()
+        class MyState {
+          @Action(Increment, { ignoreUncompleted: true })
+          increment() {
+            subscriptionsCalled.push('increment');
+            return new Promise<void>(resolve => resolvers.push(resolve));
+          }
+        }
+
+        TestBed.configureTestingModule({
+          imports: [NgxsModule.forRoot([MyState])]
+        });
+
+        const store = TestBed.inject(Store);
+
+        // Act
+        store.dispatch(new Increment()).subscribe(
+          () => subscriptionsCalled.push('previous'),
+          () => subscriptionsCalled.push('previous error'),
+          () => subscriptionsCalled.push('previous complete')
+        );
+        store.dispatch(new Increment()).subscribe(
+          () => subscriptionsCalled.push('latest'),
+          () => subscriptionsCalled.push('latest error'),
+          () => subscriptionsCalled.push('latest complete')
+        );
+        resolvers[0]();
+        tick(0);
+
+        // Assert
+        // The handler only runs once - the second dispatch is silently ignored
+        // while the first one is still uncompleted.
+        expect(subscriptionsCalled.filter(call => call === 'increment')).toEqual([
+          'increment'
+        ]);
+        expect(subscriptionsCalled).toContain('latest complete');
+        expect(subscriptionsCalled).toContain('previous complete');
       }));
     });
 


### PR DESCRIPTION
Adds `ignoreUncompleted` as an exhaustMap-like counterpart to the existing
switchMap-like `cancelUncompleted`: new dispatches are ignored (the handler
is never invoked) while a previous invocation of the same handler is still
uncompleted, instead of canceling it and starting fresh.

`cancelUncompleted` and `ignoreUncompleted` are mutually exclusive, enforced
both at compile time (via a discriminated options type) and at runtime in
dev mode.