### PR TITLE
feat(storage-plugin): report deserialize/serialize/quota failures via ErrorHandler

### DIFF
--- a/packages/storage-plugin/src/public_api.ts
+++ b/packages/storage-plugin/src/public_api.ts
@@ -1,7 +1,12 @@
 export { NgxsStoragePluginModule, withNgxsStoragePlugin } from './storage.module';
 export { withStorageFeature } from './with-storage-feature';
 export { withNgxsStorageSync } from './features/with-ngxs-storage-sync';
-export { NgxsStoragePlugin } from './storage.plugin';
+export {
+  NgxsStoragePlugin,
+  NgxsStorageDeserializationError,
+  NgxsStorageQuotaExceededError,
+  NgxsStorageSerializationError
+} from './storage.plugin';
 export * from './engines';
 
 export {

--- a/packages/storage-plugin/src/storage.plugin.ts
+++ b/packages/storage-plugin/src/storage.plugin.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector, PLATFORM_ID, inject } from '@angular/core';
+import { ErrorHandler, Injectable, Injector, PLATFORM_ID, inject } from '@angular/core';
 import { isPlatformServer } from '@angular/common';
 import { ɵhasOwnProperty, ɵPlainObject } from '@ngxs/store/internals';
 import {
@@ -23,12 +23,78 @@ import { ɵNgxsStoragePluginKeysManager } from './keys-manager';
 declare const ngDevMode: boolean;
 declare const ngServerMode: boolean;
 
+/** Reported to `ErrorHandler` when a persisted value fails to deserialize on read. */
+export class NgxsStorageDeserializationError extends Error {
+  override readonly name = 'NgxsStorageDeserializationError';
+
+  constructor(
+    readonly key: string,
+    options?: ErrorOptions
+  ) {
+    super(
+      typeof ngDevMode !== 'undefined' && ngDevMode
+        ? `Error occurred while deserializing the ${key} store value, falling back to empty object.`
+        : key,
+      options
+    );
+
+    Object.setPrototypeOf(this, NgxsStorageDeserializationError.prototype);
+  }
+}
+
+/** Reported to `ErrorHandler` when writing a persisted value exceeds the browser's storage quota. */
+export class NgxsStorageQuotaExceededError extends Error {
+  override readonly name = 'NgxsStorageQuotaExceededError';
+
+  constructor(
+    readonly key: string,
+    options?: ErrorOptions
+  ) {
+    super(
+      typeof ngDevMode !== 'undefined' && ngDevMode
+        ? `The ${key} store value exceeds the browser storage quota.`
+        : key,
+      options
+    );
+
+    Object.setPrototypeOf(this, NgxsStorageQuotaExceededError.prototype);
+  }
+}
+
+/** Reported to `ErrorHandler` when a persisted value fails to serialize (or otherwise write) on save. */
+export class NgxsStorageSerializationError extends Error {
+  override readonly name = 'NgxsStorageSerializationError';
+
+  constructor(
+    readonly key: string,
+    options?: ErrorOptions
+  ) {
+    super(
+      typeof ngDevMode !== 'undefined' && ngDevMode
+        ? `Error occurred while serializing the ${key} store value, value not updated.`
+        : key,
+      options
+    );
+
+    Object.setPrototypeOf(this, NgxsStorageSerializationError.prototype);
+  }
+}
+
 @Injectable()
 export class NgxsStoragePlugin implements NgxsPlugin {
   private _injector = inject(Injector);
   private _keysManager = inject(ɵNgxsStoragePluginKeysManager);
   private _options = inject(ɵNGXS_STORAGE_PLUGIN_OPTIONS);
   private _allStatesPersisted = inject(ɵALL_STATES_PERSISTED);
+  private _errorHandler?: ErrorHandler;
+
+  /**
+   * Keys currently over quota. Once a key lands here, further quota errors
+   * for it are swallowed rather than re-reported on every dispatch, since
+   * they'll keep failing the same way until something frees up space. Cleared
+   * once a write for that key succeeds again.
+   */
+  private _quotaExceededKeys = new Set<string>();
 
   handle(state: any, event: any, next: NgxsNextPluginFn) {
     if (
@@ -74,13 +140,10 @@ export class NgxsStoragePlugin implements NgxsPlugin {
           try {
             const newVal = this._options.deserialize!(storedValue);
             storedValue = this._options.afterDeserialize!(newVal, key);
-          } catch {
-            typeof ngDevMode !== 'undefined' &&
-              ngDevMode &&
-              console.error(
-                `Error ocurred while deserializing the ${storageKey} store value, falling back to empty object, the value obtained from the store: `,
-                storedValue
-              );
+          } catch (error) {
+            (this._errorHandler ??= this._injector.get(ErrorHandler)).handleError(
+              new NgxsStorageDeserializationError(storageKey, { cause: error })
+            );
 
             storedValue = {};
           }
@@ -126,24 +189,25 @@ export class NgxsStoragePlugin implements NgxsPlugin {
           try {
             const newStoredValue = this._options.beforeSerialize!(storedValue, key);
             engine.setItem(storageKey, this._options.serialize!(newStoredValue));
+            this._quotaExceededKeys.delete(storageKey);
           } catch (error: any) {
-            if (typeof ngDevMode !== 'undefined' && ngDevMode) {
-              if (
-                error &&
-                (error.name === 'QuotaExceededError' ||
-                  error.name === 'NS_ERROR_DOM_QUOTA_REACHED')
-              ) {
-                console.error(
-                  `The ${storageKey} store value exceeds the browser storage quota: `,
-                  storedValue
-                );
-              } else {
-                console.error(
-                  `Error ocurred while serializing the ${storageKey} store value, value not updated, the value obtained from the store: `,
-                  storedValue
-                );
+            const isQuotaError =
+              error &&
+              (error.name === 'QuotaExceededError' ||
+                error.name === 'NS_ERROR_DOM_QUOTA_REACHED');
+
+            if (isQuotaError) {
+              if (this._quotaExceededKeys.has(storageKey)) {
+                continue;
               }
+              this._quotaExceededKeys.add(storageKey);
             }
+
+            (this._errorHandler ??= this._injector.get(ErrorHandler)).handleError(
+              isQuotaError
+                ? new NgxsStorageQuotaExceededError(storageKey, { cause: error })
+                : new NgxsStorageSerializationError(storageKey, { cause: error })
+            );
           }
         }
       })

--- a/packages/storage-plugin/tests/storage-error-handler.spec.ts
+++ b/packages/storage-plugin/tests/storage-error-handler.spec.ts
@@ -1,0 +1,210 @@
+import { TestBed } from '@angular/core/testing';
+import { ErrorHandler, Injectable } from '@angular/core';
+
+import { Action, State, StateContext, Store, provideStore } from '@ngxs/store';
+import { ɵDEFAULT_STATE_KEY } from '@ngxs/storage-plugin/internals';
+
+import {
+  NgxsStorageDeserializationError,
+  NgxsStorageQuotaExceededError,
+  NgxsStorageSerializationError,
+  withNgxsStoragePlugin
+} from '../';
+
+describe('NgxsStoragePlugin ErrorHandler reporting', () => {
+  beforeEach(() => TestBed.resetTestingModule());
+
+  class Increment {
+    static type = 'INCREMENT';
+  }
+
+  interface CounterStateModel {
+    count: number;
+  }
+
+  @State<CounterStateModel>({
+    name: 'counter',
+    defaults: { count: 0 }
+  })
+  @Injectable()
+  class CounterState {
+    @Action(Increment)
+    increment(ctx: StateContext<CounterStateModel>) {
+      ctx.patchState({ count: ctx.getState().count + 1 });
+    }
+  }
+
+  afterEach(() => {
+    localStorage.removeItem(ɵDEFAULT_STATE_KEY);
+  });
+
+  it('should report deserialization failures to ErrorHandler', () => {
+    // Arrange
+    localStorage.setItem(ɵDEFAULT_STATE_KEY, '{not valid json');
+    const handleError = jest.fn();
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideStore([CounterState], withNgxsStoragePlugin({ keys: '*' })),
+        { provide: ErrorHandler, useValue: { handleError } }
+      ]
+    });
+
+    try {
+      // Act
+      TestBed.inject(Store);
+
+      // Assert
+      expect(handleError).toHaveBeenCalledTimes(1);
+      const reportedError = handleError.mock.calls[0][0];
+      expect(reportedError).toBeInstanceOf(NgxsStorageDeserializationError);
+      expect(reportedError.key).toBe(ɵDEFAULT_STATE_KEY);
+      expect(reportedError.cause).toBeInstanceOf(Error);
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+
+  it('should report serialization failures to ErrorHandler', () => {
+    // Arrange
+    const handleError = jest.fn();
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const boom = new Error('boom');
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideStore(
+          [CounterState],
+          withNgxsStoragePlugin({
+            keys: '*',
+            serialize: () => {
+              throw boom;
+            }
+          })
+        ),
+        { provide: ErrorHandler, useValue: { handleError } }
+      ]
+    });
+
+    try {
+      // Act
+      const store: Store = TestBed.inject(Store);
+      store.dispatch(new Increment());
+
+      // Assert
+      expect(handleError).toHaveBeenCalledTimes(1);
+      const reportedError = handleError.mock.calls[0][0];
+      expect(reportedError).toBeInstanceOf(NgxsStorageSerializationError);
+      expect(reportedError.key).toBe(ɵDEFAULT_STATE_KEY);
+      expect(reportedError.cause).toBe(boom);
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+
+  it('should report quota-exceeded write failures as NgxsStorageQuotaExceededError', () => {
+    // Arrange
+    const handleError = jest.fn();
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const quotaError = new Error('quota');
+    quotaError.name = 'QuotaExceededError';
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideStore(
+          [CounterState],
+          withNgxsStoragePlugin({
+            keys: '*',
+            serialize: () => {
+              throw quotaError;
+            }
+          })
+        ),
+        { provide: ErrorHandler, useValue: { handleError } }
+      ]
+    });
+
+    try {
+      // Act
+      const store: Store = TestBed.inject(Store);
+      store.dispatch(new Increment());
+
+      // Assert
+      expect(handleError).toHaveBeenCalledTimes(1);
+      const reportedError = handleError.mock.calls[0][0];
+      expect(reportedError).toBeInstanceOf(NgxsStorageQuotaExceededError);
+      expect(reportedError.cause).toBe(quotaError);
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+
+  it('should report a quota-exceeded key only once until a write for it succeeds again', () => {
+    // Arrange
+    const handleError = jest.fn();
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const quotaError = new Error('quota');
+    quotaError.name = 'QuotaExceededError';
+    let shouldThrow = true;
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideStore(
+          [CounterState],
+          withNgxsStoragePlugin({
+            keys: '*',
+            serialize: value => {
+              if (shouldThrow) throw quotaError;
+              return JSON.stringify(value);
+            }
+          })
+        ),
+        { provide: ErrorHandler, useValue: { handleError } }
+      ]
+    });
+
+    try {
+      // Act — dispatch three times while still over quota.
+      const store: Store = TestBed.inject(Store);
+      store.dispatch(new Increment());
+      store.dispatch(new Increment());
+      store.dispatch(new Increment());
+
+      // Assert — only the first write for this key was reported.
+      expect(handleError).toHaveBeenCalledTimes(1);
+
+      // Act — the write succeeds now (quota pressure resolved elsewhere).
+      shouldThrow = false;
+      store.dispatch(new Increment());
+
+      // Act — quota is hit again.
+      shouldThrow = true;
+      store.dispatch(new Increment());
+
+      // Assert — reported again, since the key had recovered in between.
+      expect(handleError).toHaveBeenCalledTimes(2);
+    } finally {
+      consoleSpy.mockRestore();
+    }
+  });
+
+  it('should not report anything to ErrorHandler when reads/writes succeed', () => {
+    // Arrange
+    const handleError = jest.fn();
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideStore([CounterState], withNgxsStoragePlugin({ keys: '*' })),
+        { provide: ErrorHandler, useValue: { handleError } }
+      ]
+    });
+
+    // Act
+    const store: Store = TestBed.inject(Store);
+    store.dispatch(new Increment());
+
+    // Assert
+    expect(handleError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/storage-plugin/tests/storage.plugin.spec.ts
+++ b/packages/storage-plugin/tests/storage.plugin.spec.ts
@@ -6,6 +6,7 @@ import { NgxsModule, State, Store, Action, StateContext } from '@ngxs/store';
 import { ɵDEFAULT_STATE_KEY } from '@ngxs/storage-plugin/internals';
 
 import {
+  NgxsStorageDeserializationError,
   NgxsStoragePluginModule,
   StorageOption,
   StorageEngine,
@@ -764,7 +765,7 @@ describe('NgxsStoragePlugin', () => {
         expect(count).toEqual(0);
       });
 
-      it('should log the namespaced key into the console when it failed to deserialize the value', () => {
+      it('should report the namespaced key via ErrorHandler when it failed to deserialize the value', () => {
         // Arrange & act
         const namespace = 'my_cool_app';
         localStorage.setItem(
@@ -773,16 +774,22 @@ describe('NgxsStoragePlugin', () => {
           // Just a random invalid value.
           `undefined+null+something_else`
         );
+        // The default `ErrorHandler` logs to `console.error('ERROR', error)`,
+        // so this also confirms the plugin no longer logs its own message directly.
         const spy = jest.spyOn(console, 'error').mockImplementation();
         testSetup({ namespace, keys: [NamesState] });
         // Assert
         try {
           expect(spy).toHaveBeenCalledWith(
-            expect.stringMatching(
-              /Error ocurred while deserializing the my_cool_app:names store value/
-            ),
-            expect.anything()
+            'ERROR',
+            expect.objectContaining({
+              key: `${namespace}:names`,
+              message: expect.stringMatching(
+                /Error occurred while deserializing the my_cool_app:names store value/
+              )
+            })
           );
+          expect(spy.mock.calls[0][1]).toBeInstanceOf(NgxsStorageDeserializationError);
         } finally {
           spy.mockRestore();
         }


### PR DESCRIPTION
Storage plugin errors were only ever surfaced via a dev-mode-only console.error, so production failures (corrupt storage, quota exceeded, a throwing serializer) were silently swallowed with no way for an app's error reporting (Sentry, Rollbar, etc.) to see them.

Following the same pattern as StateContextDestroyedError, adds three dedicated Error subclasses — NgxsStorageDeserializationError, NgxsStorageQuotaExceededError, NgxsStorageSerializationError — each wrapping the original error via the standard `cause` option and carrying a dev-mode-aware message. They're reported to ErrorHandler (lazily resolved through the existing Injector field) unconditionally, regardless of ngDevMode, replacing the manual console.error calls; the default ErrorHandler already logs to console, so nothing is lost.

Quota-exceeded keys are tracked in a Set and reported only once per key rather than on every dispatch, since a key over quota fails the same way on every subsequent write until something frees up space; the key is cleared once a write for it succeeds again.