### PR TITLE
fix(store): warn when a state uses @Service() without autoProvided: false

### DIFF
--- a/integrations/hello-world-ng22/e2e/service-decorated-state.spec.ts
+++ b/integrations/hello-world-ng22/e2e/service-decorated-state.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+// `CounterState` is decorated with `@Service({ autoProvided: false })` (see
+// `src/app/store/counter/counter.state.ts`). Unlike the unit tests, this runs against the real
+// production/AOT build (`yarn build:prod` served statically), which is the only place that
+// exercises how `@Service()` actually compiles and resolves through Angular's DI in a shipped app.
+test.describe('@Service()-decorated state (AOT production build)', () => {
+  test('should increment via the store and persist the state across a reload', async ({
+    page
+  }) => {
+    await page.goto('/');
+
+    const button = page.locator('button');
+    await button.click();
+    await button.click();
+    await expect(page.locator('p')).toContainText('Counter is 2');
+
+    // Storage plugin persists all state (`keys: '*'`) to `localStorage`. Rehydrating on reload
+    // only works if NGXS resolves the exact same `CounterState` instance it registered via
+    // `provideStore()` — which is what `autoProvided: false` guarantees.
+    await page.reload();
+
+    await expect(page.locator('p')).toContainText('Counter is 2');
+  });
+});

--- a/integrations/hello-world-ng22/src/app/store/counter/counter.state.ts
+++ b/integrations/hello-world-ng22/src/app/store/counter/counter.state.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Service } from '@angular/core';
 import { State, Action, StateContext, StateToken } from '@ngxs/store';
 
 import { Increment } from './counter.actions';
@@ -9,7 +9,7 @@ export const COUNTER_STATE_TOKEN = new StateToken<number>('counter');
   name: COUNTER_STATE_TOKEN,
   defaults: 0
 })
-@Injectable()
+@Service({ autoProvided: false })
 export class CounterState {
   @Action(Increment)
   increment(ctx: StateContext<number>) {

--- a/integrations/hello-world-ng22/src/app/store/dummy/dummy.state.ts
+++ b/integrations/hello-world-ng22/src/app/store/dummy/dummy.state.ts
@@ -1,0 +1,13 @@
+import { Service } from '@angular/core';
+import { State } from '@ngxs/store';
+
+// Intentionally decorated with bare `@Service()` (defaults to `autoProvided: true`) rather than
+// `@Service({ autoProvided: false })`. This state contributes nothing to the app — it exists so
+// the integration build/e2e run always compiles and boots a state in this "wrong" configuration,
+// proving it doesn't break the app even though NGXS's dev-mode check warns about it.
+@State({
+  name: 'dummy',
+  defaults: null
+})
+@Service()
+export class DummyState {}

--- a/integrations/hello-world-ng22/src/app/store/index.ts
+++ b/integrations/hello-world-ng22/src/app/store/index.ts
@@ -1,4 +1,5 @@
 export * from './counter/counter.state';
 export * from './counter/counter.actions';
+export * from './dummy/dummy.state';
 
 export * from './ngxs-providers';

--- a/integrations/hello-world-ng22/src/app/store/ngxs-providers.ts
+++ b/integrations/hello-world-ng22/src/app/store/ngxs-providers.ts
@@ -7,12 +7,13 @@ import { withNgxsWebSocketPlugin } from '@ngxs/websocket-plugin';
 import { withNgxsRouterPlugin } from '@ngxs/router-plugin';
 
 import { CounterState } from './counter/counter.state';
+import { DummyState } from './dummy/dummy.state';
 
 declare const ngDevMode: boolean;
 
 export function provideNgxs() {
   return provideStore(
-    [CounterState],
+    [CounterState, DummyState],
     withNgxsReduxDevtoolsPlugin({
       disabled: typeof ngDevMode !== 'undefined' && !ngDevMode
     }),

--- a/integrations/hello-world-ng22/src/app/store/service-decorated-state.spec.ts
+++ b/integrations/hello-world-ng22/src/app/store/service-decorated-state.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Component, Service } from '@angular/core';
+import { bootstrapApplication } from '@angular/platform-browser';
+import { provideStore, State } from '@ngxs/store';
+import { freshPlatform } from '@ngxs/store/internals/testing';
+
+// `@Service()` only exists from Angular v22 onwards, which is why this check is
+// exercised here (against a real `@angular/core` v22 install) rather than in the
+// `@ngxs/store` unit tests, which still run against the workspace's root Angular version.
+describe('@Service() on @State() classes', () => {
+  @Component({ selector: 'app-root', template: '', standalone: true })
+  class RootComponent {}
+
+  it(
+    'should not warn when the state is decorated with @Service({ autoProvided: false })',
+    freshPlatform(async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      @State({ name: 'scopedServiceState', defaults: null })
+      @Service({ autoProvided: false })
+      class ScopedServiceState {}
+
+      const appRef = await bootstrapApplication(RootComponent, {
+        providers: [provideStore([ScopedServiceState])]
+      });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      appRef.destroy();
+      warnSpy.mockRestore();
+    })
+  );
+
+  it(
+    'should warn when the state is decorated with bare @Service() (auto-provided at root)',
+    freshPlatform(async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      @State({ name: 'autoProvidedServiceState', defaults: null })
+      @Service()
+      class AutoProvidedServiceState {}
+
+      const appRef = await bootstrapApplication(RootComponent, {
+        providers: [provideStore([AutoProvidedServiceState])]
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('@Service({ autoProvided: false }) instead')
+      );
+
+      appRef.destroy();
+      warnSpy.mockRestore();
+    })
+  );
+});

--- a/packages/store/src/configs/messages.config.ts
+++ b/packages/store/src/configs/messages.config.ts
@@ -37,7 +37,15 @@ export function throwSelectorDecoratorError(): never {
 }
 
 export function getUndecoratedStateWithInjectableWarningMessage(name: string): string {
-  return `'${name}' class should be decorated with @Injectable() right after the @State() decorator`;
+  return `'${name}' class should be decorated with @Injectable() or @Service() right after the @State() decorator`;
+}
+
+export function getAutoProvidedServiceStateWarningMessage(name: string): string {
+  return (
+    `'${name}' class is decorated with @Service(), which defaults to being auto-provided at the root injector. ` +
+    `States are already provided explicitly by NGXS (via \`provideStates()\`, \`forRoot()\` or \`forFeature()\`), ` +
+    `so decorate it with @Service({ autoProvided: false }) instead.`
+  );
 }
 
 export function getInvalidInitializationOrderMessage(addedStates?: ɵPlainObject) {

--- a/packages/store/src/ivy/ivy-enabled-in-dev-mode.ts
+++ b/packages/store/src/ivy/ivy-enabled-in-dev-mode.ts
@@ -1,28 +1,67 @@
-import { getUndecoratedStateWithInjectableWarningMessage } from '../configs/messages.config';
+import {
+  getAutoProvidedServiceStateWarningMessage,
+  getUndecoratedStateWithInjectableWarningMessage
+} from '../configs/messages.config';
 
 /**
- * All provided or injected tokens must have `@Injectable` decorator
- * (previously, injected tokens without `@Injectable` were allowed
- * if another decorator was used, e.g. pipes).
+ * All provided or injected tokens must have an `@Injectable()` or `@Service()` decorator
+ * (previously, injected tokens without `@Injectable()` were allowed if another decorator
+ * was used, e.g. pipes).
  */
 export function ensureStateClassIsInjectable(stateClass: any): void {
-  if (jit_hasInjectableAnnotation(stateClass) || aot_hasNgInjectableDef(stateClass)) {
+  const ngMetadataName = getAppliedDecoratorName(stateClass);
+
+  if (ngMetadataName === null && !aot_hasNgInjectableDef(stateClass)) {
+    console.warn(getUndecoratedStateWithInjectableWarningMessage(stateClass.name));
     return;
   }
 
-  console.warn(getUndecoratedStateWithInjectableWarningMessage(stateClass.name));
+  if (ngMetadataName === 'Service' && isAutoProvidedService(stateClass)) {
+    console.warn(getAutoProvidedServiceStateWarningMessage(stateClass.name));
+  }
 }
 
 function aot_hasNgInjectableDef(stateClass: any): boolean {
   // `ɵprov` is a static property added by the NGCC compiler. It always exists in
   // AOT mode because this property is added before runtime. If an application is running in
-  // JIT mode then this property can be added by the `@Injectable()` decorator. The `@Injectable()`
-  // decorator has to go after the `@State()` decorator, thus we prevent users from unwanted DI errors.
+  // JIT mode then this property can be added by the `@Injectable()`/`@Service()` decorator. These
+  // decorators have to go after the `@State()` decorator, thus we prevent users from unwanted DI errors.
   return !!stateClass.ɵprov;
 }
 
-function jit_hasInjectableAnnotation(stateClass: any): boolean {
-  // `ɵprov` doesn't exist in JIT mode (for instance when running unit tests with Jest).
-  const annotations = stateClass.__annotations__ || [];
-  return annotations.some((annotation: any) => annotation?.ngMetadataName === 'Injectable');
+// `ɵprov` doesn't exist in JIT mode until the decorator itself creates it (for instance when
+// running unit tests with Jest). Both `@Injectable()` and `@Service()` are built with Angular's
+// `makeDecorator`, which tags the decorator function's prototype with an `ngMetadataName`
+// identifying which decorator it is. Where that metadata ends up depends on how the class was
+// compiled:
+// - Pure JIT (e.g. ts-jest running raw TS decorators): the decorator pushes an annotation
+//   *instance* onto `__annotations__`, which inherits `ngMetadataName` off that same prototype.
+// - AOT/ngtsc in dev mode (e.g. the Angular CLI's Vitest builder): `ɵprov` is emitted directly
+//   and, separately, `setClassMetadata()` records `{ type: <decorator fn> }` on `.decorators` for
+//   tooling, so `ngMetadataName` has to be read off `type.prototype` instead.
+function getAppliedDecoratorName(stateClass: any): 'Injectable' | 'Service' | null {
+  for (const annotation of stateClass.__annotations__ || []) {
+    const ngMetadataName = annotation?.ngMetadataName;
+    if (ngMetadataName === 'Injectable' || ngMetadataName === 'Service') {
+      return ngMetadataName;
+    }
+  }
+
+  for (const decorator of stateClass.decorators || []) {
+    const ngMetadataName = decorator?.type?.prototype?.ngMetadataName;
+    if (ngMetadataName === 'Injectable' || ngMetadataName === 'Service') {
+      return ngMetadataName;
+    }
+  }
+
+  return null;
+}
+
+// `@Service()` defaults `autoProvided` to `true`, which the compiler translates to
+// `providedIn: 'root'` on `ɵprov` (mirroring `@Injectable({ providedIn: 'root' })`). NGXS states
+// are provided explicitly through `provideStates()`/`forRoot()`/`forFeature()`, so an
+// auto-provided state could be resolved independently from the root injector, out of sync with
+// the instance NGXS registers (most notably for lazily-loaded feature states).
+function isAutoProvidedService(stateClass: any): boolean {
+  return stateClass.ɵprov?.providedIn !== null;
 }


### PR DESCRIPTION
States should not be auto-provided at root since NGXS already provides them explicitly. Added a check that warns in dev mode if @Service() is used on a state without autoProvided: false, and updated the message for the existing @Injectable() check to mention @Service() too.

Also added a dummy state and some tests in the ng22 integration app to confirm this actually works against a real Angular 22 build, not just mocked fixtures.