### PR TITLE
feat(storage-plugin): add experimental withNgxsStorageBatching feature

### DIFF
--- a/packages/storage-plugin/src/features/with-ngxs-storage-batching.ts
+++ b/packages/storage-plugin/src/features/with-ngxs-storage-batching.ts
@@ -1,0 +1,188 @@
+import {
+  DestroyRef,
+  EnvironmentProviders,
+  Injectable,
+  InjectionToken,
+  NgZone,
+  Type,
+  inject,
+  makeEnvironmentProviders,
+  provideEnvironmentInitializer
+} from '@angular/core';
+import {
+  STORAGE_ENGINE,
+  StorageEngine,
+  ɵNGXS_STORAGE_PLUGIN_OPTIONS
+} from '@ngxs/storage-plugin/internals';
+
+import { engineFactory } from '../internals';
+
+declare const ngDevMode: boolean;
+
+/**
+ * The real engine your batching engine should wrap — `localStorage`,
+ * `sessionStorage`, or whatever the plugin's config resolves to. `null` on
+ * the server, same as `STORAGE_ENGINE` would be.
+ *
+ * @experimental This API is experimental and may change in any release.
+ */
+export const NGXS_STORAGE_ENGINE_TO_WRAP =
+  /* @__PURE__ */ new InjectionToken<StorageEngine | null>(
+    typeof ngDevMode !== 'undefined' && ngDevMode ? 'NGXS_STORAGE_ENGINE_TO_WRAP' : '',
+    {
+      factory: () => engineFactory(inject(ɵNGXS_STORAGE_PLUGIN_OPTIONS))
+    }
+  );
+
+/**
+ * What a custom engine passed to `withNgxsStorageBatching()` needs to
+ * implement: the usual `StorageEngine` methods, plus `flush()`. We call
+ * `flush()` whenever the page might be about to disappear, so whatever
+ * you're buffering doesn't get lost.
+ *
+ * @experimental This API is experimental and may change in any release.
+ */
+export interface NgxsBatchingStorageEngine extends StorageEngine {
+  flush(): void;
+}
+
+/**
+ * Makes `engine` the storage engine the plugin writes through, built via DI
+ * so it can `inject(NGXS_STORAGE_ENGINE_TO_WRAP)` to get the real one
+ * underneath. How it buffers or coalesces writes is entirely up to `engine`
+ * — this just makes sure `flush()` gets called before the page disappears
+ * (hidden, unloaded, or the injector is destroyed), so nothing gets lost.
+ *
+ * Just want the built-in debounce behavior instead of writing your own
+ * engine? Use `withNgxsStorageDefaultBatching()`.
+ *
+ * Pass this as a feature to `withNgxsStoragePlugin()`, e.g.
+ * `withNgxsStoragePlugin({ keys: [...] }, withNgxsStorageBatching(MyEngine))`.
+ * Only affects keys on the default engine — a key with its own explicit
+ * `StorageEngine` keeps writing through immediately.
+ *
+ * @experimental This API is experimental and may change in any release.
+ */
+export function withNgxsStorageBatching(
+  engine: Type<NgxsBatchingStorageEngine>
+): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    engine,
+    {
+      provide: STORAGE_ENGINE,
+      useFactory: (): NgxsBatchingStorageEngine | null =>
+        inject(NGXS_STORAGE_ENGINE_TO_WRAP) && inject(engine)
+    },
+    provideEnvironmentInitializer(() => {
+      const batchingEngine = inject(STORAGE_ENGINE) as NgxsBatchingStorageEngine | null;
+      // Null on the server — nothing to flush there.
+      if (!batchingEngine) {
+        return;
+      }
+
+      const flush = () => batchingEngine.flush();
+      const onVisibilityChange = () => {
+        if (document.visibilityState === 'hidden') flush();
+      };
+
+      const ngZone = inject(NgZone);
+      ngZone.runOutsideAngular(() => {
+        document.addEventListener('visibilitychange', onVisibilityChange);
+        window.addEventListener('pagehide', flush);
+      });
+
+      inject(DestroyRef).onDestroy(() => {
+        flush();
+        document.removeEventListener('visibilitychange', onVisibilityChange);
+        window.removeEventListener('pagehide', flush);
+      });
+    })
+  ]);
+}
+
+/**
+ * @experimental This API is experimental and may change in any release.
+ */
+export interface NgxsStorageBatchingOptions {
+  /**
+   * How long to wait, in ms, after the last write before actually saving to
+   * storage. Every new write resets the clock — same idea as RxJS's
+   * `debounceTime`. Defaults to 300.
+   */
+  debounceTime?: number;
+}
+
+const ɵNGXS_STORAGE_BATCHING_OPTIONS = new InjectionToken<
+  Required<NgxsStorageBatchingOptions>
+>(typeof ngDevMode !== 'undefined' && ngDevMode ? 'NGXS_STORAGE_BATCHING_OPTIONS' : '');
+
+/**
+ * The easy option: instead of writing to storage on every single dispatch,
+ * this waits until writes go quiet for `debounceTime` ms and saves once.
+ * Handy when state changes rapidly, e.g. while dragging something or typing
+ * into a form. See `withNgxsStorageBatching()` for how we avoid losing that
+ * last write if the page closes mid-debounce.
+ *
+ * Pass this as a feature to `withNgxsStoragePlugin()`, e.g.
+ * `withNgxsStoragePlugin({ keys: [...] }, withNgxsStorageDefaultBatching())`.
+ *
+ * @experimental This API is experimental and may change in any release.
+ */
+export function withNgxsStorageDefaultBatching(
+  options: NgxsStorageBatchingOptions = {}
+): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    {
+      provide: ɵNGXS_STORAGE_BATCHING_OPTIONS,
+      useValue: { debounceTime: options.debounceTime ?? 300 }
+    },
+    withNgxsStorageBatching(ɵBatchingStorageEngine)
+  ]);
+}
+
+/**
+ * The default batching engine. Holds writes in memory until `flush()` runs,
+ * so a burst of writes to the same key ends up costing one real write.
+ * `getItem` checks that in-memory buffer first, so you never read a stale
+ * value for something you just wrote.
+ */
+@Injectable()
+class ɵBatchingStorageEngine implements NgxsBatchingStorageEngine {
+  private readonly _engine = inject(NGXS_STORAGE_ENGINE_TO_WRAP)!;
+  private readonly _ngZone = inject(NgZone);
+  private readonly _debounceTime = inject(ɵNGXS_STORAGE_BATCHING_OPTIONS).debounceTime;
+
+  private readonly _pending = new Map<string, any>();
+  private _timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  getItem(key: string): any {
+    return this._pending.has(key) ? this._pending.get(key) : this._engine.getItem(key);
+  }
+
+  setItem(key: string, value: any): void {
+    this._pending.set(key, value);
+
+    if (this._timeoutId !== null) {
+      clearTimeout(this._timeoutId);
+    }
+    this._timeoutId = this._ngZone.runOutsideAngular(() =>
+      setTimeout(() => this.flush(), this._debounceTime)
+    );
+  }
+
+  flush(): void {
+    if (this._timeoutId !== null) {
+      clearTimeout(this._timeoutId);
+      this._timeoutId = null;
+    }
+
+    if (this._pending.size === 0) {
+      return;
+    }
+
+    for (const [key, value] of this._pending) {
+      this._engine.setItem(key, value);
+    }
+    this._pending.clear();
+  }
+}

--- a/packages/storage-plugin/src/public_api.ts
+++ b/packages/storage-plugin/src/public_api.ts
@@ -2,6 +2,13 @@ export { NgxsStoragePluginModule, withNgxsStoragePlugin } from './storage.module
 export { withStorageFeature } from './with-storage-feature';
 export { withNgxsStorageSync } from './features/with-ngxs-storage-sync';
 export {
+  withNgxsStorageBatching,
+  withNgxsStorageDefaultBatching,
+  NGXS_STORAGE_ENGINE_TO_WRAP,
+  type NgxsStorageBatchingOptions,
+  type NgxsBatchingStorageEngine
+} from './features/with-ngxs-storage-batching';
+export {
   NgxsStoragePlugin,
   NgxsStorageDeserializationError,
   NgxsStorageQuotaExceededError,

--- a/packages/storage-plugin/tests/storage-batching.spec.ts
+++ b/packages/storage-plugin/tests/storage-batching.spec.ts
@@ -1,0 +1,262 @@
+import { bootstrapApplication } from '@angular/platform-browser';
+import { ApplicationConfig, Component, Injectable, inject } from '@angular/core';
+import { Action, State, StateContext, Store, provideStore } from '@ngxs/store';
+import { StorageEngine } from '@ngxs/storage-plugin/internals';
+import { freshPlatform, skipConsoleLogging } from '@ngxs/store/internals/testing';
+
+import {
+  NGXS_STORAGE_ENGINE_TO_WRAP,
+  NgxsBatchingStorageEngine,
+  withNgxsStorageBatching,
+  withNgxsStorageDefaultBatching,
+  withNgxsStoragePlugin
+} from '..';
+
+interface CounterStateModel {
+  count: number;
+}
+
+class Increment {
+  static readonly type = '[Counter] Increment';
+}
+
+@State<CounterStateModel>({
+  name: 'counter',
+  defaults: { count: 0 }
+})
+@Injectable()
+class CounterState {
+  @Action(Increment)
+  increment(ctx: StateContext<CounterStateModel>) {
+    ctx.patchState({ count: ctx.getState().count + 1 });
+  }
+}
+
+@Component({ selector: 'app-root', template: '', standalone: true })
+class TestComponent {}
+
+describe('withNgxsStorageDefaultBatching', () => {
+  /** A trivial in-memory engine, used to prove explicit per-key engines bypass batching. */
+  class FakeEngine implements StorageEngine {
+    readonly calls: Array<[string, any]> = [];
+    private _store = new Map<string, any>();
+
+    getItem(key: string) {
+      return this._store.has(key) ? this._store.get(key) : null;
+    }
+
+    setItem(key: string, value: any) {
+      this.calls.push([key, value]);
+      this._store.set(key, value);
+    }
+  }
+
+  function bootstrap(keys: any[] = [CounterState], debounceTime?: number) {
+    const appConfig: ApplicationConfig = {
+      providers: [
+        provideStore(
+          [CounterState],
+          withNgxsStoragePlugin({ keys }, withNgxsStorageDefaultBatching({ debounceTime }))
+        )
+      ]
+    };
+
+    return skipConsoleLogging(() => bootstrapApplication(TestComponent, appConfig));
+  }
+
+  afterEach(() => {
+    localStorage.removeItem('counter');
+  });
+
+  it(
+    'should not write to the storage engine until the debounce window elapses',
+    freshPlatform(async () => {
+      // Arrange
+      jest.useFakeTimers();
+      const { injector } = await bootstrap([CounterState], 300);
+      const store = injector.get(Store);
+
+      try {
+        // Act
+        store.dispatch(new Increment());
+
+        // Assert — nothing written yet, synchronously after the dispatch.
+        expect(localStorage.getItem('counter')).toBeNull();
+
+        jest.advanceTimersByTime(300);
+        expect(localStorage.getItem('counter')).toBe(JSON.stringify({ count: 1 }));
+      } finally {
+        jest.useRealTimers();
+      }
+    })
+  );
+
+  it(
+    'should coalesce rapid successive writes into a single underlying write',
+    freshPlatform(async () => {
+      // Arrange
+      jest.useFakeTimers();
+      const { injector } = await bootstrap([CounterState], 300);
+      const store = injector.get(Store);
+      const spy = jest.spyOn(Storage.prototype, 'setItem');
+
+      try {
+        // Act — three dispatches within the same debounce window.
+        store.dispatch(new Increment());
+        jest.advanceTimersByTime(100);
+        store.dispatch(new Increment());
+        jest.advanceTimersByTime(100);
+        store.dispatch(new Increment());
+        jest.advanceTimersByTime(300);
+
+        // Assert — only the final value was ever written for this key.
+        const counterCalls = spy.mock.calls.filter(([key]) => key === 'counter');
+        expect(counterCalls).toEqual([['counter', JSON.stringify({ count: 3 })]]);
+      } finally {
+        spy.mockRestore();
+        jest.useRealTimers();
+      }
+    })
+  );
+
+  it(
+    'should flush pending writes immediately when the page becomes hidden',
+    freshPlatform(async () => {
+      // Arrange
+      jest.useFakeTimers();
+      const { injector } = await bootstrap([CounterState], 300);
+      const store = injector.get(Store);
+
+      try {
+        // Act
+        store.dispatch(new Increment());
+        expect(localStorage.getItem('counter')).toBeNull();
+
+        jest.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
+        document.dispatchEvent(new Event('visibilitychange'));
+
+        // Assert — flushed without waiting for the debounce timer.
+        expect(localStorage.getItem('counter')).toBe(JSON.stringify({ count: 1 }));
+      } finally {
+        jest.restoreAllMocks();
+        jest.useRealTimers();
+      }
+    })
+  );
+
+  it(
+    'should flush pending writes immediately on pagehide',
+    freshPlatform(async () => {
+      // Arrange
+      jest.useFakeTimers();
+      const { injector } = await bootstrap([CounterState], 300);
+      const store = injector.get(Store);
+
+      try {
+        // Act
+        store.dispatch(new Increment());
+        expect(localStorage.getItem('counter')).toBeNull();
+
+        window.dispatchEvent(new Event('pagehide'));
+
+        // Assert
+        expect(localStorage.getItem('counter')).toBe(JSON.stringify({ count: 1 }));
+      } finally {
+        jest.useRealTimers();
+      }
+    })
+  );
+
+  it(
+    'should leave keys with an explicit custom engine writing through immediately',
+    freshPlatform(async () => {
+      // Arrange
+      jest.useFakeTimers();
+      const fakeEngine = new FakeEngine();
+      const { injector } = await bootstrap(
+        [{ key: CounterState, engine: () => fakeEngine }],
+        300
+      );
+      const store = injector.get(Store);
+
+      try {
+        // Act — no timer advance at all.
+        store.dispatch(new Increment());
+
+        // Assert — the explicit engine isn't wrapped by the batching feature.
+        expect(fakeEngine.calls).toEqual([['counter', JSON.stringify({ count: 1 })]]);
+      } finally {
+        jest.useRealTimers();
+      }
+    })
+  );
+});
+
+describe('withNgxsStorageBatching (custom engine)', () => {
+  /** Buffers writes and only ever commits them when `flush()` is called explicitly. */
+  @Injectable()
+  class ManualFlushEngine implements NgxsBatchingStorageEngine {
+    private readonly _engine = inject(NGXS_STORAGE_ENGINE_TO_WRAP)!;
+    private readonly _pending = new Map<string, any>();
+
+    getItem(key: string): any {
+      return this._pending.has(key) ? this._pending.get(key) : this._engine.getItem(key);
+    }
+
+    setItem(key: string, value: any): void {
+      this._pending.set(key, value);
+    }
+
+    flush(): void {
+      for (const [key, value] of this._pending) {
+        this._engine.setItem(key, value);
+      }
+      this._pending.clear();
+    }
+  }
+
+  function bootstrap() {
+    const appConfig: ApplicationConfig = {
+      providers: [
+        provideStore(
+          [CounterState],
+          withNgxsStoragePlugin(
+            { keys: [CounterState] },
+            withNgxsStorageBatching(ManualFlushEngine)
+          )
+        )
+      ]
+    };
+
+    return skipConsoleLogging(() => bootstrapApplication(TestComponent, appConfig));
+  }
+
+  afterEach(() => {
+    localStorage.removeItem('counter');
+  });
+
+  it(
+    'should let a user-supplied engine control buffering while still flushing it on hide',
+    freshPlatform(async () => {
+      // Arrange
+      const { injector } = await bootstrap();
+      const store = injector.get(Store);
+
+      try {
+        // Act
+        store.dispatch(new Increment());
+
+        // Assert — the custom engine never writes through on its own.
+        expect(localStorage.getItem('counter')).toBeNull();
+
+        jest.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden');
+        document.dispatchEvent(new Event('visibilitychange'));
+
+        // The generic flush-on-hide wiring still calls the custom engine's `flush()`.
+        expect(localStorage.getItem('counter')).toBe(JSON.stringify({ count: 1 }));
+      } finally {
+        jest.restoreAllMocks();
+      }
+    })
+  );
+});


### PR DESCRIPTION
Every dispatch writes straight through to storage, which means rapid state changes (drag, typed input) pay for one synchronous storage write each. Add withNgxsStorageBatching(engine), which lets any DI- constructed engine implementing NgxsBatchingStorageEngine (inject NGXS_STORAGE_ENGINE_TO_WRAP for the real one, expose flush()) stand in as the plugin's storage engine; the feature wires flush() to run before the page is hidden, unloaded, or torn down so nothing buffered is lost. withNgxsStorageDefaultBatching(options) is the built-in debounce-based engine on top of that, for the common case of just wanting writes coalesced after a quiet period. Marked @experimental since the engine contract may still change.