### PR TITLE
refactor(router-plugin): move derived selectors to tree-shakable exports, add named-outlet variants

### DIFF
--- a/packages/router-plugin/src/public_api.ts
+++ b/packages/router-plugin/src/public_api.ts
@@ -1,6 +1,19 @@
 export { NgxsRouterPluginModule, withNgxsRouterPlugin } from './router.module';
 export { ROUTER_STATE_TOKEN, RouterState, type RouterStateModel } from './router.state';
 export {
+  routerQueryParams,
+  routerQueryParamMap,
+  routerFragment,
+  routerParams,
+  routerParamMap,
+  routerData,
+  routerTitle,
+  routerParamsForOutlet,
+  routerParamMapForOutlet,
+  routerDataForOutlet,
+  routerTitleForOutlet
+} from './router-selectors';
+export {
   RouterStateSerializer,
   DefaultRouterStateSerializer,
   type SerializedRouterStateSnapshot

--- a/packages/router-plugin/src/router-selectors.ts
+++ b/packages/router-plugin/src/router-selectors.ts
@@ -1,0 +1,136 @@
+import { ActivatedRouteSnapshot, PRIMARY_OUTLET, RouterStateSnapshot } from '@angular/router';
+import { createSelector } from '@ngxs/store';
+
+import { ROUTER_STATE_TOKEN, RouterStateModel } from './router.state';
+
+/**
+ * These are exported as standalone tree-shakable selectors, rather than as
+ * static members on `RouterState`, because unused static class properties
+ * always ship in the bundle — bundlers can't remove individual members off
+ * a class that's itself always referenced (as `RouterState` is, via
+ * `withNgxsRouterPlugin()`). Plain top-level exports can be shaken.
+ */
+
+/**
+ * The query params of the current navigation. Unlike `routerParams`/`routerData`/
+ * `routerTitle` below, query params are global to the whole navigation, not tied
+ * to a specific activated route, so this is always accurate regardless of outlets.
+ *
+ * Assumes the default `RouterStateSerializer` output shape
+ * (`SerializedRouterStateSnapshot`). If you've provided a custom serializer,
+ * build your own selector from `RouterState.state()` instead.
+ */
+export const routerQueryParams = /* @__PURE__ */ createSelector(
+  [ROUTER_STATE_TOKEN],
+  state => state?.state?.root.queryParams
+);
+
+export const routerQueryParamMap = /* @__PURE__ */ createSelector(
+  [ROUTER_STATE_TOKEN],
+  state => state?.state?.root.queryParamMap
+);
+
+export const routerFragment = /* @__PURE__ */ createSelector(
+  [ROUTER_STATE_TOKEN],
+  state => state?.state?.root.fragment
+);
+
+/**
+ * The path params of the deepest activated route on the primary outlet —
+ * mirrors what `ActivatedRoute.snapshot.params` exposes for the component
+ * currently being rendered.
+ *
+ * Only follows the primary outlet chain, so in an app with simultaneously
+ * active named outlets this reflects the primary outlet's branch only.
+ * Use `routerParamsForOutlet(outlet)` to read params from a named outlet's branch.
+ */
+export const routerParams = /* @__PURE__ */ createSelector(
+  [ROUTER_STATE_TOKEN],
+  state => getActivatedLeafRoute(state)?.params
+);
+
+export const routerParamMap = /* @__PURE__ */ createSelector(
+  [ROUTER_STATE_TOKEN],
+  state => getActivatedLeafRoute(state)?.paramMap
+);
+
+/** The `data` of the deepest activated route on the primary outlet. Same named-outlet caveat as `routerParams`. */
+export const routerData = /* @__PURE__ */ createSelector(
+  [ROUTER_STATE_TOKEN],
+  state => getActivatedLeafRoute(state)?.data
+);
+
+/** The resolved `title` of the deepest activated route on the primary outlet. Same named-outlet caveat as `routerParams`. */
+export const routerTitle = /* @__PURE__ */ createSelector(
+  [ROUTER_STATE_TOKEN],
+  state => getActivatedLeafRoute(state)?.title
+);
+
+/**
+ * The path params of the deepest activated route within the given named
+ * outlet's branch, e.g. `routerParamsForOutlet('aux')`.
+ */
+export function routerParamsForOutlet(outlet: string) {
+  return createSelector(
+    [ROUTER_STATE_TOKEN],
+    state => getActivatedLeafRoute(state, outlet)?.params
+  );
+}
+
+export function routerParamMapForOutlet(outlet: string) {
+  return createSelector(
+    [ROUTER_STATE_TOKEN],
+    state => getActivatedLeafRoute(state, outlet)?.paramMap
+  );
+}
+
+/** The `data` of the deepest activated route within the given named outlet's branch. */
+export function routerDataForOutlet(outlet: string) {
+  return createSelector(
+    [ROUTER_STATE_TOKEN],
+    state => getActivatedLeafRoute(state, outlet)?.data
+  );
+}
+
+/** The resolved `title` of the deepest activated route within the given named outlet's branch. */
+export function routerTitleForOutlet(outlet: string) {
+  return createSelector(
+    [ROUTER_STATE_TOKEN],
+    state => getActivatedLeafRoute(state, outlet)?.title
+  );
+}
+
+/**
+ * Walks down to the deepest activated route within the given outlet's branch.
+ * For the primary outlet (the default), this simply follows `firstChild`
+ * from the root. For a named outlet, it first locates that outlet's
+ * activated route anywhere in the tree, then follows `firstChild` from there.
+ */
+function getActivatedLeafRoute(
+  state: RouterStateModel<RouterStateSnapshot> | undefined,
+  outlet: string = PRIMARY_OUTLET
+): ActivatedRouteSnapshot | undefined {
+  const root = state?.state?.root;
+  let route = outlet === PRIMARY_OUTLET ? root : root && findRouteForOutlet(root, outlet);
+  while (route?.firstChild) {
+    route = route.firstChild;
+  }
+  return route;
+}
+
+/** Depth-first search for the activated route belonging to the given outlet. */
+function findRouteForOutlet(
+  route: ActivatedRouteSnapshot,
+  outlet: string
+): ActivatedRouteSnapshot | undefined {
+  for (const child of route.children) {
+    if (child.outlet === outlet) {
+      return child;
+    }
+    const found = findRouteForOutlet(child, outlet);
+    if (found) {
+      return found;
+    }
+  }
+  return undefined;
+}

--- a/packages/router-plugin/src/router.state.ts
+++ b/packages/router-plugin/src/router.state.ts
@@ -1,6 +1,5 @@
 import { NgZone, Injectable, inject, DestroyRef } from '@angular/core';
 import {
-  ActivatedRouteSnapshot,
   NavigationCancel,
   NavigationError,
   Router,
@@ -98,60 +97,6 @@ export class RouterState {
   }
 
   static url = createSelector([ROUTER_STATE_TOKEN], state => state?.state?.url);
-
-  /**
-   * The query params of the current navigation. Unlike `params`/`data`/`title`
-   * below, query params are global to the whole navigation, not tied to a
-   * specific activated route, so this is always accurate regardless of outlets.
-   *
-   * Assumes the default `RouterStateSerializer` output shape
-   * (`SerializedRouterStateSnapshot`). If you've provided a custom serializer,
-   * build your own selector from `RouterState.state()` instead.
-   */
-  static queryParams = createSelector(
-    [ROUTER_STATE_TOKEN],
-    state => state?.state?.root.queryParams
-  );
-
-  static queryParamMap = createSelector(
-    [ROUTER_STATE_TOKEN],
-    state => state?.state?.root.queryParamMap
-  );
-
-  static fragment = createSelector([ROUTER_STATE_TOKEN], state => state?.state?.root.fragment);
-
-  /**
-   * The path params of the deepest activated route — mirrors what
-   * `ActivatedRoute.snapshot.params` exposes for the component currently
-   * being rendered.
-   *
-   * Only follows the *first* child at each level of the route tree, so —
-   * same caveat as Angular's own `ActivatedRoute` — this can resolve to the
-   * wrong branch in an app with multiple simultaneously active named
-   * outlets. Build a custom selector from `RouterState.state()` if that
-   * applies to you.
-   */
-  static params = createSelector(
-    [ROUTER_STATE_TOKEN],
-    state => getActivatedLeafRoute(state)?.params
-  );
-
-  static paramMap = createSelector(
-    [ROUTER_STATE_TOKEN],
-    state => getActivatedLeafRoute(state)?.paramMap
-  );
-
-  /** The `data` of the deepest activated route. Same named-outlet caveat as `params`. */
-  static data = createSelector(
-    [ROUTER_STATE_TOKEN],
-    state => getActivatedLeafRoute(state)?.data
-  );
-
-  /** The resolved `title` of the deepest activated route. Same named-outlet caveat as `params`. */
-  static title = createSelector(
-    [ROUTER_STATE_TOKEN],
-    state => getActivatedLeafRoute(state)?.title
-  );
 
   constructor() {
     this._setUpStoreListener();
@@ -364,15 +309,4 @@ export class RouterState {
     this._storeState = null;
     this._routerState = null;
   }
-}
-
-/** Walks the primary-outlet chain down to the deepest activated route. */
-function getActivatedLeafRoute(
-  state: RouterStateModel<RouterStateSnapshot> | undefined
-): ActivatedRouteSnapshot | undefined {
-  let route = state?.state?.root;
-  while (route?.firstChild) {
-    route = route.firstChild;
-  }
-  return route;
 }

--- a/packages/router-plugin/tests/router-derived-selectors.spec.ts
+++ b/packages/router-plugin/tests/router-derived-selectors.spec.ts
@@ -6,12 +6,22 @@ import { provideStore } from '@ngxs/store';
 import { freshPlatform } from '@ngxs/store/internals/testing';
 
 import { createNgxsRouterPluginTestingPlatform } from './helpers';
-import { RouterState, withNgxsRouterPlugin } from '../';
+import {
+  routerData,
+  routerDataForOutlet,
+  routerFragment,
+  routerParams,
+  routerParamsForOutlet,
+  routerQueryParams,
+  routerTitle,
+  routerTitleForOutlet,
+  withNgxsRouterPlugin
+} from '../';
 
 describe('RouterState derived selectors', () => {
   @Component({
     selector: 'app-root',
-    template: '<router-outlet></router-outlet>',
+    template: '<router-outlet></router-outlet><router-outlet name="aux"></router-outlet>',
     standalone: false
   })
   class RootComponent {}
@@ -28,6 +38,9 @@ describe('RouterState derived selectors', () => {
 
   @Component({ selector: 'child', template: '', standalone: false })
   class ChildComponent {}
+
+  @Component({ selector: 'aux', template: '', standalone: false })
+  class AuxComponent {}
 
   function getTestModule() {
     @NgModule({
@@ -47,10 +60,23 @@ describe('RouterState derived selectors', () => {
                 title: 'Child Title'
               }
             ]
+          },
+          {
+            path: 'aux/:auxId',
+            component: AuxComponent,
+            outlet: 'aux',
+            data: { section: 'aux' },
+            title: 'Aux Title'
           }
         ])
       ],
-      declarations: [RootComponent, HomeComponent, ParentComponent, ChildComponent],
+      declarations: [
+        RootComponent,
+        HomeComponent,
+        ParentComponent,
+        ChildComponent,
+        AuxComponent
+      ],
       bootstrap: [RootComponent],
       providers: [
         provideStore([], withNgxsRouterPlugin()),
@@ -72,20 +98,20 @@ describe('RouterState derived selectors', () => {
       await ngZone.run(() => router.navigateByUrl('/parent/1/child/2?foo=bar#frag'));
 
       // Assert
-      expect(store.selectSnapshot(RouterState.queryParams)).toEqual({ foo: 'bar' });
-      expect(store.selectSnapshot(RouterState.fragment)).toBe('frag');
+      expect(store.selectSnapshot(routerQueryParams)).toEqual({ foo: 'bar' });
+      expect(store.selectSnapshot(routerFragment)).toBe('frag');
 
       // `params`/`data`/`title` reflect the *leaf* route (`child/:childId`),
       // not the parent (`parent/:parentId`) — matches how
       // `ActivatedRoute.snapshot` behaves by default (no params inheritance).
-      expect(store.selectSnapshot(RouterState.params)).toEqual({ childId: '2' });
+      expect(store.selectSnapshot(routerParams)).toEqual({ childId: '2' });
       // Angular stashes the resolved title in `data` under a `Symbol(RouteTitle)`
       // key when a route `title` is configured, so `data` contains more than
       // just what we declared — assert our own key rather than exact equality.
-      expect(store.selectSnapshot(RouterState.data)).toEqual(
+      expect(store.selectSnapshot(routerData)).toEqual(
         expect.objectContaining({ section: 'child' })
       );
-      expect(store.selectSnapshot(RouterState.title)).toBe('Child Title');
+      expect(store.selectSnapshot(routerTitle)).toBe('Child Title');
     })
   );
 
@@ -101,8 +127,38 @@ describe('RouterState derived selectors', () => {
       await ngZone.run(() => router.navigateByUrl('/parent/3/child/4?foo=baz'));
 
       // Assert
-      expect(store.selectSnapshot(RouterState.queryParams)).toEqual({ foo: 'baz' });
-      expect(store.selectSnapshot(RouterState.params)).toEqual({ childId: '4' });
+      expect(store.selectSnapshot(routerQueryParams)).toEqual({ foo: 'baz' });
+      expect(store.selectSnapshot(routerParams)).toEqual({ childId: '4' });
+    })
+  );
+
+  it(
+    'should derive params, data and title for a named outlet independently of the primary outlet',
+    freshPlatform(async () => {
+      // Arrange
+      const { router, store, ngZone } =
+        await createNgxsRouterPluginTestingPlatform(getTestModule());
+
+      // Act — activate the primary outlet and the `aux` outlet at the same time.
+      await ngZone.run(() =>
+        router.navigate([
+          { outlets: { primary: ['parent', '1', 'child', '2'], aux: ['aux', '9'] } }
+        ])
+      );
+
+      // Assert — the primary-outlet selectors are unaffected by the aux outlet.
+      expect(store.selectSnapshot(routerParams)).toEqual({ childId: '2' });
+      expect(store.selectSnapshot(routerData)).toEqual(
+        expect.objectContaining({ section: 'child' })
+      );
+      expect(store.selectSnapshot(routerTitle)).toBe('Child Title');
+
+      // Assert — the `aux` outlet's own branch is resolved independently.
+      expect(store.selectSnapshot(routerParamsForOutlet('aux'))).toEqual({ auxId: '9' });
+      expect(store.selectSnapshot(routerDataForOutlet('aux'))).toEqual(
+        expect.objectContaining({ section: 'aux' })
+      );
+      expect(store.selectSnapshot(routerTitleForOutlet('aux'))).toBe('Aux Title');
     })
   );
 });


### PR DESCRIPTION
Static class properties always ship in the bundle once the owning class is referenced anywhere (RouterState always is, via withNgxsRouterPlugin()), so bundlers can't tree-shake individual unused selectors off it. queryParams/queryParamMap/fragment/params/ paramMap/data/title were added post-v22 and aren't released yet, so move them off RouterState into router-selectors.ts as standalone routerXxx exports instead.

Also add new selectors for named outlets — routerParamsForOutlet, routerParamMapForOutlet, routerDataForOutlet, routerTitleForOutlet — which resolve params/paramMap/data/title for a given outlet's branch, since the existing primary-outlet selectors only ever followed the first child at each level.

Mark the top-level createSelector() calls /* @__PURE__ */ so unused ones can actually be dropped. RouterState.state()/.url are untouched since those predate this and are already released.