### PR TITLE
refactor(store): seed ɵStateStream from the initial state token in its own constructor

### DIFF
--- a/packages/store/internals/src/state-stream.ts
+++ b/packages/store/internals/src/state-stream.ts
@@ -1,9 +1,9 @@
 import { DestroyRef, inject, Injectable, Signal, untracked } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { Observable } from 'rxjs';
 
 import { ɵwrapObserverCalls } from './custom-rxjs-operators';
 import { ɵOrderedBehaviorSubject } from './custom-rxjs-subjects';
+import { ɵINITIAL_STATE_TOKEN } from './initial-state';
 import { ɵPlainObject } from './symbols';
 
 /**
@@ -18,7 +18,9 @@ export class ɵStateStream extends ɵOrderedBehaviorSubject<ɵPlainObject> {
   });
 
   constructor() {
-    super({});
+    // Seeded here (rather than by `Store`) so that nothing can call `.next()`
+    // on this subject before it receives its initial value.
+    super(inject(ɵINITIAL_STATE_TOKEN));
 
     // Complete the subject once the root injector is destroyed to ensure
     // there are no active subscribers that would receive events or perform

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -9,11 +9,7 @@ import {
   take,
   of
 } from 'rxjs';
-import {
-  ɵINITIAL_STATE_TOKEN,
-  ɵNGXS_DEVELOPMENT_OPTIONS,
-  ɵStateStream
-} from '@ngxs/store/internals';
+import { ɵNGXS_DEVELOPMENT_OPTIONS, ɵStateStream } from '@ngxs/store/internals';
 
 import { InternalStateOperations } from './internal/state-operations';
 import { getRootSelectorFactory } from './selectors/selector-utils';
@@ -49,8 +45,6 @@ export class Store {
   );
 
   constructor() {
-    this.initStateStream();
-
     if (typeof ngDevMode !== 'undefined' && ngDevMode) {
       this._injector = inject(Injector);
     }
@@ -178,15 +172,5 @@ export class Store {
     const makeSelectorFn = getRootSelectorFactory(selector);
     const runtimeContext = this._stateFactory.getRuntimeSelectorContext();
     return makeSelectorFn(runtimeContext);
-  }
-
-  private initStateStream(): void {
-    const initialStateValue: any = inject(ɵINITIAL_STATE_TOKEN);
-    const value = this._stateStream.value;
-    const storeIsEmpty = !value || Object.keys(value).length === 0;
-
-    if (storeIsEmpty) {
-      this._stateStream.next(initialStateValue);
-    }
   }
 }


### PR DESCRIPTION
Store.initStateStream() used a storeIsEmpty runtime check to avoid overwriting state that external code had already set on ɵStateStream before Store ran its seeding logic. That guard is now unnecessary: nothing can call .next() on the subject before its own constructor finishes, so seeding it directly from ɵINITIAL_STATE_TOKEN in ɵStateStream's constructor preserves the same guarantee for free and removes the extra method and check from Store.