### PR TITLE
feat(router-plugin): add derived selectors for query params, params, data, and title

### DIFF
--- a/docs/plugins/router.md
+++ b/docs/plugins/router.md
@@ -72,6 +72,33 @@ export class MyApp {
 
 You can use action handlers to listen to state changes in your components and services by subscribing to the `RouterNavigation`, `RouterCancel`, `RouterError` or `RouterDataResolved` action classes.
 
+## Derived Selectors
+
+Besides `RouterState.url`, `RouterState` exposes a handful of selectors derived from the current router snapshot, so you don't have to drill into `RouterState.state()` yourself:
+
+```ts
+import { Component } from '@angular/core';
+import { select } from '@ngxs/store';
+import { RouterState } from '@ngxs/router-plugin';
+
+@Component({ ... })
+export class MyComponent {
+  queryParams = select(RouterState.queryParams);
+  fragment = select(RouterState.fragment);
+
+  // The path params, `data`, and resolved `title` of the deepest activated
+  // route — mirrors what `ActivatedRoute.snapshot` exposes for the component
+  // currently being rendered.
+  params = select(RouterState.params);
+  data = select(RouterState.data);
+  title = select(RouterState.title);
+}
+```
+
+`queryParams`/`queryParamMap`/`fragment` are global to the whole navigation, so they're always accurate. `params`/`paramMap`/`data`/`title`, however, are resolved by walking the _first_ child at each level of the route tree down to the leaf — the same approach `ActivatedRoute` itself uses — so in an app with multiple simultaneously active named outlets, this can resolve to the wrong branch. Build a custom selector from `RouterState.state()` if that applies to your app.
+
+These selectors assume the default `RouterStateSerializer` output shape (`SerializedRouterStateSnapshot`). If you provide a [custom serializer](#custom-router-state-serializer), build your own selectors from `RouterState.state()` instead.
+
 ## Listening to the data resolution event
 
 You can listen for the `RouterDataResolved` action, which is dispatched when the navigated route has linked resolvers. For example:

--- a/packages/router-plugin/src/router.state.ts
+++ b/packages/router-plugin/src/router.state.ts
@@ -1,5 +1,6 @@
 import { NgZone, Injectable, inject, DestroyRef } from '@angular/core';
 import {
+  ActivatedRouteSnapshot,
   NavigationCancel,
   NavigationError,
   Router,
@@ -97,6 +98,60 @@ export class RouterState {
   }
 
   static url = createSelector([ROUTER_STATE_TOKEN], state => state?.state?.url);
+
+  /**
+   * The query params of the current navigation. Unlike `params`/`data`/`title`
+   * below, query params are global to the whole navigation, not tied to a
+   * specific activated route, so this is always accurate regardless of outlets.
+   *
+   * Assumes the default `RouterStateSerializer` output shape
+   * (`SerializedRouterStateSnapshot`). If you've provided a custom serializer,
+   * build your own selector from `RouterState.state()` instead.
+   */
+  static queryParams = createSelector(
+    [ROUTER_STATE_TOKEN],
+    state => state?.state?.root.queryParams
+  );
+
+  static queryParamMap = createSelector(
+    [ROUTER_STATE_TOKEN],
+    state => state?.state?.root.queryParamMap
+  );
+
+  static fragment = createSelector([ROUTER_STATE_TOKEN], state => state?.state?.root.fragment);
+
+  /**
+   * The path params of the deepest activated route — mirrors what
+   * `ActivatedRoute.snapshot.params` exposes for the component currently
+   * being rendered.
+   *
+   * Only follows the *first* child at each level of the route tree, so —
+   * same caveat as Angular's own `ActivatedRoute` — this can resolve to the
+   * wrong branch in an app with multiple simultaneously active named
+   * outlets. Build a custom selector from `RouterState.state()` if that
+   * applies to you.
+   */
+  static params = createSelector(
+    [ROUTER_STATE_TOKEN],
+    state => getActivatedLeafRoute(state)?.params
+  );
+
+  static paramMap = createSelector(
+    [ROUTER_STATE_TOKEN],
+    state => getActivatedLeafRoute(state)?.paramMap
+  );
+
+  /** The `data` of the deepest activated route. Same named-outlet caveat as `params`. */
+  static data = createSelector(
+    [ROUTER_STATE_TOKEN],
+    state => getActivatedLeafRoute(state)?.data
+  );
+
+  /** The resolved `title` of the deepest activated route. Same named-outlet caveat as `params`. */
+  static title = createSelector(
+    [ROUTER_STATE_TOKEN],
+    state => getActivatedLeafRoute(state)?.title
+  );
 
   constructor() {
     this._setUpStoreListener();
@@ -309,4 +364,15 @@ export class RouterState {
     this._storeState = null;
     this._routerState = null;
   }
+}
+
+/** Walks the primary-outlet chain down to the deepest activated route. */
+function getActivatedLeafRoute(
+  state: RouterStateModel<RouterStateSnapshot> | undefined
+): ActivatedRouteSnapshot | undefined {
+  let route = state?.state?.root;
+  while (route?.firstChild) {
+    route = route.firstChild;
+  }
+  return route;
 }

--- a/packages/router-plugin/tests/router-derived-selectors.spec.ts
+++ b/packages/router-plugin/tests/router-derived-selectors.spec.ts
@@ -1,0 +1,108 @@
+import { Component, NgModule } from '@angular/core';
+import { APP_BASE_HREF } from '@angular/common';
+import { BrowserModule } from '@angular/platform-browser';
+import { RouterModule } from '@angular/router';
+import { provideStore } from '@ngxs/store';
+import { freshPlatform } from '@ngxs/store/internals/testing';
+
+import { createNgxsRouterPluginTestingPlatform } from './helpers';
+import { RouterState, withNgxsRouterPlugin } from '../';
+
+describe('RouterState derived selectors', () => {
+  @Component({
+    selector: 'app-root',
+    template: '<router-outlet></router-outlet>',
+    standalone: false
+  })
+  class RootComponent {}
+
+  @Component({ selector: 'home', template: '', standalone: false })
+  class HomeComponent {}
+
+  @Component({
+    selector: 'parent',
+    template: '<router-outlet></router-outlet>',
+    standalone: false
+  })
+  class ParentComponent {}
+
+  @Component({ selector: 'child', template: '', standalone: false })
+  class ChildComponent {}
+
+  function getTestModule() {
+    @NgModule({
+      imports: [
+        BrowserModule,
+        RouterModule.forRoot([
+          { path: '', component: HomeComponent },
+          {
+            path: 'parent/:parentId',
+            component: ParentComponent,
+            data: { section: 'parent' },
+            children: [
+              {
+                path: 'child/:childId',
+                component: ChildComponent,
+                data: { section: 'child' },
+                title: 'Child Title'
+              }
+            ]
+          }
+        ])
+      ],
+      declarations: [RootComponent, HomeComponent, ParentComponent, ChildComponent],
+      bootstrap: [RootComponent],
+      providers: [
+        provideStore([], withNgxsRouterPlugin()),
+        { provide: APP_BASE_HREF, useValue: '/' }
+      ]
+    })
+    class TestModule {}
+    return TestModule;
+  }
+
+  it(
+    'should derive queryParams, fragment, params, data and title from the deepest activated route',
+    freshPlatform(async () => {
+      // Arrange
+      const { router, store, ngZone } =
+        await createNgxsRouterPluginTestingPlatform(getTestModule());
+
+      // Act
+      await ngZone.run(() => router.navigateByUrl('/parent/1/child/2?foo=bar#frag'));
+
+      // Assert
+      expect(store.selectSnapshot(RouterState.queryParams)).toEqual({ foo: 'bar' });
+      expect(store.selectSnapshot(RouterState.fragment)).toBe('frag');
+
+      // `params`/`data`/`title` reflect the *leaf* route (`child/:childId`),
+      // not the parent (`parent/:parentId`) — matches how
+      // `ActivatedRoute.snapshot` behaves by default (no params inheritance).
+      expect(store.selectSnapshot(RouterState.params)).toEqual({ childId: '2' });
+      // Angular stashes the resolved title in `data` under a `Symbol(RouteTitle)`
+      // key when a route `title` is configured, so `data` contains more than
+      // just what we declared — assert our own key rather than exact equality.
+      expect(store.selectSnapshot(RouterState.data)).toEqual(
+        expect.objectContaining({ section: 'child' })
+      );
+      expect(store.selectSnapshot(RouterState.title)).toBe('Child Title');
+    })
+  );
+
+  it(
+    'should update derived selectors on subsequent navigations',
+    freshPlatform(async () => {
+      // Arrange
+      const { router, store, ngZone } =
+        await createNgxsRouterPluginTestingPlatform(getTestModule());
+      await ngZone.run(() => router.navigateByUrl('/parent/1/child/2?foo=bar'));
+
+      // Act
+      await ngZone.run(() => router.navigateByUrl('/parent/3/child/4?foo=baz'));
+
+      // Assert
+      expect(store.selectSnapshot(RouterState.queryParams)).toEqual({ foo: 'baz' });
+      expect(store.selectSnapshot(RouterState.params)).toEqual({ childId: '4' });
+    })
+  );
+});


### PR DESCRIPTION
RouterState only exposed `state()` and `url`, forcing every consumer to manually drill into the (possibly deeply nested) route tree for anything else — query params, path params, route data, or the resolved title.

Adds queryParams, queryParamMap, fragment, params, paramMap, data, and title as derived static selectors on RouterState. queryParams/fragment are global to the navigation and always accurate; params/data/title are resolved from the deepest activated route via a new getActivatedLeafRoute() helper that walks root.firstChild down to the leaf, mirroring how ActivatedRoute.snapshot itself behaves — including its same named-outlet caveat, called out in the JSDoc and docs.

These selectors assume the default RouterStateSerializer output shape; apps using a custom serializer should build their own from state().

Docs updated with a "Derived Selectors" section, and a new test file covers nested routes with query params, fragment, and per-leaf data/title resolution across navigations.