### PR TITLE
fix(store): avoid NG0205/ObjectUnsubscribedError during TestBed teardown

### DIFF
--- a/packages/store/src/internal/lifecycle-state-manager.ts
+++ b/packages/store/src/internal/lifecycle-state-manager.ts
@@ -1,5 +1,4 @@
-import { DestroyRef, inject, Injectable, Injector } from '@angular/core';
-import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { DestroyRef, effect, inject, Injectable, Injector } from '@angular/core';
 import { ɵNGXS_APP_BOOTSTRAP_STATE } from '@ngxs/store/internals';
 import { getValue, InitState, UpdateState } from '@ngxs/store/plugins';
 
@@ -12,7 +11,6 @@ import { getInvalidInitializationOrderMessage } from '../configs/messages.config
 
 @Injectable({ providedIn: 'root' })
 export class LifecycleStateManager {
-  private _destroyRef = inject(DestroyRef);
   private _injector = inject(Injector);
   private _store = inject(Store);
   private _internalStateOperations = inject(InternalStateOperations);
@@ -62,12 +60,18 @@ export class LifecycleStateManager {
       this._invokeInitOnStates(results.states);
 
       const options = { injector: this._injector };
-      toObservable(this._appBootstrapState, options)
-        .pipe(takeUntilDestroyed(this._destroyRef))
-        .subscribe(appBootstrapped => {
-          if (!appBootstrapped) return;
-          this._invokeBootstrapOnStates(results.states);
-        });
+      // The effect is destroyed as soon as it fires so that nothing is left
+      // registered against the root injector's `DestroyRef`. Keeping a live
+      // effect/subscription around until root injector destruction (e.g. via
+      // `toObservable` + `takeUntilDestroyed`) races with other root-scoped
+      // teardown (such as `ɵStateStream` completing itself), which can throw
+      // `NG0205`/`ObjectUnsubscribedError` during fast TestBed teardown.
+      const ref = effect(() => {
+        const appBootstrapped = this._appBootstrapState();
+        if (!appBootstrapped) return;
+        ref.destroy();
+        this._invokeBootstrapOnStates(results.states);
+      }, options);
     });
   }
 

--- a/packages/store/tests/state.spec.ts
+++ b/packages/store/tests/state.spec.ts
@@ -22,7 +22,7 @@ import {
   StateContext,
   Store
 } from '@ngxs/store';
-import { ɵMETA_KEY } from '@ngxs/store/internals';
+import { ɵMETA_KEY, ɵNGXS_APP_BOOTSTRAP_STATE } from '@ngxs/store/internals';
 
 import { NgxsAfterBootstrap } from '../src/symbols';
 import { simplePatch } from '../src/internal/state-operators';
@@ -358,6 +358,45 @@ describe('State', () => {
         LifecycleHooks.NgAfterViewInit,
         LifecycleHooks.NgxsAfterBootstrap
       ]);
+    });
+
+    it('should invoke "ngxsAfterBootstrap" only once, even if the bootstrap signal flips again later', () => {
+      // This guards against reintroducing `toObservable(...).pipe(takeUntilDestroyed(...))`
+      // for the bootstrap-completion signal (see #2479): that pattern keeps the
+      // internal `effect`/subscription alive until the root injector is destroyed,
+      // which both invokes `ngxsAfterBootstrap` on every subsequent truthy emission
+      // and races with other root-scoped teardown (e.g. `ɵStateStream` completing
+      // itself), producing `NG0205`/`ObjectUnsubscribedError` during fast TestBed
+      // teardown. The fix keeps a self-destroying `effect` that detaches itself
+      // the moment it fires, so it can only ever run `ngxsAfterBootstrap` once.
+      @State({
+        name: 'foo'
+      })
+      @Injectable()
+      class FooState implements NgxsAfterBootstrap {
+        public ngxsAfterBootstrap(): void {
+          hooks.push(LifecycleHooks.NgxsAfterBootstrap);
+        }
+      }
+
+      TestBed.configureTestingModule({
+        imports: [NgxsModule.forRoot([FooState])]
+      });
+
+      TestBed.inject(Store);
+
+      const appBootstrapState = TestBed.inject(ɵNGXS_APP_BOOTSTRAP_STATE);
+
+      appBootstrapState.set(true);
+      TestBed.flushEffects();
+
+      appBootstrapState.set(false);
+      TestBed.flushEffects();
+
+      appBootstrapState.set(true);
+      TestBed.flushEffects();
+
+      expect(hooks).toEqual([LifecycleHooks.NgxsAfterBootstrap]);
     });
   });
 


### PR DESCRIPTION
The bootstrap-completion check was rewritten in #2440 to use `toObservable` + `takeUntilDestroyed`, which keeps an internal effect alive until the root injector is destroyed. During fast TestBed teardown this raced with other root-scoped cleanup (like the state stream completing itself), throwing NG0205 or ObjectUnsubscribedError after tests had already passed.

Reverted to a self-destroying `effect()` that detaches itself the moment it fires, so nothing is left registered when the injector is torn down.

Fixes #2479