### PR TITLE
feat(storage-plugin): report withNgxsStorageSync deserialize failures via ErrorHandler

### DIFF
--- a/packages/storage-plugin/src/features/with-ngxs-storage-sync.ts
+++ b/packages/storage-plugin/src/features/with-ngxs-storage-sync.ts
@@ -1,6 +1,8 @@
 import {
   DestroyRef,
+  ErrorHandler,
   EnvironmentProviders,
+  Injector,
   NgZone,
   PLATFORM_ID,
   inject,
@@ -16,6 +18,7 @@ import {
 
 import { getStorageKey } from '../internals';
 import { ɵNgxsStoragePluginKeysManager } from '../keys-manager';
+import { NgxsStorageDeserializationError } from '../storage.plugin';
 
 /**
  * Keeps the store in sync across browser tabs/windows that share the same
@@ -45,6 +48,8 @@ export function withNgxsStorageSync(): EnvironmentProviders {
     const store = inject(Store);
     const keysManager = inject(ɵNgxsStoragePluginKeysManager);
     const options = inject(ɵNGXS_STORAGE_PLUGIN_OPTIONS);
+    const injector = inject(Injector);
+    let errorHandler: ErrorHandler | undefined;
 
     const listener = (event: StorageEvent) => {
       // `event.key` is `null` when the change came from `Storage.clear()` —
@@ -64,13 +69,10 @@ export function withNgxsStorageSync(): EnvironmentProviders {
         try {
           const newVal = options.deserialize!(event.newValue);
           storedValue = options.afterDeserialize!(newVal, key);
-        } catch {
-          typeof ngDevMode !== 'undefined' &&
-            ngDevMode &&
-            console.error(
-              `Error occurred while deserializing the ${event.key} value written by another tab, skipping sync: `,
-              event.newValue
-            );
+        } catch (error) {
+          (errorHandler ??= injector.get(ErrorHandler)).handleError(
+            new NgxsStorageDeserializationError(event.key, { cause: error })
+          );
           continue;
         }
 

--- a/packages/storage-plugin/tests/storage-sync.spec.ts
+++ b/packages/storage-plugin/tests/storage-sync.spec.ts
@@ -1,9 +1,13 @@
 import { bootstrapApplication } from '@angular/platform-browser';
-import { ApplicationConfig, Component, Injectable } from '@angular/core';
+import { ApplicationConfig, Component, ErrorHandler, Injectable } from '@angular/core';
 import { Action, State, StateContext, Store, provideStore } from '@ngxs/store';
 import { freshPlatform, skipConsoleLogging } from '@ngxs/store/internals/testing';
 
-import { withNgxsStoragePlugin, withNgxsStorageSync } from '..';
+import {
+  NgxsStorageDeserializationError,
+  withNgxsStoragePlugin,
+  withNgxsStorageSync
+} from '..';
 
 describe('withNgxsStorageSync', () => {
   interface CounterStateModel {
@@ -29,13 +33,14 @@ describe('withNgxsStorageSync', () => {
   @Component({ selector: 'app-root', template: '', standalone: true })
   class TestComponent {}
 
-  function bootstrap() {
+  function bootstrap(extraProviders: ApplicationConfig['providers'] = []) {
     const appConfig: ApplicationConfig = {
       providers: [
         provideStore(
           [CounterState],
           withNgxsStoragePlugin({ keys: [CounterState] }, withNgxsStorageSync())
-        )
+        ),
+        ...extraProviders
       ]
     };
 
@@ -113,23 +118,25 @@ describe('withNgxsStorageSync', () => {
   );
 
   it(
-    'should log and skip rather than throw when the new value fails to deserialize',
+    'should report and skip rather than throw when the new value fails to deserialize',
     freshPlatform(async () => {
       // Arrange
-      const { injector } = await bootstrap();
+      const handleError = jest.fn();
+      const { injector } = await bootstrap([
+        { provide: ErrorHandler, useValue: { handleError } }
+      ]);
       const store = injector.get(Store);
-      const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-      try {
-        // Act
-        writeFromAnotherTab('counter', null, '{not valid json');
+      // Act
+      writeFromAnotherTab('counter', null, '{not valid json');
 
-        // Assert
-        expect(store.snapshot()).toEqual({ counter: { count: 0 } });
-        expect(spy).toHaveBeenCalled();
-      } finally {
-        spy.mockRestore();
-      }
+      // Assert
+      expect(store.snapshot()).toEqual({ counter: { count: 0 } });
+      expect(handleError).toHaveBeenCalledTimes(1);
+      const reportedError = handleError.mock.calls[0][0];
+      expect(reportedError).toBeInstanceOf(NgxsStorageDeserializationError);
+      expect(reportedError.key).toBe('counter');
+      expect(reportedError.cause).toBeInstanceOf(Error);
     })
   );
 


### PR DESCRIPTION
Cross-tab deserialization failures were only logged to the console in dev mode and silently swallowed elsewhere, unlike the main storage plugin's read path. Report them through ErrorHandler using the same NgxsStorageDeserializationError, resolved lazily via Injector so it's only looked up when a failure actually occurs.