### PR TITLE
fix(storage-plugin): guard against localStorage/sessionStorage being undefined

### DIFF
--- a/packages/storage-plugin/src/engines.ts
+++ b/packages/storage-plugin/src/engines.ts
@@ -7,14 +7,28 @@ declare const ngServerMode: boolean;
 export const LOCAL_STORAGE_ENGINE = /* @__PURE__ */ new InjectionToken<StorageEngine | null>(
   typeof ngDevMode !== 'undefined' && ngDevMode ? 'LOCAL_STORAGE_ENGINE' : '',
   {
-    factory: () => (typeof ngServerMode !== 'undefined' && ngServerMode ? null : localStorage)
+    // `ngServerMode` catches Angular SSR (Node has no `localStorage` at all), but some
+    // pages also get rendered by crawlers/bots whose JS engines never define the global
+    // either. Checking `typeof` first means we return `null` instead of crashing there too.
+    factory: () =>
+      typeof ngServerMode !== 'undefined' && ngServerMode
+        ? null
+        : typeof localStorage === 'undefined'
+          ? null
+          : localStorage
   }
 );
 
 export const SESSION_STORAGE_ENGINE = /* @__PURE__ */ new InjectionToken<StorageEngine | null>(
   typeof ngDevMode !== 'undefined' && ngDevMode ? 'SESSION_STORAGE_ENGINE' : '',
   {
+    // Same reasoning as LOCAL_STORAGE_ENGINE above: `ngServerMode` only covers Angular's
+    // own SSR, so we still need to check the global exists before touching it.
     factory: () =>
-      typeof ngServerMode !== 'undefined' && ngServerMode ? null : sessionStorage
+      typeof ngServerMode !== 'undefined' && ngServerMode
+        ? null
+        : typeof sessionStorage === 'undefined'
+          ? null
+          : sessionStorage
   }
 );

--- a/packages/storage-plugin/src/internals.ts
+++ b/packages/storage-plugin/src/internals.ts
@@ -27,10 +27,15 @@ export function engineFactory(options: NgxsStoragePluginOptions): StorageEngine 
     return null;
   }
 
+  // `ngServerMode` only tells us we're not on Angular's own SSR. Some pages are also
+  // rendered by crawlers/bots running JS engines that never define these globals at
+  // all, so referencing them directly would throw a ReferenceError instead of just
+  // leaving storage disabled. Users can't opt out of this factory, so it needs to be
+  // defensive on their behalf.
   if (options.storage === StorageOption.LocalStorage) {
-    return localStorage;
+    return typeof localStorage === 'undefined' ? null : localStorage;
   } else if (options.storage === StorageOption.SessionStorage) {
-    return sessionStorage;
+    return typeof sessionStorage === 'undefined' ? null : sessionStorage;
   }
 
   return null;

--- a/packages/storage-plugin/tests/engine-factory-guards.spec.ts
+++ b/packages/storage-plugin/tests/engine-factory-guards.spec.ts
@@ -1,0 +1,48 @@
+import { StorageOption } from '@ngxs/storage-plugin/internals';
+import { engineFactory } from '../src/internals';
+
+describe('engineFactory', () => {
+  it('should return localStorage when it exists on the global', () => {
+    expect(engineFactory({ keys: '*', storage: StorageOption.LocalStorage })).toBe(
+      localStorage
+    );
+  });
+
+  it('should return sessionStorage when it exists on the global', () => {
+    expect(engineFactory({ keys: '*', storage: StorageOption.SessionStorage })).toBe(
+      sessionStorage
+    );
+  });
+
+  // Some pages get rendered by crawlers/bots whose JS engines never define
+  // `localStorage`/`sessionStorage` at all. Referencing the bare identifier in that
+  // case throws a ReferenceError, so engineFactory must check it exists first instead
+  // of assuming every non-SSR environment is a real browser.
+  it('should return null instead of throwing when localStorage is not defined on the global', () => {
+    const original = globalThis.localStorage;
+    // @ts-expect-error - simulating an environment where the global doesn't exist
+    delete globalThis.localStorage;
+
+    try {
+      const options = { keys: '*', storage: StorageOption.LocalStorage } as const;
+      expect(() => engineFactory(options)).not.toThrow();
+      expect(engineFactory(options)).toBeNull();
+    } finally {
+      globalThis.localStorage = original;
+    }
+  });
+
+  it('should return null instead of throwing when sessionStorage is not defined on the global', () => {
+    const original = globalThis.sessionStorage;
+    // @ts-expect-error - simulating an environment where the global doesn't exist
+    delete globalThis.sessionStorage;
+
+    try {
+      const options = { keys: '*', storage: StorageOption.SessionStorage } as const;
+      expect(() => engineFactory(options)).not.toThrow();
+      expect(engineFactory(options)).toBeNull();
+    } finally {
+      globalThis.sessionStorage = original;
+    }
+  });
+});


### PR DESCRIPTION
engineFactory and the LOCAL_STORAGE_ENGINE/SESSION_STORAGE_ENGINE factories only checked ngServerMode before touching localStorage/sessionStorage, which covers Angular's own SSR but not other cases where the globals simply don't exist — e.g. crawlers and bots rendering hydrated pages in JS engines that never define them. That caused a bare ReferenceError instead of the plugin falling back to null the way callers already expect. Added a typeof check next to each reference so users get a disabled engine instead of a crash they have no way to control.