### PR TITLE
feat(storage-plugin): add withNgxsStorageSync for cross-tab state sync

### DIFF
--- a/packages/storage-plugin/src/features/with-ngxs-storage-sync.ts
+++ b/packages/storage-plugin/src/features/with-ngxs-storage-sync.ts
@@ -1,0 +1,94 @@
+import {
+  DestroyRef,
+  EnvironmentProviders,
+  NgZone,
+  PLATFORM_ID,
+  inject,
+  provideEnvironmentInitializer
+} from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { Store } from '@ngxs/store';
+import { setValue } from '@ngxs/store/plugins';
+import {
+  ɵDEFAULT_STATE_KEY,
+  ɵNGXS_STORAGE_PLUGIN_OPTIONS
+} from '@ngxs/storage-plugin/internals';
+
+import { getStorageKey } from '../internals';
+import { ɵNgxsStoragePluginKeysManager } from '../keys-manager';
+
+/**
+ * Keeps the store in sync across browser tabs/windows that share the same
+ * `localStorage`/`sessionStorage` origin. When another tab writes to a
+ * persisted key, this tab rehydrates that slice of state from the new value
+ * instead of waiting for its own next write to storage.
+ *
+ * Pass this as a feature to `withNgxsStoragePlugin()`, e.g.
+ * `withNgxsStoragePlugin({ keys: [...] }, withNgxsStorageSync())` — it relies
+ * on the same key/engine registration, so it isn't meant to be provided on
+ * its own.
+ *
+ * Only reacts to the native `StorageEvent`, which the browser fires only for
+ * `localStorage`/`sessionStorage` — keys persisted through a custom
+ * `StorageEngine` aren't covered, since there's no cross-tab notification
+ * mechanism for the plugin to hook into for those.
+ */
+export function withNgxsStorageSync(): EnvironmentProviders {
+  return provideEnvironmentInitializer(() => {
+    if (
+      (typeof ngServerMode !== 'undefined' && ngServerMode) ||
+      isPlatformServer(inject(PLATFORM_ID))
+    ) {
+      return;
+    }
+
+    const store = inject(Store);
+    const keysManager = inject(ɵNgxsStoragePluginKeysManager);
+    const options = inject(ɵNGXS_STORAGE_PLUGIN_OPTIONS);
+
+    const listener = (event: StorageEvent) => {
+      // `event.key` is `null` when the change came from `Storage.clear()` —
+      // not something we can attribute to a single persisted key, so skip it.
+      if (event.key == null || event.newValue == null) {
+        return;
+      }
+
+      for (const { key, engine } of keysManager.getKeysWithEngines()) {
+        // Guard against `engine` being falsy, and only react to the two
+        // built-in Web Storage engines — a custom engine's writes can't
+        // have produced this native `StorageEvent` in the first place.
+        if (!engine || engine !== event.storageArea) continue;
+        if (getStorageKey(key, options) !== event.key) continue;
+
+        let storedValue: any;
+        try {
+          const newVal = options.deserialize!(event.newValue);
+          storedValue = options.afterDeserialize!(newVal, key);
+        } catch {
+          typeof ngDevMode !== 'undefined' &&
+            ngDevMode &&
+            console.error(
+              `Error occurred while deserializing the ${event.key} value written by another tab, skipping sync: `,
+              event.newValue
+            );
+          continue;
+        }
+
+        const currentState = store.snapshot();
+        const nextState =
+          key === ɵDEFAULT_STATE_KEY ? storedValue : setValue(currentState, key, storedValue);
+
+        store.reset(nextState);
+      }
+    };
+
+    // Registered outside Angular so that every "storage" event firing
+    // doesn't schedule a needless change-detection pass on its own — this
+    // matches how NGXS already runs dispatch itself outside the zone;
+    // `Store.select`'s stream brings subscribers back inside the zone for
+    // whatever actually changed.
+    const ngZone = inject(NgZone);
+    ngZone.runOutsideAngular(() => window.addEventListener('storage', listener));
+    inject(DestroyRef).onDestroy(() => window.removeEventListener('storage', listener));
+  });
+}

--- a/packages/storage-plugin/src/public_api.ts
+++ b/packages/storage-plugin/src/public_api.ts
@@ -1,5 +1,6 @@
 export { NgxsStoragePluginModule, withNgxsStoragePlugin } from './storage.module';
 export { withStorageFeature } from './with-storage-feature';
+export { withNgxsStorageSync } from './features/with-ngxs-storage-sync';
 export { NgxsStoragePlugin } from './storage.plugin';
 export * from './engines';
 

--- a/packages/storage-plugin/src/storage.module.ts
+++ b/packages/storage-plugin/src/storage.module.ts
@@ -52,7 +52,8 @@ export class NgxsStoragePluginModule {
 }
 
 export function withNgxsStoragePlugin(
-  options: NgxsStoragePluginOptions
+  options: NgxsStoragePluginOptions,
+  ...features: EnvironmentProviders[]
 ): EnvironmentProviders {
   return makeEnvironmentProviders([
     ɵNgxsStoragePluginKeysManager,
@@ -70,6 +71,7 @@ export function withNgxsStoragePlugin(
       provide: STORAGE_ENGINE,
       useFactory: engineFactory,
       deps: [ɵNGXS_STORAGE_PLUGIN_OPTIONS]
-    }
+    },
+    features
   ]);
 }

--- a/packages/storage-plugin/tests/storage-sync.spec.ts
+++ b/packages/storage-plugin/tests/storage-sync.spec.ts
@@ -1,0 +1,152 @@
+import { bootstrapApplication } from '@angular/platform-browser';
+import { ApplicationConfig, Component, Injectable } from '@angular/core';
+import { Action, State, StateContext, Store, provideStore } from '@ngxs/store';
+import { freshPlatform, skipConsoleLogging } from '@ngxs/store/internals/testing';
+
+import { withNgxsStoragePlugin, withNgxsStorageSync } from '..';
+
+describe('withNgxsStorageSync', () => {
+  interface CounterStateModel {
+    count: number;
+  }
+
+  class Increment {
+    static readonly type = '[Counter] Increment';
+  }
+
+  @State<CounterStateModel>({
+    name: 'counter',
+    defaults: { count: 0 }
+  })
+  @Injectable()
+  class CounterState {
+    @Action(Increment)
+    increment(ctx: StateContext<CounterStateModel>) {
+      ctx.patchState({ count: ctx.getState().count + 1 });
+    }
+  }
+
+  @Component({ selector: 'app-root', template: '', standalone: true })
+  class TestComponent {}
+
+  function bootstrap() {
+    const appConfig: ApplicationConfig = {
+      providers: [
+        provideStore(
+          [CounterState],
+          withNgxsStoragePlugin({ keys: [CounterState] }, withNgxsStorageSync())
+        )
+      ]
+    };
+
+    return skipConsoleLogging(() => bootstrapApplication(TestComponent, appConfig));
+  }
+
+  /** Simulates another tab writing `key` in the same `localStorage` origin. */
+  function writeFromAnotherTab(key: string, oldValue: string | null, newValue: string | null) {
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key,
+        oldValue,
+        newValue,
+        storageArea: localStorage
+      })
+    );
+  }
+
+  afterEach(() => {
+    localStorage.removeItem('counter');
+  });
+
+  it(
+    'should rehydrate the matching slice of state when another tab writes to its key',
+    freshPlatform(async () => {
+      // Arrange
+      const { injector } = await bootstrap();
+      const store = injector.get(Store);
+      expect(store.snapshot()).toEqual({ counter: { count: 0 } });
+
+      // Act — another tab persisted `{ count: 42 }` under the `counter` key.
+      writeFromAnotherTab('counter', null, JSON.stringify({ count: 42 }));
+
+      // Assert
+      expect(store.snapshot()).toEqual({ counter: { count: 42 } });
+    })
+  );
+
+  it(
+    'should ignore StorageEvents for keys the plugin does not manage',
+    freshPlatform(async () => {
+      // Arrange
+      const { injector } = await bootstrap();
+      const store = injector.get(Store);
+
+      // Act
+      writeFromAnotherTab('some-other-key', null, JSON.stringify({ irrelevant: true }));
+
+      // Assert
+      expect(store.snapshot()).toEqual({ counter: { count: 0 } });
+    })
+  );
+
+  it(
+    'should ignore StorageEvents from a storage area other than the one the key uses',
+    freshPlatform(async () => {
+      // Arrange
+      const { injector } = await bootstrap();
+      const store = injector.get(Store);
+
+      // Act — same key, but reported against `sessionStorage`, which this
+      // config never resolves `counter` to.
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: 'counter',
+          oldValue: null,
+          newValue: JSON.stringify({ count: 99 }),
+          storageArea: sessionStorage
+        })
+      );
+
+      // Assert
+      expect(store.snapshot()).toEqual({ counter: { count: 0 } });
+    })
+  );
+
+  it(
+    'should log and skip rather than throw when the new value fails to deserialize',
+    freshPlatform(async () => {
+      // Arrange
+      const { injector } = await bootstrap();
+      const store = injector.get(Store);
+      const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      try {
+        // Act
+        writeFromAnotherTab('counter', null, '{not valid json');
+
+        // Assert
+        expect(store.snapshot()).toEqual({ counter: { count: 0 } });
+        expect(spy).toHaveBeenCalled();
+      } finally {
+        spy.mockRestore();
+      }
+    })
+  );
+
+  it(
+    'should keep syncing after further local dispatches',
+    freshPlatform(async () => {
+      // Arrange
+      const { injector } = await bootstrap();
+      const store = injector.get(Store);
+      store.dispatch(new Increment());
+      expect(store.snapshot()).toEqual({ counter: { count: 1 } });
+
+      // Act
+      writeFromAnotherTab('counter', null, JSON.stringify({ count: 7 }));
+
+      // Assert
+      expect(store.snapshot()).toEqual({ counter: { count: 7 } });
+    })
+  );
+});


### PR DESCRIPTION
Adds withNgxsStorageSync(), a feature passed into withNgxsStoragePlugin() (e.g. withNgxsStoragePlugin({ keys: [...] }, withNgxsStorageSync())) that listens for the native StorageEvent and rehydrates the affected slice of state when another tab writes to a persisted key, instead of waiting for this tab's own next write. Only covers localStorage/sessionStorage-backed keys, since custom StorageEngines have no cross-tab notification hook.

withNgxsStoragePlugin() now accepts trailing EnvironmentProviders features, mirroring provideStore's own variadic-features convention, so sub-features that depend on the plugin's key/engine registration (like this one) can't be wired up without it.