### PR TITLE
fix(storage-plugin): type STORAGE_ENGINE as nullable to match its runtime contract

### DIFF
--- a/docs/plugins/storage.md
+++ b/docs/plugins/storage.md
@@ -319,6 +319,26 @@ export const appConfig: ApplicationConfig = {
 };
 ```
 
+`STORAGE_ENGINE` is also the token you'd `inject()` if you want to build a custom engine that wraps whatever the plugin is already using, instead of replacing it outright. Since it resolves to `null` on the server (and whenever the `storage` option doesn't resolve to a known engine), treat it as `StorageEngine | null` and guard against `null` wherever you use it:
+
+```ts
+import { inject, Injectable } from '@angular/core';
+import { StorageEngine, STORAGE_ENGINE } from '@ngxs/storage-plugin';
+
+@Injectable({ providedIn: 'root' })
+export class MyWrappingStorageEngine implements StorageEngine {
+  private readonly engine = inject(STORAGE_ENGINE);
+
+  getItem(key: string): any {
+    return this.engine?.getItem(key);
+  }
+
+  setItem(key: string, value: any): void {
+    this.engine?.setItem(key, value);
+  }
+}
+```
+
 ### Serialization Interceptors
 
 You can define your own logic before or after the state gets serialized or deserialized.

--- a/packages/storage-plugin/internals/src/symbols.ts
+++ b/packages/storage-plugin/internals/src/symbols.ts
@@ -114,7 +114,18 @@ export const ɵNGXS_STORAGE_PLUGIN_OPTIONS =
     typeof ngDevMode !== 'undefined' && ngDevMode ? 'NGXS_STORAGE_PLUGIN_OPTIONS' : ''
   );
 
-export const STORAGE_ENGINE = new InjectionToken<StorageEngine>(
+/**
+ * This is the engine the plugin uses by default, for any key that wasn't
+ * given its own explicit engine. Normally it's just `localStorage` or
+ * `sessionStorage`, picked based on the `storage` option — but it can also
+ * be a custom engine if a feature (like `withNgxsStorageBatching()`)
+ * overrides it. It's `null` on the server, since there's no storage to use
+ * there.
+ *
+ * Inject this token when you want to build a custom `StorageEngine` that
+ * wraps whatever engine the plugin is already using.
+ */
+export const STORAGE_ENGINE = new InjectionToken<StorageEngine | null>(
   typeof ngDevMode !== 'undefined' && ngDevMode ? 'STORAGE_ENGINE' : ''
 );
 

--- a/packages/storage-plugin/tests/transfer-state-storage-engine.spec.ts
+++ b/packages/storage-plugin/tests/transfer-state-storage-engine.spec.ts
@@ -80,11 +80,11 @@ describe('TransferStateStorageEngine', () => {
         }
       }
 
-      return this.engine.getItem(key);
+      return this.engine?.getItem(key);
     }
 
     setItem(key: string, value: unknown): void {
-      this.engine.setItem(key, value);
+      this.engine?.setItem(key, value);
     }
   }
 


### PR DESCRIPTION
`STORAGE_ENGINE` was declared as `InjectionToken<StorageEngine>`, but its factory (`engineFactory`) returns `null` on the server and when no valid `storage` option is set, and the plugin's own `handle()` already guards against a falsy engine at the call site. The three sibling tokens (`LOCAL_STORAGE_ENGINE`, `SESSION_STORAGE_ENGINE`, `NGXS_STORAGE_ENGINE_TO_WRAP`) are already typed `StorageEngine | null`.

Consumers injecting `STORAGE_ENGINE` directly (e.g. to build a custom `StorageEngine` that wraps the configured one) got no compile-time signal that the value could be null, leading to runtime `TypeError`s that surface as `NgxsStorageSerializationError`.